### PR TITLE
Make AQ Gate Stay Open Beyond Stage 5

### DIFF
--- a/sql/world/base/aq_gate.sql
+++ b/sql/world/base/aq_gate.sql
@@ -1,0 +1,3 @@
+UPDATE `acore_world`.`gameobject_template` SET `ScriptName`='aq_gate' WHERE  `entry`=176148;
+UPDATE `acore_world`.`gameobject_template` SET `ScriptName`='aq_gate' WHERE  `entry`=176147;
+UPDATE `acore_world`.`gameobject_template` SET `ScriptName`='aq_gate' WHERE  `entry`=176146;


### PR DESCRIPTION
Was having issues opening the gate once progression level 6 was reached. Decided to hide said gates if the player is already done with AQ40, this way they don't have to keep opening it. Gong is hidden as well to help prevent abuse.