### PR TITLE
axes flipped in this zone? (naxx40)

### DIFF
--- a/src/naxx40Scripts/boss_heigan_40.cpp
+++ b/src/naxx40Scripts/boss_heigan_40.cpp
@@ -232,7 +232,7 @@ public:
                 {
                     if (player->IsAlive() && !player->IsGameMaster())
                     {
-                        if (player->GetPositionX() <= 2769.0f)
+                        if (player->GetPositionY() <= -3735.0f)
                         {
                             player->KillSelf();
                         }


### PR DESCRIPTION
The X axis and the Y axis seem to be opposite of what's expected in this zone, causing players halfway through the room to be killed by KillPlayersInTheTunnel() in the Heigan fight.

Modifies the check to use the Y-axis instead.

![x1](https://github.com/user-attachments/assets/ffcc7a3b-f8ff-45f4-be53-b1d4f02cd85d)
![x2](https://github.com/user-attachments/assets/602431ad-d45e-4cf6-abab-4dbdbdc19a73)
![y](https://github.com/user-attachments/assets/0efd5b39-77f7-4d40-88b2-dbadcd6f2052)
