### PR TITLE
Update zone_durotar.sql - Vile Familiars

### DIFF
--- a/sql/world/base/zone_durotar.sql
+++ b/sql/world/base/zone_durotar.sql
@@ -49,6 +49,7 @@ UPDATE `quest_template` SET `Flags`=8 WHERE `ID`=790;
 
 -- Vile Familiars
 UPDATE `quest_template` SET `Flags`=8, `LogDescription`='Kill 12 Vile Familiars.$b$bReturn to Zureetha Fargaze outside the Den.', `RequiredNpcOrGoCount1`=12 WHERE `ID`=792;
+UPDATE `quest_template_addon` SET `AllowableClasses` = 1279 WHERE `ID`=792;
 
 -- Burning Blade Medallion
 UPDATE `quest_template` SET `Flags`=8 WHERE `ID`=794;


### PR DESCRIPTION
Because of the warlock's imp quest 1485, called Vile Familiars, the warlock does not get quest 792, which is also called Vile Familiars.

Can read it in the comments here:
https://www.wowhead.com/classic/quest=792/vile-familiars#comments

The warlock already gets the dagger/staff reward after completing the imp quest.

used this to calculate the correct value for AllowableClasses
https://www.azerothcore.org/wiki/chrclasses