### PR TITLE
Update ipp_aware_npcs.sql - Hide Horde Blasted Lands portals

### DIFF
--- a/sql/world/base/ipp_aware_npcs.sql
+++ b/sql/world/base/ipp_aware_npcs.sql
@@ -25,8 +25,7 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_totc' WHERE `entry`
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_icc' WHERE `entry` IN (37776, 40160, 37780, 32172);
 
 -- Hide the portals to Blasted Lands until TBC is unlocked
-UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_tbc' WHERE `entry` IN (195141);
-UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_tbc' WHERE `entry` IN (195142);
+UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_tbc' WHERE `entry` IN (195141, 195142);
 
 -- Drop source for 2.3 Jewelcrafting Recipe
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc_t4' WHERE `entry` IN (19768, 19227, 23761);

--- a/sql/world/base/ipp_aware_npcs.sql
+++ b/sql/world/base/ipp_aware_npcs.sql
@@ -24,7 +24,9 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_totc' WHERE `entry`
 # TODO: Harold Winston (32172) has rings from all patches, so he needs special phasing applied - for now make him require ICC progression
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_icc' WHERE `entry` IN (37776, 40160, 37780, 32172);
 
+-- Hide the portals to Blasted Lands until TBC is unlocked
 UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_tbc' WHERE `entry` IN (195141);
+UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_tbc' WHERE `entry` IN (195142);
 
 -- Drop source for 2.3 Jewelcrafting Recipe
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc_t4' WHERE `entry` IN (19768, 19227, 23761);


### PR DESCRIPTION
The Blasted Lands portals in the 3 Horde cities were not yet hidden.