### PR TITLE
Added exclude accounts config option

### DIFF
--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -358,3 +358,19 @@ IndividualProgression.PvPGearRequirements = 1
 #                     1 - Disabled
 #
 IndividualProgression.DisableRDF = 0
+#
+#    IndividualProgression.ExcludeAccounts
+#        Description: Enable or disable the exclusion of accounts from Individual Progression.
+#        This is useful for accounts that are used for bots, testing, or other purposes where progression should not be enforced.
+#        Default:     0 - Disabled
+#                     1 - Enabled
+#
+IndividualProgression.ExcludeAccounts = 0
+#
+#    IndividualProgression.ExcludedAccountsRegex
+#        Description: A regular expression to match account names that should be excluded from Individual Progression.
+#        This is useful for accounts that are used for bots, testing, or other purposes where progression should not be enforced.
+#        Only used if ExcludeAccounts is enabled.
+#        Default:     ""
+#
+IndividualProgression.ExcludedAccountsRegex = ""

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -315,6 +315,8 @@ private:
         sIndividualProgression->LoadCustomProgressionEntries(sConfigMgr->GetOption<std::string>("IndividualProgression.CustomProgression", ""));
         sIndividualProgression->earlyDungeonSet2 = sConfigMgr->GetOption<bool>("IndividualProgression.AllowEarlyDungeonSet2", true);
         sIndividualProgression->pvpGearRequirements = sConfigMgr->GetOption<bool>("IndividualProgression.PvPGearRequirements", true);
+        sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", false);
+        sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "");
     }
 
     static void LoadXpValues()

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -16,6 +16,7 @@
 #include "QuestDef.h"
 #include "GameObject.h"
 #include "IWorld.h"
+#include <regex>
 
 typedef std::unordered_map<uint32, uint32> questXpMapType;
 
@@ -180,8 +181,9 @@ public:
     std::map<uint32, uint8> customProgressionMap;
     questXpMapType questXpMap;
     float vanillaPowerAdjustment, vanillaHealthAdjustment, tbcPowerAdjustment, tbcHealthAdjustment, vanillaHealingAdjustment, tbcHealingAdjustment, previousGearTuning;
-    bool enabled, questXpFix, hunterPetLevelFix, requirePreAQQuests, enforceGroupRules, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, requireNaxxStrath, pvpGearRequirements;
+    bool enabled, questXpFix, hunterPetLevelFix, requirePreAQQuests, enforceGroupRules, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, requireNaxxStrath, pvpGearRequirements, excludeAccounts;
     int progressionLimit, startingProgression, tbcRacesProgressionLevel, deathKnightProgressionLevel, deathKnightStartingProgression;
+    std::string excludedAccountsRegex;
 
     bool hasPassedProgression(Player* player, ProgressionState state) const;
     static bool isBeforeProgression(Player* player, ProgressionState state) ;

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -166,9 +166,9 @@ public:
             return false;
         }
         std::string accountName;
-        bool gotAccountName = AccountMgr::GetName(player->GetSession()->GetAccountId(), accountName);
+        bool accountNameFound = AccountMgr::GetName(player->GetSession()->GetAccountId(), accountName);
         std::regex excludedAccountsRegex (sIndividualProgression->excludedAccountsRegex);
