### PR TITLE
removed additional Summon Warhorse from Paladin Trainers

### DIFF
--- a/sql/world/base/mounts_and_riding.sql
+++ b/sql/world/base/mounts_and_riding.sql
@@ -17,6 +17,7 @@ UPDATE npc_trainer SET ReqLevel=70 WHERE SpellID=34090;
 UPDATE npc_trainer SET MoneyCost=6000000 WHERE SpellID=34090;
 DELETE FROM npc_trainer WHERE SpellID=13819; # Delete Summon Warhorse from trainer - it is a free reward from a quest instead
 DELETE FROM npc_trainer WHERE SpellID=13820; # Delete Summon Warhorse from more trainers
+DELETE FROM npc_trainer WHERE SpellID=34768; # Delete Summon Warhorse from more trainers
 DELETE FROM npc_trainer WHERE SpellID=23214;
 DELETE FROM npc_trainer WHERE SpellID=34767;
 DELETE FROM npc_trainer WHERE SpellID=23161;

--- a/sql/world/base/mounts_and_riding.sql
+++ b/sql/world/base/mounts_and_riding.sql
@@ -17,7 +17,6 @@ UPDATE npc_trainer SET ReqLevel=70 WHERE SpellID=34090;
 UPDATE npc_trainer SET MoneyCost=6000000 WHERE SpellID=34090;
 DELETE FROM npc_trainer WHERE SpellID=13819; # Delete Summon Warhorse from trainer - it is a free reward from a quest instead
 DELETE FROM npc_trainer WHERE SpellID=13820; # Delete Summon Warhorse from more trainers
-DELETE FROM npc_trainer WHERE SpellID=34768; # Delete Summon Warhorse from more trainers
 DELETE FROM npc_trainer WHERE SpellID=23214;
 DELETE FROM npc_trainer WHERE SpellID=34767;
 DELETE FROM npc_trainer WHERE SpellID=23161;

--- a/sql/world/base/mounts_and_riding.sql
+++ b/sql/world/base/mounts_and_riding.sql
@@ -20,7 +20,6 @@ DELETE FROM npc_trainer WHERE SpellID=13820; # Delete Summon Warhorse from more 
 DELETE FROM npc_trainer WHERE SpellID=23214;
 DELETE FROM npc_trainer WHERE SpellID=34767;
 DELETE FROM npc_trainer WHERE SpellID=23161;
-UPDATE npc_trainer SET ReqLevel=40 WHERE SpellID=13820;
 UPDATE npc_trainer SET ReqLevel=40 WHERE SpellID=34768;
 UPDATE npc_trainer SET ReqLevel=40 WHERE SpellID=1710;
 UPDATE npc_trainer SET ReqLevel=68 WHERE SpellID=33950;

--- a/sql/world/base/mounts_and_riding.sql
+++ b/sql/world/base/mounts_and_riding.sql
@@ -16,6 +16,7 @@ UPDATE npc_trainer SET MoneyCost=10000000 WHERE SpellID=33391;
 UPDATE npc_trainer SET ReqLevel=70 WHERE SpellID=34090;
 UPDATE npc_trainer SET MoneyCost=6000000 WHERE SpellID=34090;
 DELETE FROM npc_trainer WHERE SpellID=13819; # Delete Summon Warhorse from trainer - it is a free reward from a quest instead
+DELETE FROM npc_trainer WHERE SpellID=13820; # Delete Summon Warhorse from more trainers
 DELETE FROM npc_trainer WHERE SpellID=23214;
 DELETE FROM npc_trainer WHERE SpellID=34767;
 DELETE FROM npc_trainer WHERE SpellID=23161;


### PR DESCRIPTION
This is just a small addition to remove the "Summon Warhorse" ability from Paladin Trainers.
I tested this with Paladin Trainers in Stormwind Castle.
With just the original SpellID=13819 there was still the option to learn that ability.
But since those trainers used reference ID -200020, there was still SpellID 13820 in there.