### PR TITLE
Optional ammo stack size

### DIFF
--- a/sql/world/base/vanilla_item_changes.sql
+++ b/sql/world/base/vanilla_item_changes.sql
@@ -10,10 +10,6 @@ ALTER TABLE item_template MODIFY arcane_res SMALLINT;
 UPDATE item_template SET RequiredReputationFaction=529, RequiredReputationRank=6 WHERE entry IN (18169, 18170, 18171, 18172, 18173);
 UPDATE item_template SET RequiredReputationFaction=529, RequiredReputationRank=7 WHERE entry=18182;
 
--- In 3.1 all ammo was changed to stack to 1000. This reduced the usefulness of quivers and ammo pouches
-UPDATE `item_template` SET `stackable` = 200 WHERE `stackable` = 1000 AND `InventoryType` = 24;
-UPDATE `item_template` SET `stackable` = 1000 WHERE `entry` IN (41164, 41165, 41584, 41586, 52020, 52021); -- WotLK ammo
-
 -- Restore quiver functionality
 UPDATE `item_template` SET `spellid_1` = 29418 WHERE `entry` IN (2101, 3573, 5439, 7278, 11362); 
 UPDATE `item_template` SET `spellid_1` = 14824 WHERE `entry` IN (2102, 3574, 5441, 7279, 11363);

--- a/sql/world/base/zz_optional_ammo_stack_size.sql
+++ b/sql/world/base/zz_optional_ammo_stack_size.sql
@@ -1,0 +1,7 @@
+/*
+    In 3.1 all ammo was changed to stack to 1000. This reduced the usefulness of quivers and ammo pouches
+    This SQL will restore Vanilla and TBC ammo stack sizes to 200.
+*/
+
+UPDATE `item_template` SET `stackable` = 200 WHERE `stackable` = 1000 AND `InventoryType` = 24;
+UPDATE `item_template` SET `stackable` = 1000 WHERE `entry` IN (41164, 41165, 41584, 41586, 52020, 52021); -- WotLK ammo


### PR DESCRIPTION
I've been asked to separate the ammo stack size change into an optional file.

I understand that not everyone will want the ammo stack size change
I thought about adding the update to optional_item_stack_sizes, 
but personally I do want the ammo stack size change, but not the rest, so I rather do it separately.