### PR TITLE
Fix starting progression and dungeon teleports

### DIFF
--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -25,7 +25,7 @@ bool IndividualProgression::isBeforeProgression(Player* player, ProgressionState
 
 void IndividualProgression::UpdateProgressionState(Player* player, ProgressionState newState) const
 {
-    if (progressionLimit && newState >= progressionLimit)
+    if (progressionLimit && newState > progressionLimit)
         return;
     uint8 currentState = player->GetPlayerSetting("mod-individual-progression", SETTING_PROGRESSION_STATE).value;
     if (newState > currentState)

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -9,6 +9,7 @@
 #include "GameObjectAI.h"
 #include "MapMgr.h"
 #include "ObjectAccessor.h"
+#include "ObjectMgr.h"
 #include "Group.h"
 #include "Pet.h"
 #include "DBCEnums.h"

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -202,6 +202,19 @@ public:
         {
             return false;
         }
+
+        InstanceTemplate const* instanceTemplate = sObjectMgr->GetInstanceTemplate(mapid);
+        if (instanceTemplate)
+        {
+            if (instanceTemplate->Parent == MAP_OUTLANDS && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_NAXX40))
+            {
+                return false;
+            }
+            if (instanceTemplate->Parent == MAP_NORTHREND && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5))
+            {
+                return false;
+            }
+        }
         return true;
     }
 


### PR DESCRIPTION
These changes allow `IndividualProgression.StartingProgression` to be the same as `IndividualProgression.ProgressionLimit` and to not allow players to use specific dungeon queue to teleport to Outland and Northrend dungeons.