### PR TITLE
Added Config Options for LFG and RDF

### DIFF
--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -329,12 +329,17 @@ IndividualProgression.AllowEarlyDungeonSet2 = 1
 
 IndividualProgression.PvPGearRequirements = 1
 #
-#    IndividualProgression.DisableLFG
-#        Description: Enable or disable the Looking For Group feature within the context of Individual Progression.
-#                     If set to 1, the LFG feature will be completely disabled.
-#                     If set to 0, the LFG feature will operate as usual.
+#    IndividualProgression.DisableRDF
+#        Description: Enable or disable the Random Dungeon Finder feature within the context of Individual Progression.
 #        Default:     0 - Enabled
 #                     1 - Disabled
 #
+IndividualProgression.DisableRDF = 0
 
+#
+#    IndividualProgression.DisableLFG
+#        Description: Enable or disable the Looking For Group feature within the context of Individual Progression. (This will also disable RDF)
+#        Default:     0 - Enabled
+#                     1 - Disabled
+#
 IndividualProgression.DisableLFG = 0

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -330,16 +330,9 @@ IndividualProgression.AllowEarlyDungeonSet2 = 1
 IndividualProgression.PvPGearRequirements = 1
 #
 #    IndividualProgression.DisableRDF
-#        Description: Enable or disable the Random Dungeon Finder feature within the context of Individual Progression.
+#        Description: Enable or disable the Random Dungeon Finder feature within the context of Individual Progression. 
+#        Queing for specific dungeons will still be possible. (See worldserver.conf for total LFG removal).
 #        Default:     0 - Enabled
 #                     1 - Disabled
 #
 IndividualProgression.DisableRDF = 0
-
-#
-#    IndividualProgression.DisableLFG
-#        Description: Enable or disable the Looking For Group feature within the context of Individual Progression. (This will also disable RDF)
-#        Default:     0 - Enabled
-#                     1 - Disabled
-#
-IndividualProgression.DisableLFG = 0

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -328,3 +328,13 @@ IndividualProgression.AllowEarlyDungeonSet2 = 1
 #
 
 IndividualProgression.PvPGearRequirements = 1
+#
+#    IndividualProgression.DisableLFG
+#        Description: Enable or disable the Looking For Group feature within the context of Individual Progression.
+#                     If set to 1, the LFG feature will be completely disabled.
+#                     If set to 0, the LFG feature will operate as usual.
+#        Default:     0 - Enabled
+#                     1 - Disabled
+#
+
+IndividualProgression.DisableLFG = 0

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -371,18 +371,6 @@ public:
      }
  }
 
- bool CanJoinLfg(Player* player, uint8 roles, lfg::LfgDungeonSet& dungeons, const std::string& comment) override
- {
-     // Check if LFG is disabled in the context of Individual Progression
-     if (sConfigMgr->GetOption<bool>("IndividualProgression.DisableLFG", false))
-     {
-         player->GetSession()->SendNotification("The Looking For Group feature is currently disabled by the Individual Progression module.");
-         return false; // Prevent the player from joining LFG
-     }
-
-     return true;
- }
-
     bool CanEquipItem(Player* player, uint8 /*slot*/, uint16& /*dest*/, Item* pItem, bool /*swap*/, bool /*not_loading*/) override
     {
         if (sIndividualProgression->pvpGearRequirements)

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -347,20 +347,41 @@ public:
     }
 
     void OnQueueRandomDungeon(Player* player, uint32& rDungeonId) override
-    {
-        if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_NAXX40))
-        {
-            rDungeonId = RDF_CLASSIC;
-        }
-        else if (rDungeonId == RDF_WRATH_OF_THE_LICH_KING && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5))
-        {
-            rDungeonId = RDF_THE_BURNING_CRUSADE;
-        }
-        else if (rDungeonId == RDF_WRATH_OF_THE_LICH_KING_HEROIC && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5))
-        {
-            rDungeonId = RDF_THE_BURNING_CRUSADE_HEROIC;
-        }
-    }
+ {
+     // Check if RDF is disabled in the context of Individual Progression
+     if (sConfigMgr->GetOption<bool>("IndividualProgression.DisableRDF", false))
+     {
+         // Notify the player
+         player->GetSession()->SendNotification("The Random Dungeon feature is currently disabled by the Individual Progression module.");
+         rDungeonId = 1000; // Set dungeon ID to an invalid value to cancel the queuing
+         return;
+     }
+
+     if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_NAXX40))
+     {
+         rDungeonId = RDF_CLASSIC;
+     }
+     else if (rDungeonId == RDF_WRATH_OF_THE_LICH_KING && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5))
+     {
+         rDungeonId = RDF_THE_BURNING_CRUSADE;
+     }
+     else if (rDungeonId == RDF_WRATH_OF_THE_LICH_KING_HEROIC && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5))
+     {
+         rDungeonId = RDF_THE_BURNING_CRUSADE_HEROIC;
+     }
+ }
+
+ bool CanJoinLfg(Player* player, uint8 roles, lfg::LfgDungeonSet& dungeons, const std::string& comment) override
+ {
+     // Check if LFG is disabled in the context of Individual Progression
+     if (sConfigMgr->GetOption<bool>("IndividualProgression.DisableLFG", false))
+     {
+         player->GetSession()->SendNotification("The Looking For Group feature is currently disabled by the Individual Progression module.");
+         return false; // Prevent the player from joining LFG
+     }
+
+     return true;
+ }
 
     bool CanEquipItem(Player* player, uint8 /*slot*/, uint16& /*dest*/, Item* pItem, bool /*swap*/, bool /*not_loading*/) override
     {


### PR DESCRIPTION
Added config options to disable RDF or LFG. Disabling RDF will still allow players to que for individual dungeons whereas disabling LFG will disable both RDF and LFG.