### PR TITLE
Label the Shadow Magic quest as a group quest

### DIFF
--- a/sql/world/base/vanilla_quest_levels.sql
+++ b/sql/world/base/vanilla_quest_levels.sql
@@ -19,6 +19,9 @@ UPDATE quest_template SET RequiredItemId1 = 750 WHERE ID=33;
 /*  The Legend of Stalvan  */
 UPDATE quest_template SET QuestLevel = 35 WHERE ID=98;
 
+/* Shadow Magic */
+UPDATE quest_template SET QuestInfoID = 1, SuggestedGroupNum = 2 WHERE ID=115;
+
 /*  Howling in the Hills  */
 UPDATE quest_template SET QuestLevel = 25 WHERE ID=126;
 


### PR DESCRIPTION
Labels the Shadow Magic quest as a group quest.

Related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/179


May require reset of client cache files:
pagetextcache.wdb
questcache.wdb