### PR TITLE
Naxx40: Maexxna adjustments

### DIFF
--- a/src/naxx40Scripts/boss_maexxna_40.cpp
+++ b/src/naxx40Scripts/boss_maexxna_40.cpp
@@ -208,7 +208,7 @@ public:
                 break;
             case EVENT_SUMMON_SPIDERLINGS:
                 Talk(EMOTE_SPIDERS);
-                for (uint8 i = 0; i < 8; ++i)
+                for (uint8 i = 0; i < 10; ++i)
                 {
                     me->SummonCreature(NPC_MAEXXNA_SPIDERLING, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), me->GetOrientation());
                 }

--- a/src/naxx40Scripts/boss_maexxna_40.cpp
+++ b/src/naxx40Scripts/boss_maexxna_40.cpp
@@ -22,7 +22,6 @@
 #include "SpellAuras.h"
 #include "naxxramas.h"
 
-
 enum Spells
 {
     SPELL_WEB_WRAP = 28622,
@@ -39,8 +38,7 @@ enum Events
     EVENT_NECROTIC_POISON = 3,
     EVENT_WEB_WRAP = 4,
     EVENT_HEALTH_CHECK = 5,
-    EVENT_SUMMON_SPIDERLINGS = 6,
-    EVENT_MODIFY_WEB_SPRAY_AURA = 7
+    EVENT_SUMMON_SPIDERLINGS = 6
 };
 
 enum Emotes
@@ -62,8 +60,6 @@ const Position PosWrap[3] =
     {3531.271f, -3847.424f, 299.450f, 0.0f},
     {3497.067f, -3843.384f, 302.384f, 0.0f}
 };
-
-
 
 class boss_maexxna_40 : public CreatureScript
 {
@@ -173,28 +169,9 @@ public:
             case EVENT_WEB_SPRAY:
                 Talk(EMOTE_WEB_SPRAY);
                 me->CastSpell(me, SPELL_WEB_SPRAY, true);
-                events.ScheduleEvent(EVENT_MODIFY_WEB_SPRAY_AURA, 500);  // Schedule the modify aura event with a 500ms delay
+                me->CastCustomSpell(SPELL_WEB_SPRAY, SPELLVALUE_AURA_DURATION, 10000, nullptr, true);
                 events.RepeatEvent(40000);
                 break;
-
-            case EVENT_MODIFY_WEB_SPRAY_AURA:
-            {
-                Map::PlayerList const& PlayerList = me->GetMap()->GetPlayers();
-                for (Map::PlayerList::const_iterator i = PlayerList.begin(); i != PlayerList.end(); ++i)
-                {
-                    if (Player* player = i->GetSource())
-                    {
-                        if (player->IsAlive() && player->HasAura(SPELL_WEB_SPRAY))
-                        {
-                            if (Aura* aura = player->GetAura(SPELL_WEB_SPRAY))
-                            {
-                                aura->SetDuration(8000);  // Set the duration to 8 seconds 
-                            }
-                        }
-                    }
-                }
-            }
-            break;
             case EVENT_POISON_SHOCK:
             {
                 int32 modifiedPoisonShockDamage = urand(1750, 2250);  // Set damage to a random value between 1750 and 2250

--- a/src/naxx40Scripts/boss_maexxna_40.cpp
+++ b/src/naxx40Scripts/boss_maexxna_40.cpp
@@ -301,10 +301,7 @@ public:
             {
                 if (Unit* victim = ObjectAccessor::GetUnit(*me, victimGUID))
                 {
-                    if (victim->HasAura(SPELL_WEB_WRAP))
-                    {
-                        victim->RemoveAurasDueToSpell(SPELL_WEB_WRAP, me->GetGUID());
-                    }
+                    victim->RemoveAurasDueToSpell(SPELL_WEB_WRAP, me->GetGUID());
                 }
             }
         }

--- a/src/naxx40Scripts/boss_maexxna_40.cpp
+++ b/src/naxx40Scripts/boss_maexxna_40.cpp
@@ -174,8 +174,8 @@ public:
                 break;
             case EVENT_POISON_SHOCK:
             {
-                int32 modifiedPoisonShockDamage = urand(1750, 2250);  // Set damage to a random value between 1750 and 2250
-                me->CastCustomSpell(me->GetVictim(), SPELL_POISON_SHOCK, &modifiedPoisonShockDamage, nullptr, nullptr, false, nullptr, nullptr, me->GetGUID());
+                int32 bp0 = 1499;
+                me->CastCustomSpell(me->GetVictim(), SPELL_POISON_SHOCK, &bp0, nullptr, nullptr, false, nullptr, nullptr, me->GetGUID());
                 events.RepeatEvent(10000);
                 break;
             }
@@ -249,9 +249,9 @@ public:
                 {
                     if (victim->GetTypeId() == TYPEID_PLAYER && victim->GetEntry() != NPC_WEB_WRAP)
                     {
-                        int32 modifiedBaseDamage = urand(650, 850);  // Set damage to a random value between 650 and 850
-                        int32 damageForEffect2 = modifiedBaseDamage;
-                        victim->CastCustomSpell(victim, SPELL_WEB_WRAP, nullptr, &damageForEffect2, nullptr, true, nullptr, nullptr, me->GetGUID());
+                        int32 bp1 = 242;
+                        victim->CastCustomSpell(victim, SPELL_WEB_WRAP, 0, &bp1, 0, true, nullptr, nullptr, me->GetGUID());
+                        victim->CastSpell(victim, SPELL_WEB_WRAP, true, nullptr, nullptr, me->GetGUID());
                     }
                 }
             }

