### PR TITLE
Reward Title and Progression Blocking issues fix

### DIFF
--- a/sql/world/base/dungeon_attunements.sql
+++ b/sql/world/base/dungeon_attunements.sql
@@ -35,3 +35,15 @@ UPDATE `quest_template_addon` SET `NextQuestID` = 10888 WHERE `ID` = 10886;
 
 /* A Distraction for Akama(13429) - Restore pre-3.0 version */
 UPDATE `quest_template` SET `RewardNextQuest` = 10985 WHERE `ID` = 10949;
+
+/* Reward Title Scarab Lord */
+UPDATE `quest_template` SET `RewardTitle` = 46 WHERE `ID` = 8743;
+
+/* Reward Title Champion of the Naaru and Reward Item The Tempest Key */
+UPDATE `quest_template` SET `RewardItem1` = 31704, `RewardAmount1` = 1, `RewardItem2` = 31746, `RewardAmount2` = 1, `RewardTitle` = 53 WHERE `ID` = 10888;
+DELETE FROM `achievement_reward` WHERE `ID` = 432;
+DELETE FROM `achievement_reward_locale` WHERE `ID` = 432 AND `Locale` = 'frFR';
+
+/* Reward Title Hand of A'dal */
+REPLACE INTO `achievement_reward` (`ID`, `TitleA`, `TitleH`, `ItemID`, `Sender`, `Subject`, `Body`, `MailTemplateID`) VALUES (431, 64, 64, 0, 0, NULL, NULL, 0);
+

--- a/sql/world/base/dungeon_attunements.sql
+++ b/sql/world/base/dungeon_attunements.sql
@@ -33,6 +33,11 @@ UPDATE `quest_template_addon` SET `NextQuestID` = 10888 WHERE `ID` = 10884;
 UPDATE `quest_template_addon` SET `NextQuestID` = 10888 WHERE `ID` = 10885;
 UPDATE `quest_template_addon` SET `NextQuestID` = 10888 WHERE `ID` = 10886;
 
+/* The Vials of Eternity */
+DELETE FROM `creature_questender` WHERE `id` = 19935 AND `quest` = 13432;
+DELETE FROM `creature_queststarter` WHERE `id` = 19935 AND `quest` = 13432;
+REPLACE INTO `creature_queststarter` (`id`, `quest`) VALUES (19935, 10445);
+
 /* A Distraction for Akama(13429) - Restore pre-3.0 version */
 UPDATE `quest_template` SET `RewardNextQuest` = 10985 WHERE `ID` = 10949;
 

--- a/sql/world/base/zone_deadwind_pass.sql
+++ b/sql/world/base/zone_deadwind_pass.sql
@@ -108,6 +108,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 
 -- Restless Shade
 DELETE FROM `creature_loot_template` WHERE `Entry`=7370;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (7370, 24480, 0, 80, 1, 1, 0, 1, 1, 'Restless Shade - Ghostly Essence');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (7370, 2928, 0, 0.02, 0, 1, 0, 1, 1, 'Restless Shade - Dust of Decay');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (7370, 4500, 0, 0.06, 0, 1, 0, 1, 1, 'Restless Shade - Traveler\'s Backpack');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (7370, 5759, 0, 0.18, 0, 1, 0, 1, 1, 'Restless Shade - Thorium Lockbox');
@@ -551,6 +552,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 
 -- Wailing Spectre
 DELETE FROM `creature_loot_template` WHERE `Entry`=12377;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12377, 24480, 0, 80, 1, 1, 0, 1, 1, 'Wailing Spectre - Ghostly Essence');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12377, 4500, 0, 0.04, 0, 1, 0, 1, 1, 'Wailing Spectre - Traveler\'s Backpack');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12377, 5759, 0, 0.0119, 0, 1, 0, 1, 1, 'Wailing Spectre - Thorium Lockbox');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12377, 7909, 0, 0.008, 0, 1, 0, 1, 1, 'Wailing Spectre - Aquamarine');
@@ -628,6 +630,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 
 -- Damned Soul
 DELETE FROM `creature_loot_template` WHERE `Entry`=12378;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12378, 24480, 0, 80, 1, 1, 0, 1, 1, 'Damned Soul - Ghostly Essence');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12378, 4500, 0, 0.06, 0, 1, 0, 1, 1, 'Damned Soul - Traveler\'s Backpack');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12378, 5759, 0, 0.2, 0, 1, 0, 1, 1, 'Damned Soul - Thorium Lockbox');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12378, 7909, 0, 0.12, 0, 1, 0, 1, 1, 'Damned Soul - Aquamarine');
@@ -710,6 +713,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 
 -- Unliving Caretaker
 DELETE FROM `creature_loot_template` WHERE `Entry`=12379;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12379, 24480, 0, 80, 1, 1, 0, 1, 1, 'Unliving Caretaker - Ghostly Essence');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12379, 4500, 0, 0.06, 0, 1, 0, 1, 1, 'Unliving Caretaker - Traveler\'s Backpack');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12379, 5759, 0, 0.24, 0, 1, 0, 1, 1, 'Unliving Caretaker - Thorium Lockbox');
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (12379, 7909, 0, 0.14, 0, 1, 0, 1, 1, 'Unliving Caretaker - Aquamarine');


### PR DESCRIPTION
the server side achievement_reward` WHERE `ID` = 432, I don't think it is right:
not achievement 432 reward title 53.

According to Achievement_Criteria.dbc, I find the conditions to get the achievement 432:
Complete Quest 10888
and
have title 53

so I delete the achievement_reward
and I modify quest 10888 to Reward Title Champion of the Naaru.
and to Reward Item The Tempest Key

If replace Quest  10888 to 11116, player can't get the achievement 432.
if let player  Complete both Quest 10888 and 11116 with a custom script. then the player will have two item 31746.

also According to Achievement_Criteria.dbc, I fix Reward Title  of Hand of A'dal:
Complete Quest 10985 and 10445 to get the achievement 431.
then the achievement 431 Reward Title Hand of A'dal.

and Reward Title  of Scarab Lord