### PR TITLE
 Add various optional SQL files

### DIFF
--- a/sql/world/base/optional_ipp_aware_aq_war_effort_npcs.sql
+++ b/sql/world/base/optional_ipp_aware_aq_war_effort_npcs.sql
@@ -1,9 +1,9 @@
--- This SQL query makes specific NPCs visible related to the AQ War Effort event
--- See: https://github.com/azerothcore/mod-war-effort
+-- Makes related AQ War Effort NPCs visible at progression stage 4
+-- See this GitHub repository for an AzerothCore AQ War Effort event module: https://github.com/azerothcore/mod-war-effort
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_aq' WHERE `entry` IN (15383, 15431, 15432, 15434, 15437, 15445, 15446, 
                                                                              15448, 15450, 15451, 15452, 15453, 15455, 15456, 
-                                                                             15457, 15700, 15459, 15460, 15469, 15477, 15508, 
-                                                                             15512, 15515, 15522, 15525, 15528, 15529, 15532, 
-                                                                             15533, 15534, 15535, 21968, 15738, 15737, 15739, 
-                                                                             15736, 15731, 15733, 15735, 15734, 21969, 
+                                                                             15457, 15700, 15701, 15459, 15460, 15469, 15477, 
+                                                                             15508, 15512, 15515, 15522, 15525, 15528, 15529, 
+                                                                             15532, 15533, 15534, 15535, 21968, 15738, 15737, 
+                                                                             15739, 15736, 15731, 15733, 15735, 15734, 21969, 
                                                                              15810, 15813, 15742, 15741, 15740, 15758, 15818);

--- a/sql/world/base/optional_ipp_aware_aq_war_effort_npcs.sql
+++ b/sql/world/base/optional_ipp_aware_aq_war_effort_npcs.sql
@@ -1,0 +1,9 @@
+-- This SQL query makes specific NPCs visible related to the AQ War Effort event
+-- See: https://github.com/azerothcore/mod-war-effort
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_aq' WHERE `entry` IN (15383, 15431, 15432, 15434, 15437, 15445, 15446, 
+                                                                             15448, 15450, 15451, 15452, 15453, 15455, 15456, 
+                                                                             15457, 15700, 15459, 15460, 15469, 15477, 15508, 
+                                                                             15512, 15515, 15522, 15525, 15528, 15529, 15532, 
+                                                                             15533, 15534, 15535, 21968, 15738, 15737, 15739, 
+                                                                             15736, 15731, 15733, 15735, 15734, 21969, 
+                                                                             15810, 15813, 15742, 15741, 15740, 15758, 15818);

--- a/sql/world/base/optional_tbc_hero_keys_rep_nerf.sql
+++ b/sql/world/base/optional_tbc_hero_keys_rep_nerf.sql
@@ -1,0 +1,9 @@
+/* Optional change. Obtaining keys for heroic dungeons in The Burning Crusade is conditional on having corresponding reputation at Revered rank.
+   This reduces the reputation requirements to obtain keys to Honored and thus allows you to go to heroic dungeons more quickly. 
+   This allows players to catch up fairly advanced server progression more easily. */
+UPDATE `item_template` SET `RequiredReputationRank` = 5 WHERE (`entry` = 30622);
+UPDATE `item_template` SET `RequiredReputationRank` = 5 WHERE (`entry` = 30637);
+UPDATE `item_template` SET `RequiredReputationRank` = 5 WHERE (`entry` = 30633);
+UPDATE `item_template` SET `RequiredReputationRank` = 5 WHERE (`entry` = 30634);
+UPDATE `item_template` SET `RequiredReputationRank` = 5 WHERE (`entry` = 30623);
+UPDATE `item_template` SET `RequiredReputationRank` = 5 WHERE (`entry` = 30635);

--- a/sql/world/base/optional_tbc_hero_keys_rep_super_nerf.sql
+++ b/sql/world/base/optional_tbc_hero_keys_rep_super_nerf.sql
@@ -1,0 +1,9 @@
+/* Optional change. Obtaining keys for heroic dungeons in The Burning Crusade is conditional on having corresponding reputation at Revered rank.
+   This reduces the reputation requirements to obtain keys to Friendly and thus allows you to go to heroic dungeons more quickly. 
+   This allows players to catch up fairly advanced server progression more easily. */
+UPDATE `item_template` SET `RequiredReputationRank` = 4 WHERE (`entry` = 30622);
+UPDATE `item_template` SET `RequiredReputationRank` = 4 WHERE (`entry` = 30637);
+UPDATE `item_template` SET `RequiredReputationRank` = 4 WHERE (`entry` = 30633);
+UPDATE `item_template` SET `RequiredReputationRank` = 4 WHERE (`entry` = 30634);
+UPDATE `item_template` SET `RequiredReputationRank` = 4 WHERE (`entry` = 30623);
+UPDATE `item_template` SET `RequiredReputationRank` = 4 WHERE (`entry` = 30635);

