### PR TITLE
Add sneak spell to Deviate and Silvermane Stalker

### DIFF
--- a/sql/world/base/spell_restorations.sql
+++ b/sql/world/base/spell_restorations.sql
@@ -17,3 +17,15 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`, `MoneyCost`, `ReqSkillLine`, `ReqSki
 /* Optional - give Detect Magic a new effect to tell user of enemy's resistance levels. About the same level of useful as original spell */
 DELETE FROM `spell_script_names` WHERE `spell_id`=2855 AND `ScriptName`='spell_detect_magic';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (2855, 'spell_detect_magic');
+
+/* Silvermane Stalker (2926) should have sneak spell 22766 */
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 2926 AND `action_param1` = 22766;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+(2926, 0, 1, 0, 1, 0, 100, 1, 1000, 1000, 0, 0, 0, 0, 11, 22766, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Silvermane Stalker - Out of Combat - Cast \'Sneak\'');
+
+/* Deviate Stalker (3634) should have sneak spell 22766 */
+UPDATE `creature_template` SET `AIName` = "SmartAI" WHERE `entry` = 3634;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 3634 AND `action_param1` = 22766;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+(3634, 0, 0, 0, 1, 0, 100, 1, 1000, 1000, 0, 0, 0, 0, 11, 22766, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Deviate Stalker - Out of Combat - Cast \'Sneak\'');
+


### PR DESCRIPTION
Related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/307

Both these creatures have the sneak spell in classic.
This adds the spell to their SmartAI in smart_scripts.

edit:
the deviate stalker might be an AzerothCore issue, not so much individual progression.
https://www.wowhead.com/wotlk/npc=3634/deviate-stalker#abilities
it needed fixing, but according to wowhead the deviate stalker never lost his sneak spell.