### PR TITLE
fix compiler warnings

### DIFF
--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -71,7 +71,7 @@ void IndividualProgression::ApplyGearStatsTuning(Player* player, float& computed
     if (item->Quality != ITEM_QUALITY_EPIC) // Non-endgame gear is okay
         return;
     if ((hasPassedProgression(player, PROGRESSION_NAXX40) && (item->RequiredLevel <= 60)) ||
-        hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (item->RequiredLevel <=70))
+        (hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (item->RequiredLevel <=70)))
     {
         computedAdjustment -= (100.0f * previousGearTuning);
     }
@@ -82,7 +82,7 @@ void IndividualProgression::ComputeGearTuning(Player* player, float& computedAdj
     if (item->Quality != ITEM_QUALITY_EPIC) // Non-endgame gear is okay
         return;
     if ((hasPassedProgression(player, PROGRESSION_NAXX40) && (item->RequiredLevel <= 60)) ||
-        hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (item->RequiredLevel <=70))
+        (hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (item->RequiredLevel <=70)))
     {
         computedAdjustment += previousGearTuning;
     }
@@ -133,11 +133,11 @@ void IndividualProgression::AdjustWotLKStats(Player* player) const
     AdjustStats(player, computedAdjustment, computedAdjustment);
 }
 
-void IndividualProgression::AdjustStats(Player* player, float computedAdjustment, float computedHealingAdjustment)
+void IndividualProgression::AdjustStats(Player* player, float computedAdjustment, float /*computedHealingAdjustment*/)
 {
-    int32 bp0 = 0; // This would be the damage taken adjustment value, but we are already adjusting health
+    // int32 bp0 = 0; // This would be the damage taken adjustment value, but we are already adjusting health
     auto bp1 = static_cast<int32>(computedAdjustment);
-    auto bp1Healing = static_cast<int32>(computedHealingAdjustment);
+    // auto bp1Healing = static_cast<int32>(computedHealingAdjustment);
 
     player->RemoveAura(ABSORB_SPELL);
     player->CastCustomSpell(player, ABSORB_SPELL, &bp1, nullptr, nullptr, false);

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -307,7 +307,7 @@ public:
         }
     }
 
-    bool OnUpdateFishingSkill(Player* player, int32 /*skill*/, int32 /*zone_skill*/, int32 chance, int32 roll) override
+    bool OnUpdateFishingSkill(Player* /*player*/, int32 /*skill*/, int32 /*zone_skill*/, int32 chance, int32 roll) override
     {
         if (!sIndividualProgression->enabled || !sIndividualProgression->fishingFix)
             return true;
@@ -530,7 +530,7 @@ private:
 
     static void AdjustStats(Pet* pet, float computedAdjustment, float hpAdjustment)
     {
-        int32 bp0 = 0; // This would be the damage taken adjustment value, but we are already adjusting health
+        // int32 bp0 = 0; // This would be the damage taken adjustment value, but we are already adjusting health
         auto bp1 = static_cast<int32>(computedAdjustment);
         auto bp2 = static_cast<int32>(hpAdjustment);
 
@@ -612,7 +612,7 @@ public:
         }
     }
 
-    void ModifySpellDamageTaken(Unit* /*target*/, Unit* attacker, int32& damage, SpellInfo const* spellInfo) override
+    void ModifySpellDamageTaken(Unit* /*target*/, Unit* attacker, int32& damage, SpellInfo const* /*spellInfo*/) override
     {
         if (!sIndividualProgression->enabled || !attacker)
             return;


### PR DESCRIPTION
fixes some compile warnings
[-Wlogical-op-parentheses]
[-Wunused-variable]
[-Wunused-parameter]

```
/home/jelle/wd/wow/azerothcore-wotlk/modules/mod-individual-progression/src/IndividualProgression.cpp:74:62: warning: '&&' within '||' [-Wlogical-op-parentheses]
   73 |     if ((hasPassedProgression(player, PROGRESSION_NAXX40) && (item->RequiredLevel <= 60)) ||
      |                                                                                           ~~
   74 |         hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (item->RequiredLevel <=70))
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jelle/wd/wow/azerothcore-wotlk/modules/mod-individual-progression/src/IndividualProgression.cpp:74:62: note: place parentheses around the '&&' expression to silence this warning
   74 |         hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (item->RequiredLevel <=70))
      |                                                              ^                            
      |         (                                                                                 )
/home/jelle/wd/wow/azerothcore-wotlk/modules/mod-individual-progression/src/IndividualProgression.cpp:85:62: warning: '&&' within '||' [-Wlogical-op-parentheses]
   84 |     if ((hasPassedProgression(player, PROGRESSION_NAXX40) && (item->RequiredLevel <= 60)) ||
      |                                                                                           ~~
   85 |         hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (item->RequiredLevel <=70))
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jelle/wd/wow/azerothcore-wotlk/modules/mod-individual-progression/src/IndividualProgression.cpp:85:62: note: place parentheses around the '&&' expression to silence this warning
   85 |         hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (item->RequiredLevel <=70))
      |                                                              ^                            
      |         (                                                                                 )
/home/jelle/wd/wow/azerothcore-wotlk/modules/mod-individual-progression/src/IndividualProgression.cpp:138:11: warning: unused variable 'bp0' [-Wunused-variable]
  138 |     int32 bp0 = 0; // This would be the damage taken adjustment value, but we are already adjusting health
      |           ^~~
/home/jelle/wd/wow/azerothcore-wotlk/modules/mod-individual-progression/src/IndividualProgression.cpp:140:10: warning: unused variable 'bp1Healing' [-Wunused-variable]
  140 |     auto bp1Healing = static_cast<int32>(computedHealingAdjustment);
      |          ^~~~~~~~~~
[ 96%] Building CXX object modules/CMakeFiles/modules.dir/mod-individual-progression/src/naxx40Scripts/boss_gluth_40.cpp.o
/home/jelle/wd/wow/azerothcore-wotlk/modules/mod-individual-progression/src/IndividualProgressionPlayer.cpp:310:39: warning: unused parameter 'player' [-Wunused-parameter]
  310 |     bool OnUpdateFishingSkill(Player* player, int32 /*skill*/, int32 /*zone_skill*/, int32 chance, int32 roll) override
      |                                       ^
/home/jelle/wd/wow/azerothcore-wotlk/modules/mod-individual-progression/src/IndividualProgressionPlayer.cpp:533:15: warning: unused variable 'bp0' [-Wunused-variable]
  533 |         int32 bp0 = 0; // This would be the damage taken adjustment value, but we are already adjusting health
      |               ^~~
/home/jelle/wd/wow/azerothcore-wotlk/modules/mod-individual-progression/src/IndividualProgressionPlayer.cpp:615:99: warning: unused parameter 'spellInfo' [-Wunused-parameter]
  615 |     void ModifySpellDamageTaken(Unit* /*target*/, Unit* attacker, int32& damage, SpellInfo const* spellInfo) override
      |                                                                                                   ^

```
