### PR TITLE
fix Kobold in Elwynn Forest

### DIFF
--- a/sql/world/base/vanilla_mob_factions.sql
+++ b/sql/world/base/vanilla_mob_factions.sql
@@ -2840,7 +2840,7 @@ UPDATE `creature_template` SET `faction` = 57 WHERE `entry` = 17080;
 UPDATE `creature_template` SET `faction` = 35 WHERE `entry` = 17231;
 
 /*  Kobold Laborer  */
-UPDATE `creature_template` SET `faction` = 26 WHERE `entry` = 257;
+UPDATE `creature_template` SET `faction` = 26, flags_extra = 0 WHERE `entry` = 257;
 
 /*  Kobold Worker  */
-UPDATE `creature_template` SET `faction` = 26 WHERE `entry` = 80;
+UPDATE `creature_template` SET `faction` = 26, flags_extra = 0 WHERE `entry` = 80;


### PR DESCRIPTION
flags_extra of Kobold in Elwynn Forest is 2 = "does not aggro (ignore faction/reputation hostility)".
So change it to 0