### PR TITLE
fix: vanillaScripts instance buffer overflow

### DIFF
--- a/src/vanillaScripts/instance_blackrock_spire.cpp
+++ b/src/vanillaScripts/instance_blackrock_spire.cpp
@@ -69,7 +69,8 @@ enum Texts
 
 MinionData const minionData[] =
         {
-                { NPC_CHROMATIC_ELITE_GUARD, DATA_GENERAL_DRAKKISATH }
+                { NPC_CHROMATIC_ELITE_GUARD, DATA_GENERAL_DRAKKISATH },
+                { 0, 0 } // END
         };
 
 DoorData const doorData[] =

--- a/src/vanillaScripts/instance_onyxias_lair.cpp
+++ b/src/vanillaScripts/instance_onyxias_lair.cpp
@@ -23,7 +23,8 @@
 ObjectData const creatureData[] =
         {
                 { NPC_ONYXIA, DATA_ONYXIA },
-                { NPC_ONYXIA_40, DATA_ONYXIA }
+                { NPC_ONYXIA_40, DATA_ONYXIA },
+                { 0, 0 } // END
         };
 
 class instance_onyxias_lair_40 : public InstanceMapScript


### PR DESCRIPTION
MinionData const minionData[]  is missing a {0, 0} entry to stop reading 

See `void InstanceScript::LoadMinionData(const MinionData* data)`
- https://github.com/azerothcore/azerothcore-wotlk/blob/fe206c71385aac5e12e13f436baa9273885ca3f2/src/server/game/Instances/InstanceScript.cpp#L166