### PR TITLE
Various minor issues

### DIFF
--- a/sql/world/base/class_trainers.sql
+++ b/sql/world/base/class_trainers.sql
@@ -8,8 +8,10 @@ UPDATE `quest_template` SET `RewardSpell` = 1446 WHERE `ID` IN (31, 5061);
 UPDATE `npc_trainer` SET `ReqLevel` = 30 WHERE `SpellID` = 783;
 
 /* Remove Summon Imp from Trainer - it is a quest reward instead */
-
 DELETE FROM `npc_trainer` WHERE `ID`=200009 AND `SpellID`=688;
+
+/* Remove Summon Felsteed from Trainer - it is a quest reward instead */
+DELETE FROM `npc_trainer` WHERE `ID`=200010 AND `SpellID`=1710;
 
 /* Remove Sense Undead from Trainer - it is a quest reward for Tome of Valor quest line */
 DELETE FROM `npc_trainer` WHERE `SpellID`=5502;

--- a/sql/world/base/item_changes.sql
+++ b/sql/world/base/item_changes.sql
@@ -3506,7 +3506,7 @@ UPDATE `item_template` SET `BuyPrice` = 2361 WHERE entry=5459;
 UPDATE `item_template` SET `spellid_1` = 5405, `spellcharges_1` = -1, `spellcooldown_1` = -1, `spellcategorycooldown_1` = 120000, `spellcategory_1` = 1153, `spellid_2` = 0, `spellcharges_2` = 0, `spellcategorycooldown_2` = 0, `spellcategory_2` = 0, `spellcooldown_3` = -1, `spellcategorycooldown_3` = -1, `spellcooldown_4` = -1, `spellcategorycooldown_4` = -1, `RequiredLevel` = 23 WHERE entry=5514;
 
 /*  Iridescent Hammer  */
-UPDATE `item_template` SET `BuyPrice` = 18469, `SellPrice` = 3693, `dmg_min1` = 18.0, `dmg_max1` = 34.0, `stat_type1` = 4, `stat_type2` = 7, `stat_value2` = 3 WHERE entry=5541;
+UPDATE `item_template` SET `BuyPrice` = 18469, `SellPrice` = 3693, `dmg_min1` = 18.0, `dmg_max1` = 34.0, `stat_type1` = 4, `stat_type2` = 7, `stat_value2` = 3, `delay` = 1800 WHERE entry=5541;
 
 /*  Pearl-clasped Cloak  */
 UPDATE `item_template` SET `BuyPrice` = 1852 WHERE entry=5542;

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -90,6 +90,9 @@ INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, 
 DELETE FROM `creature` WHERE `id1`=15006;
 INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (15006, 1, 2002.26, -4796.74, 56.8471, 3.00197, 600);
 
+-- Master Pyreanor <Paladin Trainer>
+UPDATE `creature` SET `position_x`=1940.23, `position_y`=-4135.53, `position_z`=41.1522, `orientation`=3.12425  WHERE `id1`=23128;
+
 -- Summon Felsteed (Warlock)
 DELETE FROM `creature_queststarter` WHERE `id`=3326 AND `quest`=3631;
 INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 3631);

--- a/sql/world/base/zone_undercity.sql
+++ b/sql/world/base/zone_undercity.sql
@@ -100,7 +100,7 @@ UPDATE `item_template` SET `flags` = 2048 WHERE `entry` = 17008;
 UPDATE `item_template` SET `description` = 'To be opened by Lord Varimathras.' WHERE `entry` = 3701;
 
 UPDATE `quest_template`
-SET `QuestCompletionLog` = "Return to Varimathras in the Undercity."
+SET `QuestCompletionLog` = "Return to Varimathras at the Royal Quarter in the Undercity."
 WHERE `ID` = 5725;
 
 UPDATE `quest_template`

--- a/sql/world/base/zone_undercity.sql
+++ b/sql/world/base/zone_undercity.sql
@@ -19,6 +19,7 @@ INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionTex
 (2847, 5, 0, 'First Aid', 3464, 1, 1, 2839, 341, 0, 0, NULL, 0, 0),
 (2847, 6, 0, 'Fishing', 3465, 1, 1, 2840, 342, 0, 0, NULL, 0, 0),
 (2847, 7, 0, 'Herbalism', 3466, 1, 1, 2841, 343, 0, 0, NULL, 0, 0),
+(2847, 8, 0, 'Inscription', 48811, 1, 1, 10019, 344, 0, 0, NULL, 0, 0),
 (2847, 9, 0, 'Leatherworking', 3467, 1, 1, 2842, 345, 0, 0, NULL, 0, 0),
 (2847, 10, 0, 'Mining', 3468, 1, 1, 2843, 347, 0, 0, NULL, 0, 0),
 (2847, 11, 0, 'Skinning', 3471, 1, 1, 2844, 346, 0, 0, NULL, 0, 0),

--- a/sql/world/base/zone_undercity.sql
+++ b/sql/world/base/zone_undercity.sql
@@ -99,6 +99,10 @@ UPDATE `item_template` SET `flags` = 2048 WHERE `entry` = 17008;
 UPDATE `item_template` SET `description` = 'To be opened by Lord Varimathras.' WHERE `entry` = 3701;
 
 UPDATE `quest_template`
+SET `QuestCompletionLog` = "Return to Varimathras in the Undercity."
+WHERE `ID` = 5725;
+
+UPDATE `quest_template`
 SET `LogDescription`  = "Bring Ambassador Malcin's Head to Varimathras in the Undercity.",
     `QuestCompletionLog` = "Return to Varimathras at the Royal Quarter in the Undercity."
 WHERE `ID` = 6521;


### PR DESCRIPTION
Related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/182 and https://github.com/ZhengPeiRu21/mod-individual-progression/issues/387

- fixes Undercity guards gossip menu for inscription
- removed Summon Felsteed spell from warlock trainers
- updated quest text for Power to Destroy
- updated attack speed for Iridescent Hammer
- moved Master Pyreanor <Paladin Trainer> a bit