### PR TITLE
fix(DB): Added an `lfgdungeons_dbc` entry for 40-man Onyxia

### DIFF
--- a/sql/world/base/dungeon_onyxia.sql
+++ b/sql/world/base/dungeon_onyxia.sql
@@ -914,11 +914,17 @@ DELETE FROM `mapdifficulty_dbc` WHERE `MapID` = 249;
 INSERT INTO `mapdifficulty_dbc` (`ID`, `MapID`, `Difficulty`, `RaidDuration`, `MaxPlayers`, `Difficultystring`) VALUES
 (755, 249, 2, 604800, 40, 'RAID_DIFFICULTY_40PLAYER');
 
+DELETE FROM `dungeonencounter_dbc` WHERE `ID` = 895;
 INSERT INTO `dungeonencounter_dbc` (`ID`, `MapID`, `Difficulty`, `OrderIndex`, `Bit`, `Name_Lang_enUS`, `Name_Lang_enGB`, `Name_Lang_koKR`, `Name_Lang_frFR`, `Name_Lang_deDE`, `Name_Lang_enCN`, `Name_Lang_zhCN`, `Name_Lang_enTW`, `Name_Lang_zhTW`, `Name_Lang_esES`, `Name_Lang_esMX`, `Name_Lang_ruRU`, `Name_Lang_ptPT`, `Name_Lang_ptBR`, `Name_Lang_itIT`, `Name_Lang_Unk`, `Name_Lang_Mask`, `SpellIconID`) VALUES
 (895, 249, 2, 0, 0, 'Onyxia', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 16712190, 0);
 
+DELETE FROM `instance_encounters` WHERE `entry` = 895;
 INSERT INTO `instance_encounters` (`entry`, `creditType`, `creditEntry`, `lastEncounterDungeon`, `comment`) VALUES
 (895, 0, 301000, 0, 'Onyxia (Vanilla)');
+
+DELETE FROM `lfgdungeons_dbc` WHERE `ID` = 1000;
+INSERT INTO `lfgdungeons_dbc` VALUES
+(1000,"Onyxia\\'s Lair (Vanilla)","","","","","","","","","","","","","","","",16712190,60,83,60,60,83,249,2,0,2,-1,"",2,0,9,"","","","","","","","","","","","","","","","",16712188);
 
 -- Victory for the Alliance - Bolvar or Varian
 DELETE FROM `creature_questender` WHERE `quest` = 7495;


### PR DESCRIPTION
This fixes an issue where scaling was not working for 40-man Onyxia with a recent AutoBalance update/rewrite which checks for acceptable level scaling ranges from LFG dungeon data.

Addresses issue #263