### PR TITLE
Kobold Workers and Laborers in Elwynn should not be hostile

### DIFF
--- a/sql/world/base/vanilla_mob_factions.sql
+++ b/sql/world/base/vanilla_mob_factions.sql
@@ -61,12 +61,6 @@ UPDATE `creature_template` SET `faction` = 14 WHERE `entry` = 3229;
 /*  Chief Sharptusk Thornmantle  */
 UPDATE `creature_template` SET `faction` = 14 WHERE `entry` = 8554;
 
-/*  Kobold Laborer  */
-UPDATE `creature_template` SET `faction` = 26, flags_extra = 0 WHERE `entry` = 257;
-
-/*  Kobold Worker  */
-UPDATE `creature_template` SET `faction` = 26, flags_extra = 0 WHERE `entry` = 80;
-
 /*  Tender  */
 UPDATE `creature_template` SET `faction` = 16 WHERE `entry` = 15271;
 


### PR DESCRIPTION
The Kobold Workers and Kobold Laborers in Northshire in Elwynn Forest should not be hostile towards the player.
There is no need to change the faction and flags of these two mobs, as their default values in the DB are already correct.