### PR TITLE
fix(DB/BWL): Add delete statement to query

### DIFF
--- a/sql/world/base/dungeon_blackwing_lair.sql
+++ b/sql/world/base/dungeon_blackwing_lair.sql
@@ -1,2 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` = 23310 AND `ScriptName` = 'spell_bwl_chromaggus_time_lapse';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (23310, 'spell_bwl_chromaggus_time_lapse');


### PR DESCRIPTION
"Query should be re-runable. By using DELETE before INSERT. This particular query isn't"

issue with this query was mentioned in acore support forum https://discord.com/channels/217589275766685707/1250053251102015509