--- a/sql/world/base/optional_vanilla_aware_war_effort_npcs.sql
+++ b/sql/world/base/optional_vanilla_aware_war_effort_npcs.sql
@@ -1,5 +1,5 @@
--- Makes related AQ War Effort NPCs visible at progression stage 4
--- See this GitHub repository for an AzerothCore AQ War Effort event module: https://github.com/azerothcore/mod-war-effort
+/* Makes related AQ War Effort NPCs visible at progression stage 4 (pre aq stage)
+See this GitHub repository for an AzerothCore AQ War Effort event module: https://github.com/azerothcore/mod-war-effort */
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_aq' WHERE `entry` IN (15383, 15431, 15432, 15434, 15437, 15445, 15446, 
                                                                              15448, 15450, 15451, 15452, 15453, 15455, 15456, 
                                                                              15457, 15700, 15701, 15459, 15460, 15469, 15477, 

--- a/sql/world/base/zz_optional_aq_quest_super_nerf.sql
+++ b/sql/world/base/zz_optional_aq_quest_super_nerf.sql
@@ -1,0 +1,39 @@
+/* Optional but suggested change. The AQ quests originally was designed for a large group of players to farm items given to a chosen player to turn in.
+   This reduces the quest requirements to be more reasonably completable by a solo player or small group.
+   Be sure to run AFTER vanilla_quest_reputations.sql.
+   Increases the Rep for The Hand of the Righteous, so only about 1 turn-in is necessary instead of 200. */
+UPDATE quest_template SET RewardFactionOverride1=4220000, RewardFactionOverride2=0,RewardFactionOverride3=0,RewardFactionOverride4=0,RewardFactionOverride5=0 WHERE ID=8301;
+UPDATE quest_template SET RewardFactionOverride1=4220000, RewardFactionOverride2=0,RewardFactionOverride3=0,RewardFactionOverride4=0,RewardFactionOverride5=0 WHERE ID=8302;
+
+/* Revert drop rate for Nightmare_corruption to nerfed WotLK drop rate */
+UPDATE `creature_loot_template` SET `Chance` = 100 WHERE `Item` = 21146;
+UPDATE `creature_loot_template` SET `Chance` = 100 WHERE `Item` = 21147;
+UPDATE `creature_loot_template` SET `Chance` = 100 WHERE `Item` = 21148;
+
+/* Revert Narain's Scrying Goggles to nerfed WotLK drop rate */
+DELETE FROM `creature_loot_template` WHERE `Item` = 20951;
+INSERT INTO `creature_loot_template` (`Chance`, `Comment`, `Entry`, `GroupId`, `Item`, `LootMode`, `MaxCount`, `MinCount`, `QuestRequired`, `Reference`) VALUES
+(1, NULL, 11502, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Molten Giant - Narain\'s Scrying Goggles', 11658, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Molten Destroyer - Narain\'s Scrying Goggles', 11659, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Flamewaker - Narain\'s Scrying Goggles', 11661, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Flamewaker Priest - Narain\'s Scrying Goggles', 11662, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Flamewaker Healer - Narain\'s Scrying Goggles', 11663, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Flamewaker Elite - Narain\'s Scrying Goggles', 11664, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Lava Annihilator - Narain\'s Scrying Goggles', 11665, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Firewalker - Narain\'s Scrying Goggles', 11666, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Flameguard - Narain\'s Scrying Goggles', 11667, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Firelord - Narain\'s Scrying Goggles', 11668, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Ancient Core Hound - Narain\'s Scrying Goggles', 11673, 0, 20951, 1, 1, 1, 1, 0),
+(1, NULL, 11982, 0, 20951, 1, 1, 1, 1, 0),
+(1, NULL, 11988, 0, 20951, 1, 1, 1, 1, 0),
+(1, NULL, 12056, 0, 20951, 1, 1, 1, 1, 0),
+(1, NULL, 12057, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Lava Elemental - Narain\'s Scrying Goggles', 12076, 0, 20951, 1, 1, 1, 1, 0),
+(1, NULL, 12098, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Lava Reaver - Narain\'s Scrying Goggles', 12100, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Lava Surger - Narain\'s Scrying Goggles', 12101, 0, 20951, 1, 1, 1, 1, 0),
+(1, NULL, 12118, 0, 20951, 1, 1, 1, 1, 0),
+(100, 'Flamewaker Protector - Narain\'s Scrying Goggles', 12119, 0, 20951, 1, 1, 1, 1, 0),
+(1, NULL, 12259, 0, 20951, 1, 1, 1, 1, 0),
+(1, NULL, 12264, 0, 20951, 1, 1, 1, 1, 0);


### PR DESCRIPTION
- In addition to the optional nerf sql file for the quest for the aq gong (vanilla), adds a "super nerf" variant (1 turn in instead of 5)
- Add an optional sql file for war effort npcs visibility during the pre aq phase
- Add an optional nerf sql file for tbc hero dungeon keys (catch up if the progress of your server is very advanced)
- In addition, add a "super nerf" variant for tbc hero dungeon keys