--- a/src/naxx40Scripts/boss_maexxna_40.cpp
+++ b/src/naxx40Scripts/boss_maexxna_40.cpp
@@ -229,30 +229,15 @@ public:
                     if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1, 0, true, true, -SPELL_WEB_WRAP))
                     {
                         target->RemoveAura(SPELL_WEB_SPRAY);
-                        float x, y, z;
-                        target->GetPosition(x, y, z);  // Get the current position of the target player
-
-                        // Set the destination position for the Web Wrap NPC
                         uint8 pos = urand(0, 2);
-                        float destX = PosWrap[pos].GetPositionX();
-                        float destY = PosWrap[pos].GetPositionY();
-                        float destZ = PosWrap[pos].GetPositionZ();
-
-                        if (Creature* wrap = me->SummonCreature(NPC_WEB_WRAP, x, y, z, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 60000))
+                        if (Creature* wrap = me->SummonCreature(NPC_WEB_WRAP, PosWrap[pos].GetPositionX(), PosWrap[pos].GetPositionY(), PosWrap[pos].GetPositionZ(), 0.0f, TEMPSUMMON_TIMED_DESPAWN, 60000))
                         {
                             wrap->AI()->SetGUID(target->GetGUID());
-                            wrap->GetMotionMaster()->MoveJump(destX, destY, destZ, 20, 20);  // Make the Web Wrap NPC fly to the destination
-
-                            // Make the player fly to the same destination as Web Wrap NPC
-                            target->GetMotionMaster()->MoveJump(destX, destY, destZ, 20, 20);
-
-                            int32 modifiedBaseDamage = urand(650, 850);  // Set damage to a random value between 650 and 850
-                            int32 damageForEffect2 = modifiedBaseDamage;
-                            target->CastCustomSpell(target, SPELL_WEB_WRAP, nullptr, &damageForEffect2, nullptr, true, nullptr, nullptr, wrap->GetGUID());
+                            target->GetMotionMaster()->MoveJump(PosWrap[pos].GetPositionX(), PosWrap[pos].GetPositionY(), PosWrap[pos].GetPositionZ(), 20, 20);
                         }
                     }
                 }
-                events.RepeatEvent(40000);
+                events.Repeat(40s);
                 break;
             }
             DoMeleeAttackIfReady();


### PR DESCRIPTION
Maexxna updates

- [x] update summoned spiders to 10
- [x] lowered bp of poison shock, web wrap dot based on 1.12 DBC values
- [x] Web Wrap NPC should spawn at target location
- [ ] Web Wrap NPC should be invisible until player lands
- [x] reverted web wrap move together


## Web wrap

Web Wrap is not implemented correctly upstream?  I tested in Naxx25 and have the same problem with positions not being updated. 

This is what I see when Web Wrap goes out. From the target POV you fly to the wall correctly, but position is not updated on the server? The player targetted does not update until web wrap is broken. 
![maexxna](https://github.com/ZhengPeiRu21/mod-individual-progression/assets/46423958/7200b4ad-b9c0-435a-88a0-9c0bce13fbbf)

Reverted web wrap mechanic based on below

classic:
https://youtu.be/ca9WJN98A58?si=iLjNhK6N1kmO2mvX&t=67

vanilla: 
https://youtu.be/i7JSMKRL6ZY?si=Z09kR08ZeY2Y7tJG&t=91
Moves player then webwrap spawns at destination

cmangos maexxna
https://github.com/cmangos/mangos-classic/blob/master/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/boss_maexxna.cpp

vmangos maexxna
https://github.com/vmangos/core/blob/development/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_maexxna.cpp

Maexxna 40
.go c 361295
naxx 10
.go c 130960