-        return (gotAccountName && std::regex_match(accountName, excludedAccountsRegex));
+        return (accountNameFound && std::regex_match(accountName, excludedAccountsRegex));
     }
 
     bool OnBeforeTeleport(Player* player, uint32 mapid, float x, float y, float z, float /*orientation*/, uint32 /*options*/, Unit* /*target*/) override

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -87,7 +87,7 @@ public:
     void OnAfterUpdateMaxHealth(Player* player, float& value) override
     {
         // TODO: This should be adjust to use an aura like damage adjustment. This is more robust to update when changing equipment, etc.
-        if (!sIndividualProgression->enabled)
+        if (!sIndividualProgression->enabled || isExcludedFromProgression(player))
         {
             return;
         }
@@ -119,7 +119,7 @@ public:
 
     void OnQuestComputeXP(Player* player, Quest const* quest, uint32& xpValue) override
     {
-        if (!sIndividualProgression->enabled || !sIndividualProgression->questXpFix)
+        if (!sIndividualProgression->enabled || !sIndividualProgression->questXpFix || isExcludedFromProgression(player))
         {
             return;
         }
@@ -136,7 +136,7 @@ public:
 
     void OnGiveXP(Player* player, uint32& amount, Unit* /*victim*/, uint8 xpSource) override
     {
-        if (!sIndividualProgression->enabled)
+        if (!sIndividualProgression->enabled || isExcludedFromProgression(player))
         {
             return;
         }
@@ -249,7 +249,7 @@ public:
 
     void OnPlayerCompleteQuest(Player* player, Quest const* quest) override
     {
-        if (!sIndividualProgression->enabled)
+        if (!sIndividualProgression->enabled || isExcludedFromProgression(player))
         {
             return;
         }
@@ -276,7 +276,7 @@ public:
 
     bool CanGroupInvite(Player* player, std::string& membername) override
     {
-        if (!sIndividualProgression->enabled || !sIndividualProgression->enforceGroupRules)
+        if (!sIndividualProgression->enabled || !sIndividualProgression->enforceGroupRules || isExcludedFromProgression(player))
         {
             return true;
         }
@@ -288,7 +288,7 @@ public:
 
     bool CanGroupAccept(Player* player, Group* group) override
     {
-        if (!sIndividualProgression->enabled || !sIndividualProgression->enforceGroupRules)
+        if (!sIndividualProgression->enabled || !sIndividualProgression->enforceGroupRules || isExcludedFromProgression(player))
         {
             return true;
         }
@@ -321,7 +321,7 @@ public:
 
     bool OnUpdateFishingSkill(Player* player, int32 /*skill*/, int32 /*zone_skill*/, int32 chance, int32 roll) override
     {
-        if (!sIndividualProgression->enabled || !sIndividualProgression->fishingFix)
+        if (!sIndividualProgression->enabled || !sIndividualProgression->fishingFix || isExcludedFromProgression(player))
             return true;
         if (chance < roll)
             return false;

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -31,10 +31,11 @@ public:
 
     void OnSetMaxLevel(Player* player, uint32& maxPlayerLevel) override
     {
-        if (!sIndividualProgression->enabled)
+        if (!sIndividualProgression->enabled || isExcludedFromProgression(player))
         {
             return;
         }
+
         if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_NAXX40))
         {
             if (sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL) > 60)
@@ -159,9 +160,20 @@ public:
         }
     }
 
+    bool isExcludedFromProgression(Player* player)
+    {
+        if(!sIndividualProgression->excludeAccounts) {
+            return false;
+        }
+        std::string accountName;
+        bool gotAccountName = AccountMgr::GetName(player->GetSession()->GetAccountId(), accountName);
+        std::regex excludedAccountsRegex (sIndividualProgression->excludedAccountsRegex);
+        return (gotAccountName && std::regex_match(accountName, excludedAccountsRegex));
+    }
+
     bool OnBeforeTeleport(Player* player, uint32 mapid, float x, float y, float z, float /*orientation*/, uint32 /*options*/, Unit* /*target*/) override
     {
-        if (!sIndividualProgression->enabled || player->IsGameMaster())
+        if (!sIndividualProgression->enabled || player->IsGameMaster() || isExcludedFromProgression(player))
         {
             return true;
         }


### PR DESCRIPTION
I'm not sure if this makes sense, but it helped me with the playerbots mod. While testing my fresh server, I realized that the bots couldn't enter Outland or Northrend. Upon investigation, I found that there's no option for them to run the raids by themselves, so once I reach Outland/Northrend, I'll run out of bots to carry me.

- I added two new config options: ExcludeAccounts and ExcludedAccountsRegex.
- If a player's account matches the regex, the portal/level restriction is not applied. In this case, I'm using "^RNDBOT.*".