### PR TITLE
Fix pvp vendors

### DIFF
--- a/sql/world/base/vanilla_creature_values.sql
+++ b/sql/world/base/vanilla_creature_values.sql
@@ -20135,7 +20135,7 @@ UPDATE `creature_template` SET `ArmorModifier` = 0.85 WHERE `entry`=14567;
 UPDATE `creature_template` SET `DamageModifier` = 2.2, `ArmorModifier` = 1.1, `RangeAttackTime` = 1551 WHERE `entry`=14568;
 
 /*  Sergeant Thunderhorn  */
-UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `speed_walk` = 1.0, `DamageModifier` = 3.45 WHERE `entry`=14581;
+UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `speed_walk` = 1.0, `DamageModifier` = 3.45 WHERE `entry`= 26396;
 
 /*  Ebonroc  */
 UPDATE `creature_template` SET `mingold` = 1202590, `maxgold` = 1212590 WHERE `entry`=14601;

--- a/sql/world/base/vanilla_creatures.sql
+++ b/sql/world/base/vanilla_creatures.sql
@@ -18335,7 +18335,7 @@ UPDATE `creature_template` SET `speed_run` = 1.14286, `DamageModifier` = 1.15 WH
 UPDATE `creature_template` SET `subname` = 'Demon Trainer', `DamageModifier` = 0.8, `RangeAttackTime` = 2112 WHERE `entry`=12776;
 
 /*  Captain Dirgehammer  */
-UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `DamageModifier` = 2.2, `ArmorModifier` = 1.65 WHERE `entry`=12777;
+UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `DamageModifier` = 2.2, `ArmorModifier` = 1.65 WHERE `entry` = 26393;
 
 /*  Lieutenant Rachel Vaccar  */
 UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `DamageModifier` = 1.05, `ArmorModifier` = 2.6 WHERE `entry`=12778;
@@ -18350,13 +18350,13 @@ UPDATE `creature_template` SET `DamageModifier` = 1.05, `ArmorModifier` = 2.6 WH
 UPDATE `creature_template` SET `subname` = 'Officer Accessories Quartermaster', `DamageModifier` = 1.05, `ArmorModifier` = 2.6 WHERE `entry`=12781;
 
 /*  Captain O'Neal  */
-UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `DamageModifier` = 3.45, `ArmorModifier` = 1.4 WHERE `entry`=12782;
+UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `DamageModifier` = 3.45, `ArmorModifier` = 1.4 WHERE `entry` = 26394;
 
 /*  Lieutenant Karter  */
 UPDATE `creature_template` SET `subname` = 'Mount Vendor', `DamageModifier` = 1.05, `ArmorModifier` = 2.6 WHERE `entry`=12783;
 
 /*  Sergeant Major Clate  */
-UPDATE `creature_template` SET `subname` = 'Food and Drink', `DamageModifier` = 2.15, `ArmorModifier` = 2.6 WHERE `entry`=12785;
+UPDATE `creature_template` SET `DamageModifier` = 2.15, `ArmorModifier` = 2.6 WHERE `entry` = 12785;
 
 /*  Guard Quine  */
 UPDATE `creature_template` SET `DamageModifier` = 3.05, `ArmorModifier` = 1.15 WHERE `entry`=12786;

--- a/sql/world/base/vanilla_creatures.sql
+++ b/sql/world/base/vanilla_creatures.sql
@@ -18377,6 +18377,7 @@ UPDATE `creature_template` SET `DamageModifier` = 1.6, `ArmorModifier` = 1.15, `
 UPDATE `creature_template` SET `DamageModifier` = 1.6, `ArmorModifier` = 1.15, `ManaModifier` = 1.0, `RangeAttackTime` = 1529, `unit_class` = 1 WHERE `entry`=12791;
 
 /*  Lady Palanseer  */
+UPDATE `creature_template` SET `minlevel` = 65, `maxlevel` = 65, `speed_walk` = 1.0, `DamageModifier` = 2.2, `ArmorModifier` = 1.65 WHERE `entry`= 12792;
 UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `speed_walk` = 1.0, `DamageModifier` = 2.2, `ArmorModifier` = 1.65 WHERE `entry`= 26397;
 
 /*  Brave Stonehide  */
@@ -20135,6 +20136,7 @@ UPDATE `creature_template` SET `ArmorModifier` = 0.85 WHERE `entry`=14567;
 UPDATE `creature_template` SET `DamageModifier` = 2.2, `ArmorModifier` = 1.1, `RangeAttackTime` = 1551 WHERE `entry`=14568;
 
 /*  Sergeant Thunderhorn  */
+UPDATE `creature_template` SET `minlevel` = 65, `maxlevel` = 65, `speed_walk` = 1.0, `DamageModifier` = 3.45 WHERE `entry`= 14581;
 UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `speed_walk` = 1.0, `DamageModifier` = 3.45 WHERE `entry`= 26396;
 
 /*  Ebonroc  */

--- a/sql/world/base/vanilla_creatures.sql
+++ b/sql/world/base/vanilla_creatures.sql
@@ -18377,7 +18377,7 @@ UPDATE `creature_template` SET `DamageModifier` = 1.6, `ArmorModifier` = 1.15, `
 UPDATE `creature_template` SET `DamageModifier` = 1.6, `ArmorModifier` = 1.15, `ManaModifier` = 1.0, `RangeAttackTime` = 1529, `unit_class` = 1 WHERE `entry`=12791;
 
 /*  Lady Palanseer  */
-UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `speed_walk` = 1.0, `DamageModifier` = 2.2, `ArmorModifier` = 1.65 WHERE `entry`=12792;
+UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `speed_walk` = 1.0, `DamageModifier` = 2.2, `ArmorModifier` = 1.65 WHERE `entry`= 26397;
 
 /*  Brave Stonehide  */
 UPDATE `creature_template` SET `subname` = 'Officer Accessories Quartermaster', `DamageModifier` = 2.9 WHERE `entry`=12793;

--- a/sql/world/base/vanilla_creatures.sql
+++ b/sql/world/base/vanilla_creatures.sql
@@ -18381,13 +18381,13 @@ UPDATE `creature_template` SET `minlevel` = 65, `maxlevel` = 65, `speed_walk` = 
 UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55, `speed_walk` = 1.0, `DamageModifier` = 2.2, `ArmorModifier` = 1.65 WHERE `entry`= 26397;
 
 /*  Brave Stonehide  */
-UPDATE `creature_template` SET `subname` = 'Officer Accessories Quartermaster', `DamageModifier` = 2.9 WHERE `entry`=12793;
+UPDATE `creature_template` SET `DamageModifier` = 2.9 WHERE `entry` = 12793;
 
 /*  Stone Guard Zarg  */
-UPDATE `creature_template` SET `subname` = 'Food and Drink', `DamageModifier` = 1.05, `RangeAttackTime` = 1606 WHERE `entry`=12794;
+UPDATE `creature_template` SET `DamageModifier` = 1.05, `RangeAttackTime` = 1606 WHERE `entry` = 12794;
 
 /*  First Sergeant Hola'mahi  */
-UPDATE `creature_template` SET `subname` = 'Reagent Vendor', `DamageModifier` = 1.2, `RangeAttackTime` = 1551 WHERE `entry`=12795;
+UPDATE `creature_template` SET `DamageModifier` = 1.2, `RangeAttackTime` = 1551 WHERE `entry` = 12795;
 
 /*  Raider Bork  */
 UPDATE `creature_template` SET `subname` = 'Mount Quartermaster', `speed_run` = 1.14286, `DamageModifier` = 1.05, `RangeAttackTime` = 1606 WHERE `entry`=12796;

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -457,7 +457,7 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (@T
 UPDATE `creature_template_addon` SET `mount` = 0 WHERE `entry` = 12796;
 
 
-DELETE FROM `creature` WHERE `guid` IN (125688, 125690, 125695, 612792, 612793, 612794, 612795, 612796, 614581, 620278, 623396, 626396, 626397);
+DELETE FROM `creature` WHERE `guid` IN (125688, 125690, 125695, 612792, 612793, 612794, 612795, 612796, 614581, 620278, 623396, 623447, 626396, 626397);
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 
 (626397, @LP_Classic, 1, 1669.78, -4200.1, 56.3815, 3.61023, 180),  -- Lady Palanseer <Armor Quartermaster>, Vanilla

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -205,26 +205,10 @@ DELETE FROM `creature` WHERE `id1` = 12788;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 (612788, 12788, 1, 1650.95, -4212.82, 55.439, 0.182965, 25);
 
--- Lady Palanseer <Armor Quartermaster>
-DELETE FROM `creature` WHERE `id1` = 34043;
-DELETE FROM `creature` WHERE `id1` = 12792;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
-(612792, 12792, 1, 1669.78, -4200.1, 56.3815, 3.61023, 180);
-
--- Brave Stonehide <Officer Accessories Quartermaster>
-DELETE FROM `creature` WHERE `id1` = 12793;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
-(612793, 12793, 1, 1657.6, -4191.97, 56.383, 4.52365, 180);
-
 -- Stone Guard Zarg <Food and Drink>
 DELETE FROM `creature` WHERE `id1` = 12794;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 (612794, 12794, 1, 1641.65, -4197.52, 56.3823, 5.41219, 180);
-
--- Raider Bork <Mount Quartermaster>
-DELETE FROM `creature` WHERE `id1` = 12796;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
-(612796, 12796, 1, 1674.43, -4212.55, 56.3829, 3.00254, 1290);
 
 -- Sergeant Ba'sha <Accessories Quartermaster>
 DELETE FROM `creature` WHERE `id1` = 12799;
@@ -318,17 +302,8 @@ UPDATE `creature_template` SET `subname`='Zeppelin Master' WHERE `entry`=12136;
 -- Legionnaire Teena
 UPDATE `creature_template` SET `subname`=NULL, `npcflag`=0, `faction`=85 WHERE `entry`=12788;
 
--- Lady Palanseer <Armor Quartermaster>
-UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12792;
-
--- Brave Stonehide <Officer Accessories Quartermaster>
-UPDATE `creature_template` SET `subname`='Officer Accessories Quartermaster' WHERE `entry`=12793;
-
 -- Stone Guard Zarg <Food and Drink>
 UPDATE `creature_template` SET `subname`='Food and Drink' WHERE `entry`=12794;
-
--- Raider Bork <Mount Quartermaster>
-UPDATE `creature_template` SET `subname`='Mount Quartermaster' WHERE `entry`=12796;
 
 -- Kor'kron Elite
 UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60, `rank`=0 WHERE `entry`=14304;
@@ -347,9 +322,6 @@ UPDATE `creature_template` SET `minlevel`=62, `maxlevel`=62 WHERE `entry`=14720;
 
 -- Horde Warbringer
 UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60, `rank`=0 WHERE `entry`=15350;
-
--- Raider Bork <Mount Quartermaster>
-UPDATE `creature_template_addon` SET `mount`=0 WHERE `entry`=12796;
 
 -- Olvia <Meat Vendor>
 DELETE FROM `npc_vendor` WHERE `entry`=3312 AND `item` IN (27854, 33454, 35953);
@@ -429,35 +401,6 @@ DELETE FROM `npc_vendor` WHERE `entry`=6929 AND `item` IN (27854, 28399, 33444, 
 -- Legionnaire Teena
 DELETE FROM `npc_vendor` WHERE `entry`=12788;
 
--- Lady Palanseer <Armor Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12792 AND `item` IN 
-    (16533, 16534, 16535, 16536, 16539, 16540, 16541, 16542, 16543, 16544, 16545, 16548, 16549, 16550, 16551, 16552, 16554, 16555, 16558, 
-    16560, 16561, 16562, 16563, 16564, 16565, 16566, 16567, 16568, 16569, 16571, 16573, 16574, 16577, 16578, 16579, 16580, 17586, 17588, 
-    17590, 17591, 17592, 17593, 17618, 17620, 17622, 17623, 17624, 17625, 22843, 22852, 22855, 22856, 22857, 22858, 22859, 
-    22860, 22862, 22863, 22864, 22865, 22867, 22868, 22869, 22870, 22872, 22873, 22874, 22875, 22876, 22877, 22878, 22879, 
-    22880, 22881, 22882, 22883, 22884, 22885, 22886, 22887, 23243, 23244, 23251, 23252, 23253, 23254, 23255, 23256, 23257, 23258, 23259, 23260, 23261, 23262, 23263, 23264);
-
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
-    (12792, 16533, 464), (12792, 16534, 542), (12792, 16535, 463), (12792, 16536, 465), (12792, 16539, 465), (12792, 16540, 541), (12792, 16541, 463), (12792, 16542, 464), (12792, 16543, 542),
-    (12792, 16544, 465), (12792, 16545, 465), (12792, 16548, 541), (12792, 16549, 463), (12792, 16550, 464), (12792, 16551, 465), (12792, 16552, 542), (12792, 16554, 465), (12792, 16555, 541),
-    (12792, 16558, 465), (12792, 16560, 541), (12792, 16561, 464), (12792, 16562, 465), (12792, 16563, 463), (12792, 16564, 542), (12792, 16565, 463), (12792, 16566, 464), (12792, 16567, 542),
-    (12792, 16568, 465), (12792, 16569, 465), (12792, 16571, 541), (12792, 16573, 465), (12792, 16574, 541), (12792, 16577, 463), (12792, 16578, 464), (12792, 16579, 542), (12792, 16580, 465),    
-    (12792, 17586, 465), (12792, 17588, 541), (12792, 17590, 465), (12792, 17591, 464), (12792, 17592, 463), (12792, 17593, 542), (12792, 17618, 465), (12792, 17620, 541), (12792, 17622, 465),
-    (12792, 17623, 464), (12792, 17624, 463), (12792, 17625, 542), (12792, 22843, 427), (12792, 22852, 427), (12792, 22855, 427), (12792, 22856, 427), (12792, 22857, 427), (12792, 22858, 427),
-    (12792, 22859, 427), (12792, 22860, 427), (12792, 22862, 428), (12792, 22863, 428), (12792, 22864, 428), (12792, 22865, 428), (12792, 22867, 428), (12792, 22868, 428), (12792, 22869, 428),
-    (12792, 22870, 428), (12792, 22872, 652), (12792, 22873, 653), (12792, 22874, 652), (12792, 22875, 653), (12792, 22876, 652), (12792, 22877, 652), (12792, 22878, 653), (12792, 22879, 652),
-    (12792, 22880, 653), (12792, 22881, 653), (12792, 22882, 653), (12792, 22883, 653), (12792, 22884, 652), (12792, 22885, 652), (12792, 22886, 652), (12792, 22887, 653), (12792, 23243, 427),
-    (12792, 23244, 444), (12792, 23251, 444), (12792, 23252, 427), (12792, 23253, 444), (12792, 23254, 427), (12792, 23255, 444), (12792, 23256, 427), (12792, 23257, 444), (12792, 23258, 427),
-    (12792, 23259, 444), (12792, 23260, 427), (12792, 23261, 444), (12792, 23262, 427), (12792, 23263, 444), (12792, 23264, 427);
-
--- Brave Stonehide <Officer Accessories Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12793 AND `item` IN (15197, 15200, 16335, 16341, 16486, 16497, 16532, 18427, 18428, 18429, 18430, 18432, 18434, 18435, 18436, 18437, 18461, 18834, 18845, 18846, 18849, 18850, 18851, 18852, 18853, 24551, 28118, 28119, 28120, 28123, 28239, 28240, 28241, 28242, 28243, 28246, 28247, 28362, 28363, 28377, 28378, 29592, 30343, 30344, 30345, 30346, 31838, 31839, 31840, 31841, 31852, 31853, 31854, 31855, 32453, 32455, 37865, 38588, 44957);
-
-DELETE FROM `npc_vendor` WHERE `entry`=12795 AND `item` IN (5565, 16583, 17020, 17021, 17026, 17028, 17029, 17030, 17031, 17032, 17033, 17034, 17035, 17036, 17037, 17038);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
-    (12795, 5565), (12795, 16583), (12795, 17020), (12795, 17021), (12795, 17026), (12795, 17028), (12795, 17029), (12795, 17030),
-    (12795, 17031), (12795, 17032), (12795, 17033), (12795, 17034), (12795, 17035), (12795, 17036), (12795, 17037), (12795, 17038);
-
 -- Stone Guard Zarg <Food and Drink>
 DELETE FROM `npc_vendor` WHERE `entry`=12794 AND `item` IN 
     (16345, 18826, 18828, 18831, 18835, 18837, 18840, 18844, 18848, 18860, 18866, 18868, 18871, 18874, 18877, 23464, 23465, 23466, 23467, 23468, 23469);
@@ -469,17 +412,23 @@ INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
     (12794, 3770), (12794, 3771), (12794, 4536), (12794, 4537), (12794, 4538), (12794, 4539), (12794, 4540), (12794, 4541), (12794, 4542), (12794, 4544), (12794, 4599), (12794, 4601),
     (12794, 4602), (12794, 4604), (12794, 4605), (12794, 4606), (12794, 4607), (12794, 4608), (12794, 8766), (12794, 8948), (12794, 8950), (12794, 8952), (12794, 8953);
 
--- Raider Bork <Mount Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12796 AND `item` IN (29466, 29469, 29470, 29472, 34129);
-DELETE FROM `npc_vendor` WHERE `entry`=12796 AND `item` IN (18245, 18246, 18247, 18248);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12796, 18245, 423), (12796, 18246, 423), (12796, 18247, 423), (12796, 18248, 423);
 
 
 
 
-SET @Hola       := 112795; -- First Sergeant Hola'mahi, Vanilla version
-SET @TH_Classic := 26396;  -- Sergeant Thunderhorn, Vanilla version
-SET @TH_TBC     := 14581;  -- Sergeant Thunderhorn, TBC version
+
+
+
+
+
+
+
+SET @Stonehide  := 112793; -- Brave Stonehide <Officer Accessories Quartermaster>, Vanilla
+SET @Hola       := 112795; -- First Sergeant Hola'mahi, Vanilla
+SET @TH_Classic := 26396;  -- Sergeant Thunderhorn, Vanilla
+SET @TH_TBC     := 14581;  -- Sergeant Thunderhorn, TBC
+SET @LP_Classic := 26397;  -- Lady Palanseer <Armor Quartermaster>, Vanilla
+SET @LP_TBC     := 12792;  -- Lady Palanseer <Armor Quartermaster>, TBC
 
 
 DELETE FROM `creature_template` WHERE `entry` = @Hola;
@@ -489,15 +438,21 @@ INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entr
 `lootid`, `pickpocketloot`, `skinloot`, `PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`, `AIName`, `MovementType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `ExperienceModifier`, 
 `RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `spell_school_immune_mask`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES 
 
+(@Stonehide, 0, 0, 0, 0, 0, 'Brave Stonehide', 'Officer Accessories Quartermaster', NULL, 0, 55, 55, 0, 125, 128, 1, 1.14286, 1, 1, 18, 1, 0, 0, 2.9, 2000, 2000, 1, 1, 1, 256, 2048, 0, 0, 0, 0, 0, 0, 7, 4096, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 2, 1, 1, 1, 0, 0, 1, 0, 0, 0, 'npc_ipp_pre_tbc', 12340),
 (@Hola, 0, 0, 0, 0, 0, 'First Sergeant Hola\'mahi', 'Reagent Vendor', NULL, 0, 55, 55, 0, 125, 130, 1, 1.14286, 1, 1, 18, 1, 0, 0, 1.2, 2000, 1551, 1, 1, 1, 768, 2048, 0, 0, 0, 0, 0, 0, 7, 4096, 0, 0, 0, 0, 0, 0, 0, '', 1, 1, 2, 1, 1, 1, 0, 0, 1, 0, 0, 0, 'npc_ipp_pre_tbc', 12340);
 
-
-UPDATE `creature_template` SET `subname` = 'Armor Quartermaster', `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = 12795;     
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_pre_tbc' WHERE `entry` = @TH_Classic;
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = @TH_TBC;
-
 DELETE FROM `creature_template_locale` WHERE `entry` = @Hola;
-INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES 
+INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES
+--
+(@Stonehide, 'deDE', 'Kriegerheldin Steinfell', 'Rüstmeisterin für Zubehör', 18019),
+(@Stonehide, 'esES', 'Valiente Piel Pétrea', 'Intendente de accesorios', 18019),
+(@Stonehide, 'esMX', 'Valiente Piel Pétrea', 'Intendente de accesorios', 18019),
+(@Stonehide, 'frFR', 'Brave Cuir-de-Pierre', 'Intendante des accessoires', 18019),
+(@Stonehide, 'koKR', '용사 스톤하이드', '보급품 병참장교', 18019),
+(@Stonehide, 'ruRU', 'Храбрец Каменная Шкура', 'Начальник снабжения аксессуарами', 18019),
+(@Stonehide, 'zhCN', '卫兵布莱恩·石皮', '杂货军需官', 18019),
+(@Stonehide, 'zhTW', '勇者石皮', '雜貨軍需官', 18019),
+--
 (@Hola, 'deDE', 'Stabsfeldwebel Hola\'mahi', 'Reagent Vendor', 18019),
 (@Hola, 'esES', 'Gran capataz Hola\'mahi', 'Reagent Vendor', 18019),
 (@Hola, 'esMX', 'Gran capataz Hola\'mahi', 'Reagent Vendor', 18019),
@@ -509,14 +464,44 @@ INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `Ver
 
 DELETE FROM `creature_template_model` WHERE `CreatureID` = @Hola;
 INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES 
+(@Stonehide, 0, 12675, 1, 1, 12340),
 (@Hola, 0, 12677, 1, 1, 12340);
 
 
-DELETE FROM `creature` WHERE `guid` IN (612795, 614581, 626396);
+UPDATE `creature_template` SET `subname` = 'Officer Accessories Quartermaster', `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = 12793;
+UPDATE `creature_template` SET `subname` = 'Armor Quartermaster', `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = 12795;
+UPDATE `creature_template` SET `subname` = 'Mount Quartermaster' WHERE `entry` = 12796;
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (20278, 23396);
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_pre_tbc' WHERE `entry` IN (@TH_Classic, @LP_Classic);
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (@TH_TBC, @LP_TBC);
+
+    
+UPDATE `creature_template_addon` SET `mount` = 0 WHERE `entry` = 12796;
+
+
+
+DELETE FROM `creature` WHERE `guid` IN (125690, 125695, 612792, 612793, 612795, 612796, 614581, 620278, 623396, 626396, 626397);
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
-(612795, @Hola, 1, 1673.9, -4216, 56.3826, 2.93578, 180),
-(614581, @TH_TBC, 1, 1669.09, -4196.78, 56.4831, 4.10416, 180),
-(626396, @TH_Classic, 1, 1644.52, -4195.26, 56.3826, 5.43078, 180);
+
+(626397, @LP_Classic, 1, 1669.78, -4200.1, 56.3815, 3.61023, 180),  -- Lady Palanseer <Armor Quartermaster>, Vanilla
+(612792, @LP_TBC, 1, 1674.48, -4211.93, 56.4831, 3.03786, 180),     -- Lady Palanseer <Armor Quartermaster>, TBC
+(612793, @Stonehide, 1, 1657.6, -4191.97, 56.383, 4.52365, 180),    -- Brave Stonehide <Officer Accessories Quartermaster>, Vanilla
+(125690, 12793, 1, 1672.24, -4206.81, 56.3827, 3.30568, 180),       -- Brave Stonehide <Officer Accessories Quartermaster>, TBC
+(612795, @Hola, 1, 1673.9, -4216, 56.3826, 2.93578, 180),           -- First Sergeant Hola'mahi <Armor Quartermaster>, Vanilla
+(125695, 12795, 1, 1673.9, -4216, 56.3826, 2.93578, 180),           -- First Sergeant Hola'mahi <Armor Quartermaster>, TBC
+(626396, @TH_Classic, 1, 1644.52, -4195.26, 56.3826, 5.43078, 180), -- Sergeant Thunderhorn <Weapons Quartermaster>, Vanilla
+(614581, @TH_TBC, 1, 1669.09, -4196.78, 56.4831, 4.10416, 180),     -- Sergeant Thunderhorn <Weapons Quartermaster>, TBC
+(612796, 12796, 1, 1674.43, -4212.55, 56.3829, 3.00254, 180),       -- Raider Bork <Mount Quartermaster>
+(620278, 20278, 1, 1654.25, -4189.82, 56.3825, 4.71787, 180),       -- Vixton Pinchwhistle <Arena Vendor>
+(623396, 23396, 1, 1660.37, -4190.74, 56.3817, 4.54116, 180);       -- Krixel Pinchwhistle <Arena Vendor>
+
+
+
+
+-- Raider Bork <Mount Quartermaster>
+DELETE FROM `npc_vendor` WHERE `entry`= 12796;
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
+(12796, 18245, 423), (12796, 18246, 423), (12796, 18247, 423), (12796, 18248, 423);
     
 -- First Sergeant Hola'mahi <Reagent Vendor> - vanilla
 DELETE FROM `npc_vendor` WHERE `entry` = @Hola; 
@@ -544,6 +529,76 @@ INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `Exte
 (12795,0,29602,0,0,652,0), (12795,0,29603,0,0,653,0), (12795,0,29604,0,0,444,0), (12795,0,29605,0,0,427,0), (12795,0,29612,0,0,465,0), (12795,0,29613,0,0,541,0), (12795,0,29614,0,0,542,0), 
 (12795,0,29615,0,0,463,0), (12795,0,29616,0,0,464,0), (12795,0,29617,0,0,465,0);
 
+-- Brave Stonehide <Officer Accessories Quartermaster> - Vanilla
+DELETE FROM `npc_vendor` WHERE `entry` = @Stonehide;
+INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES
+(@Stonehide, 0, 15199, 0, 0, 1006, 0), (@Stonehide, 0, 18607, 0, 0, 386, 0), (@Stonehide, 0, 18839, 0, 0, 2354, 0), (@Stonehide, 0, 18841, 0, 0, 2354, 0);
+
+-- Brave Stonehide <Officer Accessories Quartermaster> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 12793;
+INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES 
+(12793, 15197, 0, 0, 1007), (12793, 15199, 0, 0, 1006), (12793, 15200, 0, 0, 838), (12793, 16335, 0, 0, 491), (12793, 16341, 0, 0, 986), (12793, 16486, 0, 0, 492),
+(12793, 16497, 0, 0, 492), (12793, 16532, 0, 0, 492), (12793, 18427, 0, 0, 1050), (12793, 18428, 0, 0, 930), (12793, 18429, 0, 0, 492), (12793, 18430, 0, 0, 931),
+(12793, 18432, 0, 0, 931), (12793, 18434, 0, 0, 492), (12793, 18435, 0, 0, 931), (12793, 18436, 0, 0, 931), (12793, 18437, 0, 0, 931), (12793, 18461, 0, 0, 774), 
+(12793, 18607, 0, 0, 386), (12793, 18834, 0, 0, 634), (12793, 18839, 0, 0, 460), (12793, 18841, 0, 0, 460), (12793, 18845, 0, 0, 634), (12793, 18846, 0, 0, 634),
+(12793, 18849, 0, 0, 634), (12793, 18850, 0, 0, 634), (12793, 18851, 0, 0, 634), (12793, 18852, 0, 0, 634), (12793, 18853, 0, 0, 634), (12793, 24551, 0, 0, 125),
+(12793, 28118, 0, 0, 95), (12793, 28119, 0, 0, 95), (12793, 28120, 0, 0, 95), (12793, 28123, 0, 0, 99), (12793, 28239, 0, 0, 2404), (12793, 28240, 0, 0, 2404),
+(12793, 28241, 0, 0, 2404), (12793, 28242, 0, 0, 2404), (12793, 28243, 0, 0, 2404), (12793, 28244, 0, 0, 125), (12793, 28245, 0, 0, 125), (12793, 28246, 0, 0, 129),
+(12793, 28247, 0, 0, 129), (12793, 28362, 0, 0, 95), (12793, 28363, 0, 0, 99), (12793, 28377, 0, 0, 165), (12793, 28378, 0, 0, 165), (12793, 28379, 0, 0, 165),
+(12793, 28380, 0, 0, 165), (12793, 29592, 0, 0, 634), (12793, 30343, 0, 0, 2404), (12793, 30344, 0, 0, 2404), (12793, 30345, 0, 0, 2404), (12793, 30346, 0, 0, 2404),
+(12793, 31838, 0, 0, 1648), (12793, 31839, 0, 0, 1649), (12793, 31840, 0, 0, 1648), (12793, 31841, 0, 0, 1649), (12793, 31852, 0, 0, 1652), (12793, 31853, 0, 0, 1653),
+(12793, 31854, 0, 0, 1652), (12793, 31855, 0, 0, 1653), (12793, 32453, 0, 0, 1564), (12793, 32455, 0, 0, 460);
+
+-- Vixton Pinchwhistle <Arena Vendor> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 20278;
+INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES 
+(20278, 24544, 0, 0, 22), (20278, 24545, 0, 0, 22), (20278, 24546, 0, 0, 24), (20278, 24547, 0, 0, 22), (20278, 24549, 0, 0, 21), (20278, 24550, 0, 0, 26),
+(20278, 24552, 0, 0, 22), (20278, 24553, 0, 0, 22), (20278, 24554, 0, 0, 24), (20278, 24555, 0, 0, 22), (20278, 24556, 0, 0, 21), (20278, 24557, 0, 0, 26),
+(20278, 25830, 0, 0, 22), (20278, 25831, 0, 0, 22), (20278, 25832, 0, 0, 24), (20278, 25833, 0, 0, 22), (20278, 25834, 0, 0, 21), (20278, 25854, 0, 0, 24),
+(20278, 25855, 0, 0, 22), (20278, 25856, 0, 0, 22), (20278, 25857, 0, 0, 21), (20278, 25858, 0, 0, 22), (20278, 25997, 0, 0, 22), (20278, 25998, 0, 0, 22),
+(20278, 25999, 0, 0, 24), (20278, 26000, 0, 0, 21), (20278, 26001, 0, 0, 22), (20278, 27469, 0, 0, 22), (20278, 27470, 0, 0, 21), (20278, 27471, 0, 0, 22),
+(20278, 27472, 0, 0, 22), (20278, 27473, 0, 0, 24), (20278, 27702, 0, 0, 22), (20278, 27703, 0, 0, 21), (20278, 27704, 0, 0, 22), (20278, 27705, 0, 0, 22),
+(20278, 27706, 0, 0, 24), (20278, 27707, 0, 0, 21), (20278, 27708, 0, 0, 22), (20278, 27709, 0, 0, 22), (20278, 27710, 0, 0, 24), (20278, 27711, 0, 0, 22),
+(20278, 27879, 0, 0, 22), (20278, 27880, 0, 0, 21), (20278, 27881, 0, 0, 22), (20278, 27882, 0, 0, 22), (20278, 27883, 0, 0, 24), (20278, 28126, 0, 0, 21),
+(20278, 28127, 0, 0, 22), (20278, 28128, 0, 0, 22), (20278, 28129, 0, 0, 24), (20278, 28130, 0, 0, 22), (20278, 28136, 0, 0, 21), (20278, 28137, 0, 0, 22),
+(20278, 28138, 0, 0, 22), (20278, 28139, 0, 0, 24), (20278, 28140, 0, 0, 22), (20278, 28294, 0, 0, 26), (20278, 28295, 0, 0, 133), (20278, 28297, 0, 0, 148),
+(20278, 28298, 0, 0, 26), (20278, 28299, 0, 0, 26), (20278, 28300, 0, 0, 26), (20278, 28302, 0, 0, 21), (20278, 28305, 0, 0, 133), (20278, 28307, 0, 0, 21),
+(20278, 28308, 0, 0, 133), (20278, 28309, 0, 0, 21), (20278, 28310, 0, 0, 21), (20278, 28312, 0, 0, 133), (20278, 28313, 0, 0, 133), (20278, 28314, 0, 0, 21),
+(20278, 28319, 0, 0, 2388), (20278, 28320, 0, 0, 2388), (20278, 28331, 0, 0, 22), (20278, 28332, 0, 0, 22), (20278, 28333, 0, 0, 24), (20278, 28334, 0, 0, 22),
+(20278, 28335, 0, 0, 21), (20278, 28346, 0, 0, 21), (20278, 28355, 0, 0, 2388), (20278, 28356, 0, 0, 2388), (20278, 28357, 0, 0, 2388), (20278, 28358, 0, 0, 22),
+(20278, 28476, 0, 0, 26), (20278, 30186, 0, 0, 24), (20278, 30187, 0, 0, 22), (20278, 30188, 0, 0, 21), (20278, 30200, 0, 0, 22), (20278, 30201, 0, 0, 22),
+(20278, 31375, 0, 0, 21), (20278, 31376, 0, 0, 22), (20278, 31377, 0, 0, 22), (20278, 31378, 0, 0, 24), (20278, 31379, 0, 0, 22), (20278, 31396, 0, 0, 22),
+(20278, 31397, 0, 0, 21), (20278, 31400, 0, 0, 22), (20278, 31406, 0, 0, 22), (20278, 31407, 0, 0, 24), (20278, 31409, 0, 0, 21), (20278, 31410, 0, 0, 22),
+(20278, 31411, 0, 0, 22), (20278, 31412, 0, 0, 24), (20278, 31413, 0, 0, 22), (20278, 31613, 0, 0, 22), (20278, 31614, 0, 0, 21), (20278, 31616, 0, 0, 22),
+(20278, 31618, 0, 0, 22), (20278, 31619, 0, 0, 24), (20278, 32450, 0, 0, 148), (20278, 32451, 0, 0, 148), (20278, 32452, 0, 0, 21), (20278, 33936, 0, 0, 2388),
+(20278, 33939, 0, 0, 2388), (20278, 33942, 0, 0, 2388), (20278, 33945, 0, 0, 2388), (20278, 33948, 0, 0, 2388), (20278, 33951, 0, 0, 2388);
+
+-- Krixel Pinchwhistle <Arena Vendor> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 23396;
+INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES 
+(23396, 30486, 0, 0, 2285), (23396, 30487, 0, 0, 2283), (23396, 30488, 0, 0, 2285), (23396, 30489, 0, 0, 2285), (23396, 30490, 0, 0, 2288), (23396, 31958, 0, 0, 2283),
+(23396, 31959, 0, 0, 1664), (23396, 31960, 0, 0, 2285), (23396, 31961, 0, 0, 2283), (23396, 31962, 0, 0, 2285), (23396, 31963, 0, 0, 2285), (23396, 31964, 0, 0, 2288),
+(23396, 31965, 0, 0, 2287), (23396, 31966, 0, 0, 1664), (23396, 31967, 0, 0, 2283), (23396, 31968, 0, 0, 2285), (23396, 31969, 0, 0, 2285), (23396, 31971, 0, 0, 2288),
+(23396, 31972, 0, 0, 2285), (23396, 31973, 0, 0, 2283), (23396, 31974, 0, 0, 2285), (23396, 31975, 0, 0, 2285), (23396, 31976, 0, 0, 2288), (23396, 31977, 0, 0, 2285),
+(23396, 31978, 0, 0, 2283), (23396, 31979, 0, 0, 2288), (23396, 31980, 0, 0, 2285), (23396, 31981, 0, 0, 2283), (23396, 31982, 0, 0, 2285), (23396, 31983, 0, 0, 2285),
+(23396, 31984, 0, 0, 1664), (23396, 31985, 0, 0, 2283), (23396, 31986, 0, 0, 1664), (23396, 31987, 0, 0, 2283), (23396, 31988, 0, 0, 2285), (23396, 31989, 0, 0, 2285),
+(23396, 31990, 0, 0, 2288), (23396, 31991, 0, 0, 2285), (23396, 31992, 0, 0, 2285), (23396, 31993, 0, 0, 2283), (23396, 31995, 0, 0, 2285), (23396, 31996, 0, 0, 2288),
+(23396, 31997, 0, 0, 2285), (23396, 31998, 0, 0, 2283), (23396, 31999, 0, 0, 2285), (23396, 32000, 0, 0, 2285), (23396, 32001, 0, 0, 2288), (23396, 32002, 0, 0, 2285),
+(23396, 32003, 0, 0, 2283), (23396, 32004, 0, 0, 2285), (23396, 32005, 0, 0, 2283), (23396, 32006, 0, 0, 2285), (23396, 32007, 0, 0, 2285), (23396, 32008, 0, 0, 2288),
+(23396, 32009, 0, 0, 2285), (23396, 32010, 0, 0, 2283), (23396, 32011, 0, 0, 2285), (23396, 32012, 0, 0, 2285), (23396, 32013, 0, 0, 2288), (23396, 32014, 0, 0, 1664),
+(23396, 32015, 0, 0, 2283), (23396, 32016, 0, 0, 2285), (23396, 32017, 0, 0, 2285), (23396, 32018, 0, 0, 2288), (23396, 32019, 0, 0, 2285), (23396, 32020, 0, 0, 2285),
+(23396, 32021, 0, 0, 2283), (23396, 32022, 0, 0, 2285), (23396, 32023, 0, 0, 2285), (23396, 32024, 0, 0, 2288), (23396, 32025, 0, 0, 1664), (23396, 32026, 0, 0, 2287),
+(23396, 32027, 0, 0, 2283), (23396, 32028, 0, 0, 2287), (23396, 32029, 0, 0, 2285), (23396, 32030, 0, 0, 2283), (23396, 32031, 0, 0, 2285), (23396, 32032, 0, 0, 2285),
+(23396, 32033, 0, 0, 2288), (23396, 32034, 0, 0, 2283), (23396, 32035, 0, 0, 2285), (23396, 32036, 0, 0, 2285), (23396, 32037, 0, 0, 2288), (23396, 32038, 0, 0, 2285),
+(23396, 32039, 0, 0, 2285), (23396, 32040, 0, 0, 2283), (23396, 32041, 0, 0, 2285), (23396, 32042, 0, 0, 2285), (23396, 32043, 0, 0, 2288), (23396, 32044, 0, 0, 2287),
+(23396, 32045, 0, 0, 2285), (23396, 32046, 0, 0, 2283), (23396, 32047, 0, 0, 2288), (23396, 32048, 0, 0, 2285), (23396, 32049, 0, 0, 2283), (23396, 32050, 0, 0, 2285),
+(23396, 32051, 0, 0, 2285), (23396, 32052, 0, 0, 2287), (23396, 32053, 0, 0, 2284), (23396, 32054, 0, 0, 1758), (23396, 32055, 0, 0, 1664), (23396, 32056, 0, 0, 2283),
+(23396, 32057, 0, 0, 2285), (23396, 32058, 0, 0, 2285), (23396, 32059, 0, 0, 2288), (23396, 32060, 0, 0, 2285), (23396, 32961, 0, 0, 2283), (23396, 32962, 0, 0, 1758),
+(23396, 32963, 0, 0, 2284), (23396, 32964, 0, 0, 2284), (23396, 33076, 0, 0, 1758), (23396, 33077, 0, 0, 1758), (23396, 33078, 0, 0, 1758), (23396, 33309, 0, 0, 2285),
+(23396, 33313, 0, 0, 2285), (23396, 33937, 0, 0, 1758), (23396, 33940, 0, 0, 1758), (23396, 33943, 0, 0, 1758), (23396, 33946, 0, 0, 1758), (23396, 33949, 0, 0, 1758),
+(23396, 33952, 0, 0, 1758);
+
+
 
 -- Sergeant Thunderhorn <Weapons Quartermaster> - vanilla
 DELETE FROM `npc_vendor` WHERE `entry` = @TH_Classic;
@@ -560,6 +615,42 @@ INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost
 (@TH_TBC, 28926, 0, 0, 2240), (@TH_TBC, 28928, 0, 0, 2239), (@TH_TBC, 28929, 0, 0, 2240), (@TH_TBC, 28930, 0, 0, 2240), (@TH_TBC, 28931, 0, 0, 2238),
 (@TH_TBC, 28933, 0, 0, 2237), (@TH_TBC, 28935, 0, 0, 2237), (@TH_TBC, 28937, 0, 0, 2239), (@TH_TBC, 28938, 0, 0, 2242), (@TH_TBC, 28939, 0, 0, 2242);
 
+-- Lady Palanseer <Armor Quartermaster> - vanilla
+DELETE FROM `npc_vendor` WHERE `entry`= @LP_Classic;
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
+(@LP_Classic, 16533, 464), (@LP_Classic, 16534, 542), (@LP_Classic, 16535, 463), (@LP_Classic, 16536, 465), (@LP_Classic, 16539, 465), (@LP_Classic, 16540, 541), (@LP_Classic, 16541, 463), 
+(@LP_Classic, 16542, 464), (@LP_Classic, 16543, 542), (@LP_Classic, 16544, 465), (@LP_Classic, 16545, 465), (@LP_Classic, 16548, 541), (@LP_Classic, 16549, 463), (@LP_Classic, 16550, 464), 
+(@LP_Classic, 16551, 465), (@LP_Classic, 16552, 542), (@LP_Classic, 16554, 465), (@LP_Classic, 16555, 541), (@LP_Classic, 16558, 465), (@LP_Classic, 16560, 541), (@LP_Classic, 16561, 464), 
+(@LP_Classic, 16562, 465), (@LP_Classic, 16563, 463), (@LP_Classic, 16564, 542), (@LP_Classic, 16565, 463), (@LP_Classic, 16566, 464), (@LP_Classic, 16567, 542), (@LP_Classic, 16568, 465), 
+(@LP_Classic, 16569, 465), (@LP_Classic, 16571, 541), (@LP_Classic, 16573, 465), (@LP_Classic, 16574, 541), (@LP_Classic, 16577, 463), (@LP_Classic, 16578, 464), (@LP_Classic, 16579, 542), 
+(@LP_Classic, 16580, 465), (@LP_Classic, 17586, 465), (@LP_Classic, 17588, 541), (@LP_Classic, 17590, 465), (@LP_Classic, 17591, 464), (@LP_Classic, 17592, 463), (@LP_Classic, 17593, 542), 
+(@LP_Classic, 17618, 465), (@LP_Classic, 17620, 541), (@LP_Classic, 17622, 465), (@LP_Classic, 17623, 464), (@LP_Classic, 17624, 463), (@LP_Classic, 17625, 542), (@LP_Classic, 22843, 427), 
+(@LP_Classic, 22852, 427), (@LP_Classic, 22855, 427), (@LP_Classic, 22856, 427), (@LP_Classic, 22857, 427), (@LP_Classic, 22858, 427), (@LP_Classic, 22859, 427), (@LP_Classic, 22860, 427), 
+(@LP_Classic, 22862, 428), (@LP_Classic, 22863, 428), (@LP_Classic, 22864, 428), (@LP_Classic, 22865, 428), (@LP_Classic, 22867, 428), (@LP_Classic, 22868, 428), (@LP_Classic, 22869, 428),
+(@LP_Classic, 22870, 428), (@LP_Classic, 22872, 652), (@LP_Classic, 22873, 653), (@LP_Classic, 22874, 652), (@LP_Classic, 22875, 653), (@LP_Classic, 22876, 652), (@LP_Classic, 22877, 652), 
+(@LP_Classic, 22878, 653), (@LP_Classic, 22879, 652), (@LP_Classic, 22880, 653), (@LP_Classic, 22881, 653), (@LP_Classic, 22882, 653), (@LP_Classic, 22883, 653), (@LP_Classic, 22884, 652), 
+(@LP_Classic, 22885, 652), (@LP_Classic, 22886, 652), (@LP_Classic, 22887, 653), (@LP_Classic, 23243, 427), (@LP_Classic, 23244, 444), (@LP_Classic, 23251, 444), (@LP_Classic, 23252, 427), 
+(@LP_Classic, 23253, 444), (@LP_Classic, 23254, 427), (@LP_Classic, 23255, 444), (@LP_Classic, 23256, 427), (@LP_Classic, 23257, 444), (@LP_Classic, 23258, 427), (@LP_Classic, 23259, 444), 
+(@LP_Classic, 23260, 427), (@LP_Classic, 23261, 444), (@LP_Classic, 23262, 427), (@LP_Classic, 23263, 444), (@LP_Classic, 23264, 427);
+
+-- Lady Palanseer <Armor Quartermaster> - TBC
+DELETE FROM `npc_vendor` WHERE `entry`= @LP_TBC;
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES 
+(@LP_TBC, 28805, 0, 0, 2259), (@LP_TBC, 28806, 0, 0, 2261), (@LP_TBC, 28807, 0, 0, 2263), (@LP_TBC, 28808, 0, 0, 2265), (@LP_TBC, 28809, 0, 0, 2267), (@LP_TBC, 28811, 0, 0, 2261),
+(@LP_TBC, 28812, 0, 0, 2263), (@LP_TBC, 28813, 0, 0, 2265), (@LP_TBC, 28814, 0, 0, 2267), (@LP_TBC, 28815, 0, 0, 2259), (@LP_TBC, 28817, 0, 0, 2261), (@LP_TBC, 28818, 0, 0, 2263),
+(@LP_TBC, 28819, 0, 0, 2265), (@LP_TBC, 28820, 0, 0, 2267), (@LP_TBC, 28821, 0, 0, 2259), (@LP_TBC, 28831, 0, 0, 2259), (@LP_TBC, 28832, 0, 0, 2261), (@LP_TBC, 28833, 0, 0, 2263),
+(@LP_TBC, 28834, 0, 0, 2265), (@LP_TBC, 28835, 0, 0, 2267), (@LP_TBC, 28836, 0, 0, 2261), (@LP_TBC, 28837, 0, 0, 2263), (@LP_TBC, 28838, 0, 0, 2265), (@LP_TBC, 28839, 0, 0, 2267),
+(@LP_TBC, 28840, 0, 0, 2259), (@LP_TBC, 28841, 0, 0, 2259), (@LP_TBC, 28842, 0, 0, 2261), (@LP_TBC, 28843, 0, 0, 2263), (@LP_TBC, 28844, 0, 0, 2265), (@LP_TBC, 28845, 0, 0, 2267),
+(@LP_TBC, 28846, 0, 0, 2259), (@LP_TBC, 28847, 0, 0, 2261), (@LP_TBC, 28848, 0, 0, 2263), (@LP_TBC, 28849, 0, 0, 2265), (@LP_TBC, 28850, 0, 0, 2267), (@LP_TBC, 28851, 0, 0, 2259),
+(@LP_TBC, 28852, 0, 0, 2261), (@LP_TBC, 28853, 0, 0, 2263), (@LP_TBC, 28854, 0, 0, 2265), (@LP_TBC, 28855, 0, 0, 2267), (@LP_TBC, 28856, 0, 0, 2261), (@LP_TBC, 28857, 0, 0, 2263),
+(@LP_TBC, 28858, 0, 0, 2265), (@LP_TBC, 28859, 0, 0, 2267), (@LP_TBC, 28860, 0, 0, 2259), (@LP_TBC, 28861, 0, 0, 2259), (@LP_TBC, 28862, 0, 0, 2261), (@LP_TBC, 28863, 0, 0, 2263), 
+(@LP_TBC, 28864, 0, 0, 2265), (@LP_TBC, 28865, 0, 0, 2267), (@LP_TBC, 28866, 0, 0, 2267), (@LP_TBC, 28867, 0, 0, 2263), (@LP_TBC, 28868, 0, 0, 2261), (@LP_TBC, 28869, 0, 0, 2259),
+(@LP_TBC, 28870, 0, 0, 2265), (@LP_TBC, 28871, 0, 0, 2261), (@LP_TBC, 28872, 0, 0, 2263), (@LP_TBC, 28873, 0, 0, 2265), (@LP_TBC, 28874, 0, 0, 2267), (@LP_TBC, 28875, 0, 0, 2259),
+(@LP_TBC, 31584, 0, 0, 2261), (@LP_TBC, 31585, 0, 0, 2263), (@LP_TBC, 31586, 0, 0, 2265), (@LP_TBC, 31587, 0, 0, 2267), (@LP_TBC, 31588, 0, 0, 2259), (@LP_TBC, 31621, 0, 0, 2261),
+(@LP_TBC, 31626, 0, 0, 2263), (@LP_TBC, 31627, 0, 0, 2265), (@LP_TBC, 31628, 0, 0, 2267), (@LP_TBC, 31629, 0, 0, 2259), (@LP_TBC, 31635, 0, 0, 2259), (@LP_TBC, 31636, 0, 0, 2261),
+(@LP_TBC, 31637, 0, 0, 2263), (@LP_TBC, 31638, 0, 0, 2265), (@LP_TBC, 31639, 0, 0, 2267), (@LP_TBC, 31646, 0, 0, 2259), (@LP_TBC, 31647, 0, 0, 2261), (@LP_TBC, 31648, 0, 0, 2263),
+(@LP_TBC, 31649, 0, 0, 2265), (@LP_TBC, 31650, 0, 0, 2267);
+
 
 
 /* Hide certain vendor items until the player has reached the progression tier for them */
@@ -567,54 +658,54 @@ DELETE FROM `conditions` WHERE `SourceGroup` IN (12792, @TH_Classic, @TH_TBC);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
 `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
 -- 
-(23, 12792, 16533, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Silk Cowl until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16534, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Silk Trousers until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16535, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Silk Raiment until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16536, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Silk Amice until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16539, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Silk Boots until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16540, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Silk Handguards until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16541, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Plate Armor until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16542, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Plate Headpiece until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16543, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Plate Leggings until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16544, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Plate Shoulders until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16545, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Plate Boots until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16548, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Plate Gauntlets until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16549, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dragonhide Hauberk until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16550, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dragonhide Helmet until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16551, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dragonhide Epaulets until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16552, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dragonhide Leggings until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16554, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dragonhide Boots until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16555, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dragonshide Gloves until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16558, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Leather Treads until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16560, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Leather Mitts until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16561, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Leather Helm until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16562, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Leather Spaulders until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16563, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Leather Breastplate until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16564, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Leather Legguards until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16565, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Chain Chestpiece until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16566, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Chain Helmet until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16567, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Chain Legguards until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16568, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Chain Shoulders until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16569, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Chain Sabatons until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16571, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Chain Gloves until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16573, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Mail Boots until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16574, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Mail Gauntlets until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16577, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Mail Armor until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16578, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Mail Helm until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16579, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Mail Leggings until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 16580, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Mail Spaulders until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17586, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dreadweave Boots until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17588, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dreadweave Gloves until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17590, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dreadweave Mantle until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17591, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dreadweave Hood until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17592, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dreadweave Robe until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17593, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dreadweave Pants until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17618, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Satin Boots until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17620, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Satin Gloves until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17622, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Satin Mantle until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17623, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Satin Cowl until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17624, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Satin Robes until the player has completed PROGRESSION_ONYXIA'),
-(23, 12792, 17625, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Satin Leggings until the player has completed PROGRESSION_ONYXIA'),    
+(23, @LP_Classic, 16533, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Silk Cowl until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16534, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Silk Trousers until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16535, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Silk Raiment until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16536, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Silk Amice until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16539, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Silk Boots until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16540, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Silk Handguards until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16541, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Plate Armor until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16542, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Plate Headpiece until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16543, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Plate Leggings until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16544, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Plate Shoulders until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16545, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Plate Boots until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16548, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Plate Gauntlets until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16549, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dragonhide Hauberk until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16550, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dragonhide Helmet until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16551, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dragonhide Epaulets until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16552, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dragonhide Leggings until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16554, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dragonhide Boots until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16555, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dragonshide Gloves until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16558, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Leather Treads until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16560, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Leather Mitts until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16561, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Leather Helm until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16562, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Leather Spaulders until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16563, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Leather Breastplate until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16564, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Leather Legguards until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16565, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Chain Chestpiece until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16566, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Chain Helmet until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16567, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Chain Legguards until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16568, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Chain Shoulders until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16569, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Chain Sabatons until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16571, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Chain Gloves until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16573, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Mail Boots until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16574, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Mail Gauntlets until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16577, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Mail Armor until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16578, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Mail Helm until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16579, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Mail Leggings until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 16580, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Mail Spaulders until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17586, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dreadweave Boots until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17588, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dreadweave Gloves until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17590, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dreadweave Mantle until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17591, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dreadweave Hood until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17592, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Dreadweave Robe until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17593, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Dreadweave Pants until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17618, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Satin Boots until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17620, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Satin Gloves until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17622, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Satin Mantle until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17623, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Satin Cowl until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17624, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Satin Robes until the player has completed PROGRESSION_ONYXIA'),
+(23, @LP_Classic, 17625, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Satin Leggings until the player has completed PROGRESSION_ONYXIA'),    
 --
 (23, @TH_Classic, 16345, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Blade until the player has completed PROGRESSION_ONYXIA'),
 (23, @TH_Classic, 18826, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Shield Wall until the player has completed PROGRESSION_ONYXIA'),
@@ -638,10 +729,13 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (23, @TH_Classic, 23468, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Tome of Destruction until the player has completed PROGRESSION_ONYXIA'),
 (23, @TH_Classic, 23469, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Tome of Mending until the player has completed PROGRESSION_ONYXIA');
 
+-- WotLK pvp vendors
 DELETE FROM `creature` WHERE `id1` IN 
 (34038,  -- Sergeant Thunderhorn <Apprentice Armor Quartermaster>
+ 34043,  -- Lady Palanseer <Armor Quartermaster>
  34060,  -- Doris Volanthius <Veteran Armor Quartermaster>
  34063); -- Blood Guard Zar'shi <Northrend Armor Quartermaster>
+
 
 -- Nogg Quest Flags fix
 UPDATE `creature_template` SET `npcflag` = `npcflag` | 2 WHERE `entry` = 3412;

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -535,7 +535,7 @@ INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `Exte
 -- Raider Bork <Mount Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`= 12796;
 INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
-(12796, 18245, 423), (12796, 18246, 423), (12796, 18247, 423), (12796, 18248, 423);
+(12796, 18245, 423), (12796, 18246, 423), (12796, 18247, 423), (12796, 18248, 423), (12796, 34129, 423);
 
 -- Vixton Pinchwhistle <Arena Vendor> - TBC
 DELETE FROM `npc_vendor` WHERE `entry` = 20278;
@@ -653,7 +653,7 @@ INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost
 
 
 /* Hide certain vendor items until the player has reached the progression tier for them */
-DELETE FROM `conditions` WHERE `SourceGroup` IN (@LP_Classic, @LP_TBC, @TH_Classic, @TH_TBC);
+DELETE FROM `conditions` WHERE `SourceGroup` IN (12796, @LP_Classic, @LP_TBC, @TH_Classic, @TH_TBC);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
 `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
 -- 
@@ -726,7 +726,10 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (23, @TH_Classic, 23466, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Spellblade until the player has completed PROGRESSION_ONYXIA'),
 (23, @TH_Classic, 23467, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Quickblade until the player has completed PROGRESSION_ONYXIA'),
 (23, @TH_Classic, 23468, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Tome of Destruction until the player has completed PROGRESSION_ONYXIA'),
-(23, @TH_Classic, 23469, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Tome of Mending until the player has completed PROGRESSION_ONYXIA');
+(23, @TH_Classic, 23469, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Tome of Mending until the player has completed PROGRESSION_ONYXIA'),
+--
+(23, 12796, 34129, 0, 0, 8, 0, 66008, 0, 0, 0, 0, 0, '', 'Raider Bork will not sell Swift Warstrider until the player has completed PROGRESSION_PRE_TBC');
+
 
 -- WotLK pvp vendors
 DELETE FROM `creature` WHERE `id1` IN 

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -657,7 +657,7 @@ INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost
 
 
 /* Hide certain vendor items until the player has reached the progression tier for them */
-DELETE FROM `conditions` WHERE `SourceGroup` IN (12792, @TH_Classic, @TH_TBC);
+DELETE FROM `conditions` WHERE `SourceGroup` IN (@LP_Classic, @LP_TBC, @TH_Classic, @TH_TBC);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
 `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
 -- 

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -461,7 +461,7 @@ DELETE FROM `creature` WHERE `guid` IN (125688, 125690, 125695, 612792, 612793, 
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 
 (626397, @LP_Classic, 1, 1669.78, -4200.1, 56.3815, 3.61023, 180),  -- Lady Palanseer <Armor Quartermaster>, Vanilla
-(612792, @LP_TBC, 1, 1674.48, -4211.93, 56.4831, 3.03786, 180),     -- Lady Palanseer <Armor Quartermaster>, TBC
+(612792, @LP_TBC, 1, 1669.78, -4200.1, 56.3815, 3.61023, 180),      -- Lady Palanseer <Armor Quartermaster>, TBC
 (612793, @Stonehide, 1, 1657.6, -4191.97, 56.383, 4.52365, 180),    -- Brave Stonehide <Officer Accessories Quartermaster>, Vanilla
 (125690, 12793, 1, 1672.24, -4206.81, 56.3827, 3.30568, 180),       -- Brave Stonehide <Officer Accessories Quartermaster>, TBC
 (612794, @Zarg, 1, 1641.65, -4197.52, 56.3823, 5.41219, 180),       -- Stone Guard Zarg <Food and Drink>, Vanilla

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -46,7 +46,6 @@ UPDATE `creature_template` SET `subname`='Journeyman Tailor', `npcflag`=81, `tra
 -- Magar <Expert Tailor>
 UPDATE `creature_template` SET `subname`='Expert Tailor' WHERE `entry`=3363;
 
-
 -- Snarl <Expert Blacksmith>
 DELETE FROM `npc_trainer` WHERE `ID`=1383;
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1383, -310000), (1383, -310001);
@@ -127,7 +126,6 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11046, -300000);
 DELETE FROM `npc_trainer` WHERE `ID`=11066;
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11066, -330000);
 
-
 -- Snarl <Expert Blacksmith>
 DELETE FROM `gossip_menu_option` WHERE `MenuID`=2782;
 INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES
@@ -142,7 +140,6 @@ INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionTex
 DELETE FROM `gossip_menu_option` WHERE `MenuID`=4151;
 INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES
 (4151, 0, 3, 'Train me.', 3266, 5, 16);
-
 
 -- Saru Steelfury <Artisan Blacksmith>
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=1012 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
@@ -184,7 +181,6 @@ DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=43
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
 (15, 4347, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');
 
-
 -- Nazgrel <Advisor to Thrall>
 DELETE FROM `creature` WHERE `id1` = 3230 AND `map`= 1;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
@@ -204,11 +200,6 @@ INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `posit
 DELETE FROM `creature` WHERE `id1` = 12788;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 (612788, 12788, 1, 1650.95, -4212.82, 55.439, 0.182965, 25);
-
--- Stone Guard Zarg <Food and Drink>
-DELETE FROM `creature` WHERE `id1` = 12794;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
-(612794, 12794, 1, 1641.65, -4197.52, 56.3823, 5.41219, 180);
 
 -- Sergeant Ba'sha <Accessories Quartermaster>
 DELETE FROM `creature` WHERE `id1` = 12799;
@@ -301,9 +292,6 @@ UPDATE `creature_template` SET `subname`='Zeppelin Master' WHERE `entry`=12136;
 
 -- Legionnaire Teena
 UPDATE `creature_template` SET `subname`=NULL, `npcflag`=0, `faction`=85 WHERE `entry`=12788;
-
--- Stone Guard Zarg <Food and Drink>
-UPDATE `creature_template` SET `subname`='Food and Drink' WHERE `entry`=12794;
 
 -- Kor'kron Elite
 UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60, `rank`=0 WHERE `entry`=14304;
@@ -399,31 +387,11 @@ DELETE FROM `npc_vendor` WHERE `entry`=5817 AND `item` IN (10648, 14341, 18256, 
 DELETE FROM `npc_vendor` WHERE `entry`=6929 AND `item` IN (27854, 28399, 33444, 33445, 33454, 35953, 35954);
 
 -- Legionnaire Teena
-DELETE FROM `npc_vendor` WHERE `entry`=12788;
-
--- Stone Guard Zarg <Food and Drink>
-DELETE FROM `npc_vendor` WHERE `entry`=12794 AND `item` IN 
-    (16345, 18826, 18828, 18831, 18835, 18837, 18840, 18844, 18848, 18860, 18866, 18868, 18871, 18874, 18877, 23464, 23465, 23466, 23467, 23468, 23469);
-DELETE FROM `npc_vendor` WHERE `entry`=12794 AND `item` IN
-    (117, 159, 1179, 1205, 1645, 1708, 2287, 2593, 2594, 2595, 2596, 2723, 3770, 3771, 4536, 4537, 4538, 4539, 4540, 4541, 4542, 4544, 4599, 4601, 4602, 4604, 4605, 4606, 4607, 4608, 8766, 8948, 8950, 8952, 8953);
-
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
-    (12794, 117), (12794, 159), (12794, 1179), (12794, 1205), (12794, 1645), (12794, 1708), (12794, 2287), (12794, 2593), (12794, 2594), (12794, 2595), (12794, 2596), (12794, 2723),
-    (12794, 3770), (12794, 3771), (12794, 4536), (12794, 4537), (12794, 4538), (12794, 4539), (12794, 4540), (12794, 4541), (12794, 4542), (12794, 4544), (12794, 4599), (12794, 4601),
-    (12794, 4602), (12794, 4604), (12794, 4605), (12794, 4606), (12794, 4607), (12794, 4608), (12794, 8766), (12794, 8948), (12794, 8950), (12794, 8952), (12794, 8953);
-
-
-
-
-
-
-
-
-
-
+DELETE FROM `npc_vendor` WHERE `entry`= 12788;
 
 
 SET @Stonehide  := 112793; -- Brave Stonehide <Officer Accessories Quartermaster>, Vanilla
+SET @Zarg       := 112794; -- Stone Guard Zarg <Food and Drink>, Vanilla
 SET @Hola       := 112795; -- First Sergeant Hola'mahi, Vanilla
 SET @TH_Classic := 26396;  -- Sergeant Thunderhorn, Vanilla
 SET @TH_TBC     := 14581;  -- Sergeant Thunderhorn, TBC
@@ -431,7 +399,7 @@ SET @LP_Classic := 26397;  -- Lady Palanseer <Armor Quartermaster>, Vanilla
 SET @LP_TBC     := 12792;  -- Lady Palanseer <Armor Quartermaster>, TBC
 
 
-DELETE FROM `creature_template` WHERE `entry` = @Hola;
+DELETE FROM `creature_template` WHERE `entry` IN (@Stonehide, @Zarg, @Hola);
 INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`, `KillCredit1`, `KillCredit2`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, 
 `exp`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `speed_swim`, `speed_flight`, `detection_range`, `scale`, `rank`, `dmgschool`, `DamageModifier`, `BaseAttackTime`, `RangeAttackTime`, 
 `BaseVariance`, `RangeVariance`, `unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, `trainer_type`, `trainer_spell`, `trainer_class`, `trainer_race`, `type`, `type_flags`, 
@@ -439,9 +407,10 @@ INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entr
 `RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `spell_school_immune_mask`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES 
 
 (@Stonehide, 0, 0, 0, 0, 0, 'Brave Stonehide', 'Officer Accessories Quartermaster', NULL, 0, 55, 55, 0, 125, 128, 1, 1.14286, 1, 1, 18, 1, 0, 0, 2.9, 2000, 2000, 1, 1, 1, 256, 2048, 0, 0, 0, 0, 0, 0, 7, 4096, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 2, 1, 1, 1, 0, 0, 1, 0, 0, 0, 'npc_ipp_pre_tbc', 12340),
+(@Zarg, 0, 0, 0, 0, 0, 'Stone Guard Zarg', 'Food and Drink', NULL, 0, 55, 55, 0, 125, 130, 1, 1.14286, 1, 1, 18, 1, 0, 0, 1.05, 2000, 1606, 1, 1, 1, 768, 2048, 0, 0, 0, 0, 0, 0, 7, 4096, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 2, 1, 1, 1, 0, 0, 1, 0, 0, 0, 'npc_ipp_pre_tbc', 12340),
 (@Hola, 0, 0, 0, 0, 0, 'First Sergeant Hola\'mahi', 'Reagent Vendor', NULL, 0, 55, 55, 0, 125, 130, 1, 1.14286, 1, 1, 18, 1, 0, 0, 1.2, 2000, 1551, 1, 1, 1, 768, 2048, 0, 0, 0, 0, 0, 0, 7, 4096, 0, 0, 0, 0, 0, 0, 0, '', 1, 1, 2, 1, 1, 1, 0, 0, 1, 0, 0, 0, 'npc_ipp_pre_tbc', 12340);
 
-DELETE FROM `creature_template_locale` WHERE `entry` = @Hola;
+DELETE FROM `creature_template_locale` WHERE `entry` IN (@Stonehide, @Zarg, @Hola);
 INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES
 --
 (@Stonehide, 'deDE', 'Kriegerheldin Steinfell', 'Rüstmeisterin für Zubehör', 18019),
@@ -453,57 +422,95 @@ INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `Ver
 (@Stonehide, 'zhCN', '卫兵布莱恩·石皮', '杂货军需官', 18019),
 (@Stonehide, 'zhTW', '勇者石皮', '雜貨軍需官', 18019),
 --
-(@Hola, 'deDE', 'Stabsfeldwebel Hola\'mahi', 'Reagent Vendor', 18019),
-(@Hola, 'esES', 'Gran capataz Hola\'mahi', 'Reagent Vendor', 18019),
-(@Hola, 'esMX', 'Gran capataz Hola\'mahi', 'Reagent Vendor', 18019),
-(@Hola, 'frFR', 'Sergent Hola\'mahi', 'Reagent Vendor', 18019),
-(@Hola, 'koKR', '선임하사 홀라마히', 'Reagent Vendor', 18019),
-(@Hola, 'ruRU', 'Первый сержант Хола\'махи', 'Reagent Vendor', 18019),
-(@Hola, 'zhCN', '一等军士长霍拉麦', 'Reagent Vendor', 18019),
-(@Hola, 'zhTW', '一等士官霍拉麥', 'Reagent Vendor', 18019);
+(@Zarg, 'deDE', 'Steingardist Zarg', 'Speis & Trank', 18019),
+(@Zarg, 'esES', 'Guardia de piedra Zarg', 'Alimentos y bebidas', 18019),
+(@Zarg, 'esMX', 'Guardia de piedra Zarg', 'Alimentos y bebidas', 18019),
+(@Zarg, 'frFR', 'Garde de pierre Zarg', 'Nourriture & boissons', 18019),
+(@Zarg, 'koKR', '투사 자르그', '식료품 상인', 18019),
+(@Zarg, 'ruRU', 'Каменный страж Зарг', 'Еда и напитки', 18019),
+(@Zarg, 'zhCN', '石头守卫扎尔格', '食物和饮料', 18019),
+(@Zarg, 'zhTW', '石衛士札爾格', '食物和飲料', 18019),
+--
+(@Hola, 'deDE', 'Stabsfeldwebel Hola\'mahi', 'Reagenzien', 18019),
+(@Hola, 'esES', 'Gran capataz Hola\'mahi', 'Componentes', 18019),
+(@Hola, 'esMX', 'Gran capataz Hola\'mahi', 'Componentes', 18019),
+(@Hola, 'frFR', 'Sergent Hola\'mahi', 'Composants', 18019),
+(@Hola, 'koKR', '선임하사 홀라마히', '마법 재료 상인', 18019),
+(@Hola, 'ruRU', 'Первый сержант Хола\'махи', 'Реагенты', 18019),
+(@Hola, 'zhCN', '一等军士长霍拉麦', '材料商', 18019),
+(@Hola, 'zhTW', '一等士官霍拉麥', '施法材料', 18019);
 
-DELETE FROM `creature_template_model` WHERE `CreatureID` = @Hola;
+DELETE FROM `creature_template_model` WHERE `CreatureID` IN (@Stonehide, @Zarg, @Hola);
 INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES 
 (@Stonehide, 0, 12675, 1, 1, 12340),
+(@Zarg, 0, 12676, 1, 1, 12340),
 (@Hola, 0, 12677, 1, 1, 12340);
 
-
 UPDATE `creature_template` SET `subname` = 'Officer Accessories Quartermaster', `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = 12793;
+UPDATE `creature_template` SET `subname` = 'Weapons Quartermaster', `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = 12794;
 UPDATE `creature_template` SET `subname` = 'Armor Quartermaster', `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = 12795;
 UPDATE `creature_template` SET `subname` = 'Mount Quartermaster' WHERE `entry` = 12796;
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (20278, 23396);
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (20278, 23396, 23447);
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_pre_tbc' WHERE `entry` IN (@TH_Classic, @LP_Classic);
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (@TH_TBC, @LP_TBC);
 
-    
 UPDATE `creature_template_addon` SET `mount` = 0 WHERE `entry` = 12796;
 
 
-
-DELETE FROM `creature` WHERE `guid` IN (125690, 125695, 612792, 612793, 612795, 612796, 614581, 620278, 623396, 626396, 626397);
+DELETE FROM `creature` WHERE `guid` IN (125688, 125690, 125695, 612792, 612793, 612794, 612795, 612796, 614581, 620278, 623396, 626396, 626397);
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 
 (626397, @LP_Classic, 1, 1669.78, -4200.1, 56.3815, 3.61023, 180),  -- Lady Palanseer <Armor Quartermaster>, Vanilla
 (612792, @LP_TBC, 1, 1674.48, -4211.93, 56.4831, 3.03786, 180),     -- Lady Palanseer <Armor Quartermaster>, TBC
 (612793, @Stonehide, 1, 1657.6, -4191.97, 56.383, 4.52365, 180),    -- Brave Stonehide <Officer Accessories Quartermaster>, Vanilla
 (125690, 12793, 1, 1672.24, -4206.81, 56.3827, 3.30568, 180),       -- Brave Stonehide <Officer Accessories Quartermaster>, TBC
-(612795, @Hola, 1, 1673.9, -4216, 56.3826, 2.93578, 180),           -- First Sergeant Hola'mahi <Armor Quartermaster>, Vanilla
+(612794, @Zarg, 1, 1641.65, -4197.52, 56.3823, 5.41219, 180),       -- Stone Guard Zarg <Food and Drink>, Vanilla
+(125688, 12794, 1, 1641.65, -4197.52, 56.3823, 5.41219, 180),       -- Stone Guard Zarg <Weapons Quartermaster>, TBC
+(612795, @Hola, 1, 1673.9, -4216, 56.3826, 2.93578, 180),           -- First Sergeant Hola'mahi <Reagent Vendor>, Vanilla
 (125695, 12795, 1, 1673.9, -4216, 56.3826, 2.93578, 180),           -- First Sergeant Hola'mahi <Armor Quartermaster>, TBC
 (626396, @TH_Classic, 1, 1644.52, -4195.26, 56.3826, 5.43078, 180), -- Sergeant Thunderhorn <Weapons Quartermaster>, Vanilla
 (614581, @TH_TBC, 1, 1669.09, -4196.78, 56.4831, 4.10416, 180),     -- Sergeant Thunderhorn <Weapons Quartermaster>, TBC
 (612796, 12796, 1, 1674.43, -4212.55, 56.3829, 3.00254, 180),       -- Raider Bork <Mount Quartermaster>
-(620278, 20278, 1, 1654.25, -4189.82, 56.3825, 4.71787, 180),       -- Vixton Pinchwhistle <Arena Vendor>
-(623396, 23396, 1, 1660.37, -4190.74, 56.3817, 4.54116, 180);       -- Krixel Pinchwhistle <Arena Vendor>
+(623447, 23447, 1, 1644.52, -4195.26, 56.3826, 5.43078, 180),       -- Sergeant Kien <Armor Quartermaster>, TBC
+(620278, 20278, 1, 1654.25, -4189.82, 56.3825, 4.71787, 180),       -- Vixton Pinchwhistle <Arena Vendor>, TBC
+(623396, 23396, 1, 1660.37, -4190.74, 56.3817, 4.54116, 180);       -- Krixel Pinchwhistle <Arena Vendor>, TBC
 
 
+-- Brave Stonehide <Officer Accessories Quartermaster> - Vanilla
+DELETE FROM `npc_vendor` WHERE `entry` = @Stonehide;
+INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES
+(@Stonehide, 0, 15199, 0, 0, 1006, 0), (@Stonehide, 0, 18607, 0, 0, 386, 0), (@Stonehide, 0, 18839, 0, 0, 2354, 0), (@Stonehide, 0, 18841, 0, 0, 2354, 0);
 
+-- Brave Stonehide <Officer Accessories Quartermaster> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 12793;
+INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES 
+(12793, 15197, 0, 0, 1007), (12793, 15199, 0, 0, 1006), (12793, 15200, 0, 0, 838), (12793, 16335, 0, 0, 491), (12793, 16341, 0, 0, 986), (12793, 16486, 0, 0, 492),
+(12793, 16497, 0, 0, 492), (12793, 16532, 0, 0, 492), (12793, 18427, 0, 0, 1050), (12793, 18428, 0, 0, 930), (12793, 18429, 0, 0, 492), (12793, 18430, 0, 0, 931),
+(12793, 18432, 0, 0, 931), (12793, 18434, 0, 0, 492), (12793, 18435, 0, 0, 931), (12793, 18436, 0, 0, 931), (12793, 18437, 0, 0, 931), (12793, 18461, 0, 0, 774), 
+(12793, 18607, 0, 0, 386), (12793, 18834, 0, 0, 634), (12793, 18839, 0, 0, 460), (12793, 18841, 0, 0, 460), (12793, 18845, 0, 0, 634), (12793, 18846, 0, 0, 634),
+(12793, 18849, 0, 0, 634), (12793, 18850, 0, 0, 634), (12793, 18851, 0, 0, 634), (12793, 18852, 0, 0, 634), (12793, 18853, 0, 0, 634), (12793, 24551, 0, 0, 125),
+(12793, 28118, 0, 0, 95), (12793, 28119, 0, 0, 95), (12793, 28120, 0, 0, 95), (12793, 28123, 0, 0, 99), (12793, 28239, 0, 0, 2404), (12793, 28240, 0, 0, 2404),
+(12793, 28241, 0, 0, 2404), (12793, 28242, 0, 0, 2404), (12793, 28243, 0, 0, 2404), (12793, 28244, 0, 0, 125), (12793, 28245, 0, 0, 125), (12793, 28246, 0, 0, 129),
+(12793, 28247, 0, 0, 129), (12793, 28362, 0, 0, 95), (12793, 28363, 0, 0, 99), (12793, 28377, 0, 0, 165), (12793, 28378, 0, 0, 165), (12793, 28379, 0, 0, 165),
+(12793, 28380, 0, 0, 165), (12793, 29592, 0, 0, 634), (12793, 30343, 0, 0, 2404), (12793, 30344, 0, 0, 2404), (12793, 30345, 0, 0, 2404), (12793, 30346, 0, 0, 2404),
+(12793, 31838, 0, 0, 1648), (12793, 31839, 0, 0, 1649), (12793, 31840, 0, 0, 1648), (12793, 31841, 0, 0, 1649), (12793, 31852, 0, 0, 1652), (12793, 31853, 0, 0, 1653),
+(12793, 31854, 0, 0, 1652), (12793, 31855, 0, 0, 1653), (12793, 32453, 0, 0, 1564), (12793, 32455, 0, 0, 460);
 
--- Raider Bork <Mount Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`= 12796;
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
-(12796, 18245, 423), (12796, 18246, 423), (12796, 18247, 423), (12796, 18248, 423);
-    
--- First Sergeant Hola'mahi <Reagent Vendor> - vanilla
+-- Stone Guard Zarg <Food and Drink>, Vanilla
+DELETE FROM `npc_vendor` WHERE `entry` = @Zarg; 
+INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
+(@Zarg, 117), (@Zarg, 159), (@Zarg, 1179), (@Zarg, 1205), (@Zarg, 1645), (@Zarg, 1708), (@Zarg, 2287), (@Zarg, 2593), (@Zarg, 2594), (@Zarg, 2595), (@Zarg, 2596), (@Zarg, 2723),
+(@Zarg, 3770), (@Zarg, 3771), (@Zarg, 4536), (@Zarg, 4537), (@Zarg, 4538), (@Zarg, 4539), (@Zarg, 4540), (@Zarg, 4541), (@Zarg, 4542), (@Zarg, 4544), (@Zarg, 4599), (@Zarg, 4601),
+(@Zarg, 4602), (@Zarg, 4604), (@Zarg, 4605), (@Zarg, 4606), (@Zarg, 4607), (@Zarg, 4608), (@Zarg, 8766), (@Zarg, 8948), (@Zarg, 8950), (@Zarg, 8952), (@Zarg, 8953);
+
+-- Stone Guard Zarg <Weapons Quartermaster>, TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 12794;
+INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES
+(12794,0,16345,0,0,2291,0), (12794,0,18826,0,0,2291,0), (12794,0,18828,0,0,2291,0), (12794,0,18831,0,0,2257,0), (12794,0,18835,0,0,2291,0), (12794,0,18837,0,0,2291,0), (12794,0,18840,0,0,2291,0), 
+(12794,0,18844,0,0,2291,0), (12794,0,18848,0,0,2291,0), (12794,0,18860,0,0,2291,0), (12794,0,18866,0,0,2291,0), (12794,0,18868,0,0,2257,0), (12794,0,18871,0,0,2257,0), (12794,0,18874,0,0,2257,0), 
+(12794,0,18877,0,0,2257,0), (12794,0,23464,0,0,2291,0), (12794,0,23465,0,0,2257,0), (12794,0,23466,0,0,2291,0), (12794,0,23467,0,0,2291,0), (12794,0,23468,0,0,2291,0), (12794,0,23469,0,0,2291,0);
+
+-- First Sergeant Hola'mahi <Reagent Vendor> - Vanilla
 DELETE FROM `npc_vendor` WHERE `entry` = @Hola; 
 INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
 (@Hola, 5565), (@Hola, 16583), (@Hola, 17020), (@Hola, 17021), (@Hola, 17026), (@Hola, 17028), (@Hola, 17029), (@Hola, 17030),
@@ -529,25 +536,10 @@ INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `Exte
 (12795,0,29602,0,0,652,0), (12795,0,29603,0,0,653,0), (12795,0,29604,0,0,444,0), (12795,0,29605,0,0,427,0), (12795,0,29612,0,0,465,0), (12795,0,29613,0,0,541,0), (12795,0,29614,0,0,542,0), 
 (12795,0,29615,0,0,463,0), (12795,0,29616,0,0,464,0), (12795,0,29617,0,0,465,0);
 
--- Brave Stonehide <Officer Accessories Quartermaster> - Vanilla
-DELETE FROM `npc_vendor` WHERE `entry` = @Stonehide;
-INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES
-(@Stonehide, 0, 15199, 0, 0, 1006, 0), (@Stonehide, 0, 18607, 0, 0, 386, 0), (@Stonehide, 0, 18839, 0, 0, 2354, 0), (@Stonehide, 0, 18841, 0, 0, 2354, 0);
-
--- Brave Stonehide <Officer Accessories Quartermaster> - TBC
-DELETE FROM `npc_vendor` WHERE `entry` = 12793;
-INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES 
-(12793, 15197, 0, 0, 1007), (12793, 15199, 0, 0, 1006), (12793, 15200, 0, 0, 838), (12793, 16335, 0, 0, 491), (12793, 16341, 0, 0, 986), (12793, 16486, 0, 0, 492),
-(12793, 16497, 0, 0, 492), (12793, 16532, 0, 0, 492), (12793, 18427, 0, 0, 1050), (12793, 18428, 0, 0, 930), (12793, 18429, 0, 0, 492), (12793, 18430, 0, 0, 931),
-(12793, 18432, 0, 0, 931), (12793, 18434, 0, 0, 492), (12793, 18435, 0, 0, 931), (12793, 18436, 0, 0, 931), (12793, 18437, 0, 0, 931), (12793, 18461, 0, 0, 774), 
-(12793, 18607, 0, 0, 386), (12793, 18834, 0, 0, 634), (12793, 18839, 0, 0, 460), (12793, 18841, 0, 0, 460), (12793, 18845, 0, 0, 634), (12793, 18846, 0, 0, 634),
-(12793, 18849, 0, 0, 634), (12793, 18850, 0, 0, 634), (12793, 18851, 0, 0, 634), (12793, 18852, 0, 0, 634), (12793, 18853, 0, 0, 634), (12793, 24551, 0, 0, 125),
-(12793, 28118, 0, 0, 95), (12793, 28119, 0, 0, 95), (12793, 28120, 0, 0, 95), (12793, 28123, 0, 0, 99), (12793, 28239, 0, 0, 2404), (12793, 28240, 0, 0, 2404),
-(12793, 28241, 0, 0, 2404), (12793, 28242, 0, 0, 2404), (12793, 28243, 0, 0, 2404), (12793, 28244, 0, 0, 125), (12793, 28245, 0, 0, 125), (12793, 28246, 0, 0, 129),
-(12793, 28247, 0, 0, 129), (12793, 28362, 0, 0, 95), (12793, 28363, 0, 0, 99), (12793, 28377, 0, 0, 165), (12793, 28378, 0, 0, 165), (12793, 28379, 0, 0, 165),
-(12793, 28380, 0, 0, 165), (12793, 29592, 0, 0, 634), (12793, 30343, 0, 0, 2404), (12793, 30344, 0, 0, 2404), (12793, 30345, 0, 0, 2404), (12793, 30346, 0, 0, 2404),
-(12793, 31838, 0, 0, 1648), (12793, 31839, 0, 0, 1649), (12793, 31840, 0, 0, 1648), (12793, 31841, 0, 0, 1649), (12793, 31852, 0, 0, 1652), (12793, 31853, 0, 0, 1653),
-(12793, 31854, 0, 0, 1652), (12793, 31855, 0, 0, 1653), (12793, 32453, 0, 0, 1564), (12793, 32455, 0, 0, 460);
+-- Raider Bork <Mount Quartermaster>
+DELETE FROM `npc_vendor` WHERE `entry`= 12796;
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
+(12796, 18245, 423), (12796, 18246, 423), (12796, 18247, 423), (12796, 18248, 423);
 
 -- Vixton Pinchwhistle <Arena Vendor> - TBC
 DELETE FROM `npc_vendor` WHERE `entry` = 20278;
@@ -598,7 +590,18 @@ INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `Exte
 (23396, 33313, 0, 0, 2285), (23396, 33937, 0, 0, 1758), (23396, 33940, 0, 0, 1758), (23396, 33943, 0, 0, 1758), (23396, 33946, 0, 0, 1758), (23396, 33949, 0, 0, 1758),
 (23396, 33952, 0, 0, 1758);
 
-
+-- Sergeant Kien <Armor Quartermaster> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 23447;
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES 
+(23447, 32785, 0, 0, 1911), (23447, 32786, 0, 0, 1911), (23447, 32787, 0, 0, 1911), (23447, 32788, 0, 0, 1911), (23447, 32789, 0, 0, 1911), (23447, 32790, 0, 0, 1911), 
+(23447, 32791, 0, 0, 1911), (23447, 32792, 0, 0, 1911), (23447, 32793, 0, 0, 1911), (23447, 32794, 0, 0, 1911), (23447, 32795, 0, 0, 1911), (23447, 32796, 0, 0, 1911), 
+(23447, 32797, 0, 0, 1923), (23447, 32798, 0, 0, 1923), (23447, 32799, 0, 0, 1923), (23447, 32800, 0, 0, 1923), (23447, 32801, 0, 0, 1923), (23447, 32802, 0, 0, 1923), 
+(23447, 32803, 0, 0, 1923), (23447, 32804, 0, 0, 1923), (23447, 32805, 0, 0, 1923), (23447, 32806, 0, 0, 1923), (23447, 32807, 0, 0, 1923), (23447, 32808, 0, 0, 1923), 
+(23447, 32809, 0, 0, 1935), (23447, 32810, 0, 0, 1935), (23447, 32811, 0, 0, 1935), (23447, 32812, 0, 0, 1935), (23447, 32813, 0, 0, 1935), (23447, 32814, 0, 0, 1935),
+(23447, 32816, 0, 0, 1935), (23447, 32817, 0, 0, 1935), (23447, 32818, 0, 0, 1935), (23447, 32819, 0, 0, 1935), (23447, 32820, 0, 0, 1935), (23447, 32821, 0, 0, 1935), 
+(23447, 32979, 0, 0, 1923), (23447, 32980, 0, 0, 1935), (23447, 32981, 0, 0, 1911), (23447, 32988, 0, 0, 1923), (23447, 32989, 0, 0, 1935), (23447, 32990, 0, 0, 1911),
+(23447, 32997, 0, 0, 1935), (23447, 32998, 0, 0, 1923), (23447, 32999, 0, 0, 1911), (23447, 33056, 0, 0, 129), (23447, 33057, 0, 0, 129), (23447, 33064, 0, 0, 129), 
+(23447, 33065, 0, 0, 127), (23447, 33066, 0, 0, 127), (23447, 33067, 0, 0, 127), (23447, 33068, 0, 0, 127);
 
 -- Sergeant Thunderhorn <Weapons Quartermaster> - vanilla
 DELETE FROM `npc_vendor` WHERE `entry` = @TH_Classic;

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -543,7 +543,7 @@ INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
 
 -- Vixton Pinchwhistle <Arena Vendor> - TBC
 DELETE FROM `npc_vendor` WHERE `entry` = 20278;
-INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES 
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES 
 (20278, 24544, 0, 0, 22), (20278, 24545, 0, 0, 22), (20278, 24546, 0, 0, 24), (20278, 24547, 0, 0, 22), (20278, 24549, 0, 0, 21), (20278, 24550, 0, 0, 26),
 (20278, 24552, 0, 0, 22), (20278, 24553, 0, 0, 22), (20278, 24554, 0, 0, 24), (20278, 24555, 0, 0, 22), (20278, 24556, 0, 0, 21), (20278, 24557, 0, 0, 26),
 (20278, 25830, 0, 0, 22), (20278, 25831, 0, 0, 22), (20278, 25832, 0, 0, 24), (20278, 25833, 0, 0, 22), (20278, 25834, 0, 0, 21), (20278, 25854, 0, 0, 24),
@@ -567,7 +567,7 @@ INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `Exte
 
 -- Krixel Pinchwhistle <Arena Vendor> - TBC
 DELETE FROM `npc_vendor` WHERE `entry` = 23396;
-INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES 
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES 
 (23396, 30486, 0, 0, 2285), (23396, 30487, 0, 0, 2283), (23396, 30488, 0, 0, 2285), (23396, 30489, 0, 0, 2285), (23396, 30490, 0, 0, 2288), (23396, 31958, 0, 0, 2283),
 (23396, 31959, 0, 0, 1664), (23396, 31960, 0, 0, 2285), (23396, 31961, 0, 0, 2283), (23396, 31962, 0, 0, 2285), (23396, 31963, 0, 0, 2285), (23396, 31964, 0, 0, 2288),
 (23396, 31965, 0, 0, 2287), (23396, 31966, 0, 0, 1664), (23396, 31967, 0, 0, 2283), (23396, 31968, 0, 0, 2285), (23396, 31969, 0, 0, 2285), (23396, 31971, 0, 0, 2288),

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -201,11 +201,6 @@ DELETE FROM `creature` WHERE `id1` = 12788;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 (612788, 12788, 1, 1650.95, -4212.82, 55.439, 0.182965, 25);
 
--- Sergeant Ba'sha <Accessories Quartermaster>
-DELETE FROM `creature` WHERE `id1` = 12799;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES
-(612799, 12799, 1, 1632.21, -4262.19, 49.027, 3.63029, 430);
-
 -- High Overlord Saurfang
 DELETE FROM `creature` WHERE `id1` = 14720;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
@@ -446,20 +441,21 @@ INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`,
 (@Zarg, 0, 12676, 1, 1, 12340),
 (@Hola, 0, 12677, 1, 1, 12340);
 
-UPDATE `creature_template` SET `subname` = 'Officer Accessories Quartermaster', `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = 12793;
-UPDATE `creature_template` SET `subname` = 'Weapons Quartermaster', `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = 12794;
-UPDATE `creature_template` SET `subname` = 'Armor Quartermaster', `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = 12795;
+UPDATE `creature_template` SET `subname` = 'Officer Accessories Quartermaster' WHERE `entry` = 12793;
+UPDATE `creature_template` SET `subname` = 'Weapons Quartermaster' WHERE `entry` = 12794;
+UPDATE `creature_template` SET `subname` = 'Armor Quartermaster'  WHERE `entry` = 12795;
 UPDATE `creature_template` SET `subname` = 'Mount Quartermaster' WHERE `entry` = 12796;
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (20278, 23396, 23447);
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_pre_tbc' WHERE `entry` IN (@TH_Classic, @LP_Classic);
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (@TH_TBC, @LP_TBC);
+
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_pre_tbc' WHERE `entry` IN (12799, @TH_Classic, @LP_Classic);
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (12793, 12794, 12795, 20278, 23396, 23447, @TH_TBC, @LP_TBC);
 
 UPDATE `creature_template_addon` SET `mount` = 0 WHERE `entry` = 12796;
 
 
-DELETE FROM `creature` WHERE `guid` IN (125688, 125690, 125695, 612792, 612793, 612794, 612795, 612796, 614581, 620278, 623396, 623447, 626396, 626397);
+DELETE FROM `creature` WHERE `guid` IN (125688, 125690, 125695, 612792, 612793, 612794, 612795, 612796, 612799, 614581, 620278, 623396, 623447, 626396, 626397);
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 
+(612799, 12799, 1, 1632.21, -4262.19, 49.027, 3.63029, 430),        -- Sergeant Ba'sha <Accessories Quartermaster>, Vanilla
 (626397, @LP_Classic, 1, 1669.78, -4200.1, 56.3815, 3.61023, 180),  -- Lady Palanseer <Armor Quartermaster>, Vanilla
 (612792, @LP_TBC, 1, 1669.78, -4200.1, 56.3815, 3.61023, 180),      -- Lady Palanseer <Armor Quartermaster>, TBC
 (612793, @Stonehide, 1, 1657.6, -4191.97, 56.383, 4.52365, 180),    -- Brave Stonehide <Officer Accessories Quartermaster>, Vanilla

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -483,7 +483,7 @@ INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `Exte
 
 -- Brave Stonehide <Officer Accessories Quartermaster> - TBC
 DELETE FROM `npc_vendor` WHERE `entry` = 12793;
-INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES 
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES 
 (12793, 15197, 0, 0, 1007), (12793, 15199, 0, 0, 1006), (12793, 15200, 0, 0, 838), (12793, 16335, 0, 0, 491), (12793, 16341, 0, 0, 986), (12793, 16486, 0, 0, 492),
 (12793, 16497, 0, 0, 492), (12793, 16532, 0, 0, 492), (12793, 18427, 0, 0, 1050), (12793, 18428, 0, 0, 930), (12793, 18429, 0, 0, 492), (12793, 18430, 0, 0, 931),
 (12793, 18432, 0, 0, 931), (12793, 18434, 0, 0, 492), (12793, 18435, 0, 0, 931), (12793, 18436, 0, 0, 931), (12793, 18437, 0, 0, 931), (12793, 18461, 0, 0, 774), 

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -221,11 +221,6 @@ DELETE FROM `creature` WHERE `id1` = 12794;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 (612794, 12794, 1, 1641.65, -4197.52, 56.3823, 5.41219, 180);
 
--- First Sergeant Hola'mahi <Reagent Vendor>
-DELETE FROM `creature` WHERE `id1` = 12795;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
-(612795, 12795, 1, 1673.9, -4216, 56.3826, 2.93578, 180);
-
 -- Raider Bork <Mount Quartermaster>
 DELETE FROM `creature` WHERE `id1` = 12796;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
@@ -235,11 +230,6 @@ INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `posit
 DELETE FROM `creature` WHERE `id1` = 12799;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES
 (612799, 12799, 1, 1632.21, -4262.19, 49.027, 3.63029, 430);
-
--- Sergeant Thunderhorn <Weapons Quartermaster>
-DELETE FROM `creature` WHERE `id1` = 14581;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES
-(614581, 14581, 1, 1644.52, -4195.26, 56.3826, 5.43078, 180);
 
 -- High Overlord Saurfang
 DELETE FROM `creature` WHERE `id1` = 14720;
@@ -334,9 +324,6 @@ UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12792;
 -- Brave Stonehide <Officer Accessories Quartermaster>
 UPDATE `creature_template` SET `subname`='Officer Accessories Quartermaster' WHERE `entry`=12793;
 
--- First Sergeant Hola'mahi <Reagent Vendor>
-UPDATE `creature_template` SET `subname`='Reagent Vendor' WHERE `entry`=12795;
-
 -- Stone Guard Zarg <Food and Drink>
 UPDATE `creature_template` SET `subname`='Food and Drink' WHERE `entry`=12794;
 
@@ -354,9 +341,6 @@ UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14376;
 
 -- Scout Tharr
 UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14377;
-
--- Sergeant Thunderhorn <Weapons Quartermaster>
-UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=14581;
 
 -- High Overlord Saurfang
 UPDATE `creature_template` SET `minlevel`=62, `maxlevel`=62 WHERE `entry`=14720;
@@ -469,15 +453,6 @@ INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
 -- Brave Stonehide <Officer Accessories Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=12793 AND `item` IN (15197, 15200, 16335, 16341, 16486, 16497, 16532, 18427, 18428, 18429, 18430, 18432, 18434, 18435, 18436, 18437, 18461, 18834, 18845, 18846, 18849, 18850, 18851, 18852, 18853, 24551, 28118, 28119, 28120, 28123, 28239, 28240, 28241, 28242, 28243, 28246, 28247, 28362, 28363, 28377, 28378, 29592, 30343, 30344, 30345, 30346, 31838, 31839, 31840, 31841, 31852, 31853, 31854, 31855, 32453, 32455, 37865, 38588, 44957);
 
--- First Sergeant Hola'mahi <Reagent Vendor>
-DELETE FROM `npc_vendor` WHERE `entry`=12795 AND `item` IN 
-    (16533, 16534, 16535, 16536, 16539, 16540, 16541, 16542, 16543, 16544, 16545, 16548, 16549, 16550, 16551, 16552, 16554, 16555, 16558, 
-    16560, 16561, 16562, 16563, 16564, 16565, 16566, 16567, 16568, 16569, 16571, 16573, 16574, 16577, 16578, 16579, 16580, 17586, 17588, 
-    17590, 17591, 17592, 17593, 17618, 17620, 17622, 17623, 17624, 17625, 22843, 22852, 22855, 22856, 22857, 22858, 22859, 
-    22860, 22862, 22863, 22864, 22865, 22867, 22868, 22869, 22870, 22872, 22873, 22874, 22875, 22876, 22877, 22878, 22879, 
-    22880, 22881, 22882, 22883, 22884, 22885, 22886, 22887, 23243, 23244, 23251, 23252, 23253, 23254, 23255, 23256, 23257, 23258, 23259, 
-    23260, 23261, 23262, 23263, 23264, 29600, 29601, 29602, 29603, 29604, 29605, 29612, 29613, 29614, 29615, 29616, 29617);
-
 DELETE FROM `npc_vendor` WHERE `entry`=12795 AND `item` IN (5565, 16583, 17020, 17021, 17026, 17028, 17029, 17030, 17031, 17032, 17033, 17034, 17035, 17036, 17037, 17038);
 INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
     (12795, 5565), (12795, 16583), (12795, 17020), (12795, 17021), (12795, 17026), (12795, 17028), (12795, 17029), (12795, 17030),
@@ -499,16 +474,96 @@ DELETE FROM `npc_vendor` WHERE `entry`=12796 AND `item` IN (29466, 29469, 29470,
 DELETE FROM `npc_vendor` WHERE `entry`=12796 AND `item` IN (18245, 18246, 18247, 18248);
 INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12796, 18245, 423), (12796, 18246, 423), (12796, 18247, 423), (12796, 18248, 423);
 
--- Sergeant Thunderhorn <Weapons Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=14581 AND `item` IN (16345, 18826, 18828, 18831, 18835, 18837, 18840, 18844, 18848, 18860, 18866, 18868, 18871, 18874, 18877, 23464, 23465, 23466, 23467, 23468, 23469);
+
+
+
+SET @Hola       := 112795; -- First Sergeant Hola'mahi, Vanilla version
+SET @TH_Classic := 26396;  -- Sergeant Thunderhorn, Vanilla version
+SET @TH_TBC     := 14581;  -- Sergeant Thunderhorn, TBC version
+
+
+DELETE FROM `creature_template` WHERE `entry` = @Hola;
+INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`, `KillCredit1`, `KillCredit2`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, 
+`exp`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `speed_swim`, `speed_flight`, `detection_range`, `scale`, `rank`, `dmgschool`, `DamageModifier`, `BaseAttackTime`, `RangeAttackTime`, 
+`BaseVariance`, `RangeVariance`, `unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, `trainer_type`, `trainer_spell`, `trainer_class`, `trainer_race`, `type`, `type_flags`, 
+`lootid`, `pickpocketloot`, `skinloot`, `PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`, `AIName`, `MovementType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `ExperienceModifier`, 
+`RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `spell_school_immune_mask`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES 
+
+(@Hola, 0, 0, 0, 0, 0, 'First Sergeant Hola\'mahi', 'Reagent Vendor', NULL, 0, 55, 55, 0, 125, 130, 1, 1.14286, 1, 1, 18, 1, 0, 0, 1.2, 2000, 1551, 1, 1, 1, 768, 2048, 0, 0, 0, 0, 0, 0, 7, 4096, 0, 0, 0, 0, 0, 0, 0, '', 1, 1, 2, 1, 1, 1, 0, 0, 1, 0, 0, 0, 'npc_ipp_pre_tbc', 12340);
+
+
+UPDATE `creature_template` SET `subname` = 'Armor Quartermaster', `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = 12795;     
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_pre_tbc' WHERE `entry` = @TH_Classic;
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` = @TH_TBC;
+
+DELETE FROM `creature_template_locale` WHERE `entry` = @Hola;
+INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES 
+(@Hola, 'deDE', 'Stabsfeldwebel Hola\'mahi', 'Reagent Vendor', 18019),
+(@Hola, 'esES', 'Gran capataz Hola\'mahi', 'Reagent Vendor', 18019),
+(@Hola, 'esMX', 'Gran capataz Hola\'mahi', 'Reagent Vendor', 18019),
+(@Hola, 'frFR', 'Sergent Hola\'mahi', 'Reagent Vendor', 18019),
+(@Hola, 'koKR', '선임하사 홀라마히', 'Reagent Vendor', 18019),
+(@Hola, 'ruRU', 'Первый сержант Хола\'махи', 'Reagent Vendor', 18019),
+(@Hola, 'zhCN', '一等军士长霍拉麦', 'Reagent Vendor', 18019),
+(@Hola, 'zhTW', '一等士官霍拉麥', 'Reagent Vendor', 18019);
+
+DELETE FROM `creature_template_model` WHERE `CreatureID` = @Hola;
+INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES 
+(@Hola, 0, 12677, 1, 1, 12340);
+
+
+DELETE FROM `creature` WHERE `guid` IN (612795, 614581, 626396);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
+(612795, @Hola, 1, 1673.9, -4216, 56.3826, 2.93578, 180),
+(614581, @TH_TBC, 1, 1669.09, -4196.78, 56.4831, 4.10416, 180),
+(626396, @TH_Classic, 1, 1644.52, -4195.26, 56.3826, 5.43078, 180);
+    
+-- First Sergeant Hola'mahi <Reagent Vendor> - vanilla
+DELETE FROM `npc_vendor` WHERE `entry` = @Hola; 
+INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
+(@Hola, 5565), (@Hola, 16583), (@Hola, 17020), (@Hola, 17021), (@Hola, 17026), (@Hola, 17028), (@Hola, 17029), (@Hola, 17030),
+(@Hola, 17031), (@Hola, 17032), (@Hola, 17033), (@Hola, 17034), (@Hola, 17035), (@Hola, 17036), (@Hola, 17037), (@Hola, 17038);
+
+-- First Sergeant Hola'mahi <Armor Quartermaster> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 12795;
+INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES 
+(12795,0,16533,0,0,464,0), (12795,0,16534,0,0,542,0), (12795,0,16535,0,0,463,0), (12795,0,16536,0,0,465,0), (12795,0,16539,0,0,465,0), (12795,0,16540,0,0,541,0), (12795,0,16541,0,0,463,0), 
+(12795,0,16542,0,0,464,0), (12795,0,16543,0,0,542,0), (12795,0,16544,0,0,465,0), (12795,0,16545,0,0,465,0), (12795,0,16548,0,0,541,0), (12795,0,16549,0,0,463,0), (12795,0,16550,0,0,464,0), 
+(12795,0,16551,0,0,465,0), (12795,0,16552,0,0,542,0), (12795,0,16554,0,0,465,0), (12795,0,16555,0,0,541,0), (12795,0,16558,0,0,465,0), (12795,0,16560,0,0,541,0), (12795,0,16561,0,0,464,0), 
+(12795,0,16562,0,0,465,0), (12795,0,16563,0,0,463,0), (12795,0,16564,0,0,542,0), (12795,0,16565,0,0,463,0), (12795,0,16566,0,0,464,0), (12795,0,16567,0,0,542,0), (12795,0,16568,0,0,465,0), 
+(12795,0,16569,0,0,465,0), (12795,0,16571,0,0,541,0), (12795,0,16573,0,0,465,0), (12795,0,16574,0,0,541,0), (12795,0,16577,0,0,463,0), (12795,0,16578,0,0,464,0), (12795,0,16579,0,0,542,0), 
+(12795,0,16580,0,0,465,0), (12795,0,17586,0,0,465,0), (12795,0,17588,0,0,541,0), (12795,0,17590,0,0,465,0), (12795,0,17591,0,0,464,0), (12795,0,17592,0,0,463,0), (12795,0,17593,0,0,542,0), 
+(12795,0,17618,0,0,465,0), (12795,0,17620,0,0,541,0), (12795,0,17622,0,0,465,0), (12795,0,17623,0,0,464,0), (12795,0,17624,0,0,463,0), (12795,0,17625,0,0,542,0), (12795,0,22843,0,0,427,0), 
+(12795,0,22852,0,0,427,0), (12795,0,22855,0,0,427,0), (12795,0,22856,0,0,427,0), (12795,0,22857,0,0,427,0), (12795,0,22858,0,0,427,0), (12795,0,22859,0,0,427,0), (12795,0,22860,0,0,427,0),
+(12795,0,22862,0,0,428,0), (12795,0,22863,0,0,428,0), (12795,0,22864,0,0,428,0), (12795,0,22865,0,0,428,0), (12795,0,22867,0,0,428,0), (12795,0,22868,0,0,428,0), (12795,0,22869,0,0,428,0), 
+(12795,0,22870,0,0,428,0), (12795,0,22872,0,0,652,0), (12795,0,22873,0,0,653,0), (12795,0,22874,0,0,652,0), (12795,0,22875,0,0,653,0), (12795,0,22876,0,0,652,0), (12795,0,22877,0,0,652,0), 
+(12795,0,22878,0,0,653,0), (12795,0,22879,0,0,652,0), (12795,0,22880,0,0,653,0), (12795,0,22881,0,0,653,0), (12795,0,22882,0,0,653,0), (12795,0,22883,0,0,653,0), (12795,0,22884,0,0,652,0), 
+(12795,0,22885,0,0,652,0), (12795,0,22886,0,0,652,0), (12795,0,22887,0,0,653,0), (12795,0,23243,0,0,427,0), (12795,0,23244,0,0,444,0), (12795,0,23251,0,0,444,0), (12795,0,23252,0,0,427,0), 
+(12795,0,23253,0,0,444,0), (12795,0,23254,0,0,427,0), (12795,0,23255,0,0,444,0), (12795,0,23256,0,0,427,0), (12795,0,23257,0,0,444,0), (12795,0,23258,0,0,427,0), (12795,0,23259,0,0,444,0), 
+(12795,0,23260,0,0,427,0), (12795,0,23261,0,0,444,0), (12795,0,23262,0,0,427,0), (12795,0,23263,0,0,444,0), (12795,0,23264,0,0,427,0), (12795,0,29600,0,0,428,0), (12795,0,29601,0,0,427,0), 
+(12795,0,29602,0,0,652,0), (12795,0,29603,0,0,653,0), (12795,0,29604,0,0,444,0), (12795,0,29605,0,0,427,0), (12795,0,29612,0,0,465,0), (12795,0,29613,0,0,541,0), (12795,0,29614,0,0,542,0), 
+(12795,0,29615,0,0,463,0), (12795,0,29616,0,0,464,0), (12795,0,29617,0,0,465,0);
+
+
+-- Sergeant Thunderhorn <Weapons Quartermaster> - vanilla
+DELETE FROM `npc_vendor` WHERE `entry` = @TH_Classic;
 INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
-    (14581, 16345, 2291), (14581, 18826, 2291), (14581, 18828, 2291), (14581, 18831, 2257), (14581, 18835, 2291), (14581, 18837, 2291), (14581, 18840, 2291), 
-    (14581, 18844, 2291), (14581, 18848, 2291), (14581, 18860, 2291), (14581, 18866, 2291), (14581, 18868, 2257), (14581, 18871, 2257), (14581, 18874, 2257), 
-    (14581, 18877, 2257), (14581, 23464, 2291), (14581, 23465, 2257), (14581, 23466, 2291), (14581, 23467, 2291), (14581, 23468, 2291), (14581, 23469, 2291);
+(@TH_Classic, 16345, 2291), (@TH_Classic, 18826, 2291), (@TH_Classic, 18828, 2291), (@TH_Classic, 18831, 2257), (@TH_Classic, 18835, 2291), (@TH_Classic, 18837, 2291), (@TH_Classic, 18840, 2291), 
+(@TH_Classic, 18844, 2291), (@TH_Classic, 18848, 2291), (@TH_Classic, 18860, 2291), (@TH_Classic, 18866, 2291), (@TH_Classic, 18868, 2257), (@TH_Classic, 18871, 2257), (@TH_Classic, 18874, 2257), 
+(@TH_Classic, 18877, 2257), (@TH_Classic, 23464, 2291), (@TH_Classic, 23465, 2257), (@TH_Classic, 23466, 2291), (@TH_Classic, 23467, 2291), (@TH_Classic, 23468, 2291), (@TH_Classic, 23469, 2291);
+
+-- Sergeant Thunderhorn <Weapons Quartermaster> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = @TH_TBC;
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES
+(@TH_TBC, 28293, 0, 0, 2237), (@TH_TBC, 28917, 0, 0, 2237), (@TH_TBC, 28918, 0, 0, 2237), (@TH_TBC, 28919, 0, 0, 2237), (@TH_TBC, 28920, 0, 0, 2239),
+(@TH_TBC, 28921, 0, 0, 2240), (@TH_TBC, 28922, 0, 0, 2240), (@TH_TBC, 28923, 0, 0, 2237), (@TH_TBC, 28924, 0, 0, 2240), (@TH_TBC, 28925, 0, 0, 2239),
+(@TH_TBC, 28926, 0, 0, 2240), (@TH_TBC, 28928, 0, 0, 2239), (@TH_TBC, 28929, 0, 0, 2240), (@TH_TBC, 28930, 0, 0, 2240), (@TH_TBC, 28931, 0, 0, 2238),
+(@TH_TBC, 28933, 0, 0, 2237), (@TH_TBC, 28935, 0, 0, 2237), (@TH_TBC, 28937, 0, 0, 2239), (@TH_TBC, 28938, 0, 0, 2242), (@TH_TBC, 28939, 0, 0, 2242);
+
 
 
 /* Hide certain vendor items until the player has reached the progression tier for them */
-DELETE FROM `conditions` WHERE `SourceGroup` IN (12792, 14581);
+DELETE FROM `conditions` WHERE `SourceGroup` IN (12792, @TH_Classic, @TH_TBC);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
 `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
 -- 
@@ -561,27 +616,27 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (23, 12792, 17624, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Warlords Satin Robes until the player has completed PROGRESSION_ONYXIA'),
 (23, 12792, 17625, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Lady Palanseer will not sell Generals Satin Leggings until the player has completed PROGRESSION_ONYXIA'),    
 --
-(23, 14581, 16345, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Blade until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18826, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Shield Wall until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18828, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Cleaver until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18831, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Battle Axe until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18835, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Recurve until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18837, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Crossbow until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18840, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Razor until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18844, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Right Claw until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18848, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Left Claw until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18860, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Street Sweeper until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18866, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Bludgeon until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18868, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Pulverizer until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18871, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Pig Sticker until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18874, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords War Staff until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 18877, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Greatsword until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 23464, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Battle Mace until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 23465, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Destroyer until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 23466, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Spellblade until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 23467, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Quickblade until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 23468, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Tome of Destruction until the player has completed PROGRESSION_ONYXIA'),
-(23, 14581, 23469, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Tome of Mending until the player has completed PROGRESSION_ONYXIA');
+(23, @TH_Classic, 16345, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Blade until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18826, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Shield Wall until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18828, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Cleaver until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18831, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Battle Axe until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18835, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Recurve until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18837, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Crossbow until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18840, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Razor until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18844, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Right Claw until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18848, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Left Claw until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18860, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Street Sweeper until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18866, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Bludgeon until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18868, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Pulverizer until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18871, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Pig Sticker until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18874, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords War Staff until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 18877, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Greatsword until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 23464, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Battle Mace until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 23465, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Destroyer until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 23466, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Spellblade until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 23467, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Quickblade until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 23468, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Tome of Destruction until the player has completed PROGRESSION_ONYXIA'),
+(23, @TH_Classic, 23469, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Sergeant Thunderhorn will not sell High Warlords Tome of Mending until the player has completed PROGRESSION_ONYXIA');
 
 DELETE FROM `creature` WHERE `id1` IN 
 (34038,  -- Sergeant Thunderhorn <Apprentice Armor Quartermaster>

--- a/sql/world/base/zone_stormwind.sql
+++ b/sql/world/base/zone_stormwind.sql
@@ -374,6 +374,8 @@ UPDATE `creature_template` SET `subname` = 'Mount Vendor' WHERE `entry` = 12783;
 UPDATE `creature_template` SET `subname` = 'Weapons Quartermaster' WHERE `entry` = 12784; 
 UPDATE `creature_template` SET `subname` = 'Armor Quartermaster' WHERE `entry` = 12785;
 UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55 WHERE `entry`IN (26393, 26394); 
+UPDATE `creature_template` SET `npcflag` = 4224 WHERE `entry` IN (24671, 24672);
+
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_pre_tbc' WHERE `entry` IN (12805, 26393, 26394);
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (12781, 12784, 12785, 20278, 23396, 23446, 24671, 24672);
 

--- a/sql/world/base/zone_stormwind.sql
+++ b/sql/world/base/zone_stormwind.sql
@@ -369,11 +369,9 @@ INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`,
 (@Biggins, 0, 12669, 1, 1, 12340),
 (@Clate, 0, 12925, 1, 1, 12340);
 
-UPDATE `creature_template` SET `subname` = 'Officer Accessories Quartermaster' WHERE `entry` = 12781; 
 UPDATE `creature_template` SET `subname` = 'Mount Vendor' WHERE `entry` = 12783;
 UPDATE `creature_template` SET `subname` = 'Weapons Quartermaster' WHERE `entry` = 12784; 
 UPDATE `creature_template` SET `subname` = 'Armor Quartermaster' WHERE `entry` = 12785;
-UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55 WHERE `entry`IN (26393, 26394); 
 UPDATE `creature_template` SET `npcflag` = 4224 WHERE `entry` IN (24671, 24672);
 
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_pre_tbc' WHERE `entry` IN (12805, 26393, 26394);
@@ -393,7 +391,7 @@ INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `posit
 (624671, 24671, 0, -8778.3, 432.142, 105.309, 4.17386, 180),    -- Captain O'Neal <Weapons Quartermaster>, TBC
 (626393, 26393, 0, -8768.77, 401.647, 109.665, 2.22999, 180),   -- Captain Dirgehammer <Armor Quartermaster>, Vanilla
 (624672, 24672, 0, -8773.33, 427.279, 105.233, 3.84677, 180),   -- Captain Dirgehammer <Armor Quartermaster>, TBC
-(133928, 12784, 0, -8764.6, 413.632, 103.922, 0.693375, 180),    -- Lieutenant Jackspring <Weapons Quartermaster>, TBC 
+(133928, 12784, 0, -8764.6, 413.632, 103.922, 0.693375, 180),   -- Lieutenant Jackspring <Weapons Quartermaster>, TBC 
 (720278, 20278, 0, -8789.08, 425.681, 105.233, 5.68294, 180),   -- Vixton Pinchwhistle <Arena Vendor>, TBC
 (723396, 23396, 0, -8786.12, 428.386, 105.233, 5.5871, 180),    -- Krixel Pinchwhistle <Arena Vendor>, TBC
 (623446, 23446, 0, -8785.74, 420.484, 105.233, 0.701937, 180),  -- Lieutenant Tristia <Armor Quartermaster>, TBC

--- a/sql/world/base/zone_stormwind.sql
+++ b/sql/world/base/zone_stormwind.sql
@@ -133,11 +133,6 @@ DELETE FROM `creature` WHERE `id1`= 7798;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 (607798, 7798, 0, -8422.17, 630.877, 95.8402, 5.044, 430);
 
--- Lieutenant Karter <War Mount Quartermaster>
-DELETE FROM `creature` WHERE `id1`= 12783;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
-(612783, 12783, 0, -8779.7, 432.158, 105.233, 5.36374, 300);
-
 -- Lieutenant Rachel Vaccar <Outland Armor Quartermaster>
 DELETE FROM `creature` WHERE `id1`= 12778;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
@@ -225,9 +220,6 @@ UPDATE `creature_template` SET `subname`='Weapon Crafter' WHERE `entry`=7232;
 -- Lieutenant Rachel Vaccar <Outland Armor Quartermaster>
 UPDATE `creature_template` SET `subname`=NULL, `minlevel`=55, `maxlevel`=55, `npcflag`=0 WHERE `entry`=12778;
 
--- Lieutenant Karter <War Mount Quartermaster>
-UPDATE `creature_template` SET `subname`='Mount Vendor' WHERE `entry`=12783;
-
 -- Officer Jaxon
 UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14423;
 
@@ -242,9 +234,6 @@ UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60, `rank`=0 WHERE `ent
 
 -- King Varian Wrynn
 UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=29611;
-
--- Lieutenant Karter <Mount Vendor>
-UPDATE `creature_template_addon` SET `mount`=0 WHERE `entry`=12783;
 
 -- Tomas <Cook>
 DELETE FROM `npc_trainer` WHERE `ID`=1430;
@@ -335,28 +324,6 @@ DELETE FROM `npc_vendor` WHERE `entry`=6740 AND `item` IN (4536, 4537, 4538, 453
 DELETE FROM `npc_vendor` WHERE `entry`=12778;
 
 
-
--- Lieutenant Karter <War Mount Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12783 AND `item` IN (29465, 29467, 29468, 29471, 35906);
-DELETE FROM `npc_vendor` WHERE `entry`=12783 AND `item` IN (18241, 18242, 18243, 18244);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12783, 18241, 423), (12783, 18242, 423), (12783, 18243, 423), (12783, 18244, 423);
-
--- Officer Areyn <Accessories Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12805 AND `item` IN (18445, 18447, 18448, 18449, 18454, 18455, 18456, 18457, 18854, 18856, 18858, 18859, 18862, 18863, 18864);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES 
-    (12805, 18445, 492), (12805, 18447, 931), (12805, 18448, 492), (12805, 18449, 931), (12805, 18454, 492), (12805, 18455, 931), (12805, 18456, 492), (12805, 18457, 931), 
-    (12805, 18854, 634), (12805, 18856, 634), (12805, 18858, 634), (12805, 18859, 634), (12805, 18862, 634), (12805, 18863, 634), (12805, 18864, 634);
-
-
-
-
-
-
-
-
-
-
-
 SET @Biggins     := 112781; -- Master Sergeant Biggins <Officer Accessories Quartermaster>, Vanilla
 SET @Clate       := 112785; -- Stone Guard Zarg <Food and Drink>, Vanilla
 
@@ -402,16 +369,18 @@ INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`,
 (@Biggins, 0, 12669, 1, 1, 12340),
 (@Clate, 0, 12925, 1, 1, 12340);
 
-
 UPDATE `creature_template` SET `subname` = 'Officer Accessories Quartermaster' WHERE `entry` = 12781; 
+UPDATE `creature_template` SET `subname` = 'Mount Vendor' WHERE `entry` = 12783;
 UPDATE `creature_template` SET `subname` = 'Weapons Quartermaster' WHERE `entry` = 12784; 
 UPDATE `creature_template` SET `subname` = 'Armor Quartermaster' WHERE `entry` = 12785;
 UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55 WHERE `entry`IN (26393, 26394); 
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_pre_tbc' WHERE `entry` IN (12805, 26393, 26394);
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (12781, 12784, 12785, 24671, 24672);
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (12781, 12784, 12785, 20278, 23396, 23446, 24671, 24672);
+
+UPDATE `creature_template_addon` SET `mount` = 0 WHERE `entry`= 12783;
 
 
-DELETE FROM `creature` WHERE `guid` IN (133928, 133926, 133929, 612781, 612785, 624671, 624672, 626393, 626394);
+DELETE FROM `creature` WHERE `guid` IN (133928, 133926, 133929, 612781, 612783, 612785, 623446, 624671, 624672, 626393, 626394, 720278, 723396);
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 --
 (612781, @Biggins, 0, -8777.4, 417.124, 103.921, 6.23553, 180), -- Master Sergeant Biggins <Officer Accessories Quartermaster>, Vanilla
@@ -422,8 +391,11 @@ INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `posit
 (624671, 24671, 0, -8778.3, 432.142, 105.309, 4.17386, 180),    -- Captain O'Neal <Weapons Quartermaster>, TBC
 (626393, 26393, 0, -8768.77, 401.647, 109.665, 2.22999, 180),   -- Captain Dirgehammer <Armor Quartermaster>, Vanilla
 (624672, 24672, 0, -8773.33, 427.279, 105.233, 3.84677, 180),   -- Captain Dirgehammer <Armor Quartermaster>, TBC
-(133928, 12784, 0, -8764.6, 413.632, 103.922, 0.693375, 180;    -- Lieutenant Jackspring <Weapons Quartermaster>, TBC 
-
+(133928, 12784, 0, -8764.6, 413.632, 103.922, 0.693375, 180,    -- Lieutenant Jackspring <Weapons Quartermaster>, TBC 
+(720278, 20278, 0, -8789.08, 425.681, 105.233, 5.68294, 180),   -- Vixton Pinchwhistle <Arena Vendor>, TBC
+(723396, 23396, 0, -8786.12, 428.386, 105.233, 5.5871, 180),    -- Krixel Pinchwhistle <Arena Vendor>, TBC
+(623446, 23446, 0, -8785.74, 420.484, 105.233, 0.701937, 180),  -- Lieutenant Tristia <Armor Quartermaster>, TBC
+(612783, 12783, 0, -8779.7, 432.158, 105.233, 5.36374, 180);    -- Lieutenant Karter <Mount Vendor>
 
 
 -- Master Sergeant Biggins <Officer Accessories Quartermaster> - Vanilla
@@ -446,6 +418,18 @@ INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost
 (12781, 31840, 0, 0, 1648), (12781, 31841, 0, 0, 1649), (12781, 31852, 0, 0, 1652), (12781, 31853, 0, 0, 1653), (12781, 31854, 0, 0, 1652), (12781, 31855, 0, 0, 1653),
 (12781, 32453, 0, 0, 1564), (12781, 32455, 0, 0, 460);
 
+-- Officer Areyn <Accessories Quartermaster>
+DELETE FROM `npc_vendor` WHERE `entry` = 12805;
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES 
+(12805, 18445, 492), (12805, 18447, 931), (12805, 18448, 492), (12805, 18449, 931), (12805, 18454, 492), 
+(12805, 18455, 931), (12805, 18456, 492), (12805, 18457, 931), (12805, 18854, 634), (12805, 18856, 634), 
+(12805, 18858, 634), (12805, 18859, 634), (12805, 18862, 634), (12805, 18863, 634), (12805, 18864, 634);
+
+-- Lieutenant Karter <War Mount Quartermaster>
+DELETE FROM `npc_vendor` WHERE `entry` = 12783;
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
+(12783, 18241, 423), (12783, 18242, 423), (12783, 18243, 423), (12783, 18244, 423), (12783, 35906, 423);
+
 -- Lieutenant Jackspring <Weapons Quartermaster> - TBC
 DELETE FROM `npc_vendor` WHERE `entry` = 12784;
 INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES 
@@ -461,6 +445,7 @@ INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
 (@Clate, 4540), (@Clate, 4541), (@Clate, 4542), (@Clate, 4544), (@Clate, 4599), (@Clate, 4601), (@Clate, 4602), (@Clate, 4604), (@Clate, 4605), 
 (@Clate, 4606), (@Clate, 4607), (@Clate, 4608), (@Clate, 8766), (@Clate, 8948), (@Clate, 8950), (@Clate, 8952), (@Clate, 8953);
 
+-- Sergeant Major Clate <Armor Quartermaster> - TBC 
 DELETE FROM `npc_vendor` WHERE `entry` = 12785;
 INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
 (12785, 16437, 465), (12785, 16440, 541), (12785, 16441, 464), (12785, 16442, 542), (12785, 16443, 463), (12785, 16444, 465), (12785, 16446, 465), (12785, 16448, 541), (12785, 16449, 465),
@@ -475,7 +460,6 @@ INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
 (12785, 23305, 652), (12785, 23306, 444), (12785, 23307, 427), (12785, 23308, 444), (12785, 23309, 427), (12785, 23310, 444), (12785, 23311, 427), (12785, 23312, 444), (12785, 23313, 427),
 (12785, 23314, 444), (12785, 23315, 427), (12785, 23316, 444), (12785, 23317, 427), (12785, 23318, 444), (12785, 23319, 427), (12785, 29594, 427), (12785, 29595, 428), (12785, 29596, 652),
 (12785, 29597, 653), (12785, 29598, 444), (12785, 29599, 427), (12785, 29606, 465), (12785, 29607, 541), (12785, 29608, 542), (12785, 29609, 463), (12785, 29610, 464), (12785, 29611, 465);
-
 
 -- Lieutenant Tristia <Armor Quartermaster> - TBC
 DELETE FROM `npc_vendor` WHERE `entry` = 23446;
@@ -538,7 +522,6 @@ INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost
 (24672, 31622, 0, 0, 2263), (24672, 31623, 0, 0, 2265), (24672, 31624, 0, 0, 2267), (24672, 31625, 0, 0, 2259), (24672, 31630, 0, 0, 2259), (24672, 31631, 0, 0, 2261),
 (24672, 31632, 0, 0, 2263), (24672, 31633, 0, 0, 2265), (24672, 31634, 0, 0, 2267), (24672, 31640, 0, 0, 2259), (24672, 31641, 0, 0, 2261), (24672, 31642, 0, 0, 2263),
 (24672, 31643, 0, 0, 2265), (24672, 31644, 0, 0, 2267);
-
 
 
 /* Hide certain vendor items until the player has reached the progression tier for them */
@@ -615,7 +598,9 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (23, 26394, 23453, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Tome of Restoration until the player has completed PROGRESSION_ONYXIA'),
 (23, 26394, 23454, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Warhammer until the player has completed PROGRESSION_ONYXIA'),
 (23, 26394, 23455, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Demolisher until the player has completed PROGRESSION_ONYXIA'),
-(23, 26394, 23456, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Swiftblade until the player has completed PROGRESSION_ONYXIA');
+(23, 26394, 23456, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Swiftblade until the player has completed PROGRESSION_ONYXIA'),
+--
+(23, 12783, 35906, 0, 0, 8, 0, 66008, 0, 0, 0, 0, 0, '', 'Lieutenant Karter will not sell Reins of the Black War Elekk until the player has completed PROGRESSION_PRE_TBC');
 
 
 UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_pre_tbc' WHERE `guid` IN (61936, 61940, 61942, 61944, 61945, 61946, 61947, 61949, 61951);

--- a/sql/world/base/zone_stormwind.sql
+++ b/sql/world/base/zone_stormwind.sql
@@ -138,12 +138,6 @@ DELETE FROM `creature` WHERE `id1`= 12783;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 (612783, 12783, 0, -8779.7, 432.158, 105.233, 5.36374, 300);
 
--- Captain Dirgehammer <Armor Quartermaster>
-DELETE FROM `creature` WHERE `id1`= 12777;
-DELETE FROM `creature` WHERE `id1`= 34075;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
-(612777, 12777, 0, -8768.77, 401.647, 109.665, 2.22999, 300);
-
 -- Lieutenant Rachel Vaccar <Outland Armor Quartermaster>
 DELETE FROM `creature` WHERE `id1`= 12778;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
@@ -159,30 +153,11 @@ DELETE FROM `creature` WHERE `id1`= 12780;
 INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 (612780, 12780, 0, -8779.46, 427.206, 105.275, 3.80473, 300);
 
--- Master Sergeant Biggins <Accessories Quartermaster>
-DELETE FROM `creature` WHERE `id1`= 12781;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
-(612781, 12781, 0, -8777.4, 417.124, 103.921, 6.23553, 300);
-
--- Captain O'Neal <Weapons Quartermaster>
-DELETE FROM `creature` WHERE `id1`= 12782;
-DELETE FROM `creature` WHERE `id1`= 34081;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
-(612782, 12782, 0, -8778.3, 432.142, 105.309, 4.17386, 300);
-
--- Lieutenant Jackspring <Legacy Weapon Quartermaster>
-DELETE FROM `creature` WHERE `id1`= 12784;
-
 -- Knight-Lieutenant T'Maire Sydes <Northrend Armor Quartermaster>
 DELETE FROM `creature` WHERE `id1`= 40607;
 
 -- Lieutenant Tristia <Veteran Armor Quartermaster>
 DELETE FROM `creature` WHERE `id1`= 34078;
-
--- Sergeant Major Clate <Legacy Armor Quartermaster>
-DELETE FROM `creature` WHERE `id1`= 12785;
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
-(612785, 12785, 0, -8771.31, 401.973, 109.665, 0.659191, 300);
 
 -- Officer Areyn <Accessories Quartermaster>
 DELETE FROM `creature` WHERE `id1`= 12805;
@@ -250,17 +225,8 @@ UPDATE `creature_template` SET `subname`='Weapon Crafter' WHERE `entry`=7232;
 -- Lieutenant Rachel Vaccar <Outland Armor Quartermaster>
 UPDATE `creature_template` SET `subname`=NULL, `minlevel`=55, `maxlevel`=55, `npcflag`=0 WHERE `entry`=12778;
 
--- Master Sergeant Biggins <Accessories Quartermaster>
-UPDATE `creature_template` SET `subname`='Officer Accessories Quartermaster' WHERE `entry`=12781;
-
--- Captain O'Neal <Weapons Quartermaster>
-UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12782;
-
 -- Lieutenant Karter <War Mount Quartermaster>
 UPDATE `creature_template` SET `subname`='Mount Vendor' WHERE `entry`=12783;
-
--- Sergeant Major Clate <Legacy Armor Quartermaster>
-UPDATE `creature_template` SET `subname`='Food and Drink' WHERE `entry`=12785;
 
 -- Officer Jaxon
 UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14423;
@@ -365,61 +331,15 @@ DELETE FROM `npc_vendor` WHERE `entry`=5565 AND `item`=38426;
 -- Innkeeper Allison <Innkeeper>
 DELETE FROM `npc_vendor` WHERE `entry`=6740 AND `item` IN (4536, 4537, 4538, 4539, 4602, 8953, 27855, 27856, 28399, 33444, 33445, 33449, 35948, 35949, 35950, 35954);
 
--- Captain Dirgehammer <Armor Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12777 AND `item` IN 
-    (16437, 16440, 16441, 16442, 16443, 16444, 16446, 16448, 16449, 16450, 16451, 16452, 16453, 16454, 16455, 16456, 16457, 16459, 16462, 16463, 16465, 16466, 16467, 16468, 
-    16471, 16472, 16473, 16474, 16475, 16476, 16477, 16478, 16479, 16480, 16483, 16484, 17578, 17579, 17580, 17581, 17583, 17584, 17602, 17603, 17604, 17605, 17607, 17608, 
-    23272, 23273, 23274, 23275, 23276, 23277, 23278, 23279, 23280, 23281, 23282, 23283, 23284, 23285, 23286, 23287, 23288, 23289, 23290, 23291, 23292, 23293, 23294, 23295, 23296, 23297, 23298, 23299, 
-    23300, 23301, 23302, 23303, 23304, 23305, 23306, 23307, 23308, 23309, 23310, 23311, 23312, 23313, 23314, 23315, 23316, 23317, 23318, 23319);
-
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
-    (12777, 16437, 465), (12777, 16440, 541), (12777, 16441, 464), (12777, 16442, 542), (12777, 16443, 463), (12777, 16444, 465), (12777, 16446, 465), (12777, 16448, 541), (12777, 16449, 465),
-    (12777, 16450, 542), (12777, 16451, 464), (12777, 16452, 463), (12777, 16453, 463), (12777, 16454, 541), (12777, 16455, 464), (12777, 16456, 542), (12777, 16457, 465), (12777, 16459, 465),
-    (12777, 16462, 465), (12777, 16463, 541), (12777, 16465, 464), (12777, 16466, 463), (12777, 16467, 542), (12777, 16468, 465), (12777, 16471, 541), (12777, 16472, 465), (12777, 16473, 463),
-    (12777, 16474, 464), (12777, 16475, 542), (12777, 16476, 465), (12777, 16477, 463), (12777, 16478, 464), (12777, 16479, 542), (12777, 16480, 465), (12777, 16483, 465), (12777, 16484, 541),
-    (12777, 17578, 464), (12777, 17579, 542), (12777, 17580, 465), (12777, 17581, 463), (12777, 17583, 465), (12777, 17584, 541), (12777, 17602, 464), (12777, 17603, 542), (12777, 17604, 465),
-    (12777, 17605, 463), (12777, 17607, 465), (12777, 17608, 541), (12777, 23272, 652), (12777, 23273, 653), (12777, 23274, 428), (12777, 23275, 427), (12777, 23276, 444), (12777, 23277, 427),
-    (12777, 23278, 427), (12777, 23279, 428), (12777, 23280, 428), (12777, 23281, 427), (12777, 23282, 428), (12777, 23283, 427), (12777, 23284, 428), (12777, 23285, 427), (12777, 23286, 428),
-    (12777, 23287, 427), (12777, 23288, 428), (12777, 23289, 427), (12777, 23290, 428), (12777, 23291, 427), (12777, 23292, 652), (12777, 23293, 653), (12777, 23294, 652), (12777, 23295, 653),
-    (12777, 23296, 653), (12777, 23297, 652), (12777, 23298, 652), (12777, 23299, 653), (12777, 23300, 652), (12777, 23301, 653), (12777, 23302, 653), (12777, 23303, 652), (12777, 23304, 653),
-    (12777, 23305, 652), (12777, 23306, 444), (12777, 23307, 427), (12777, 23308, 444), (12777, 23309, 427), (12777, 23310, 444), (12777, 23311, 427), (12777, 23312, 444), (12777, 23313, 427),
-    (12777, 23314, 444), (12777, 23315, 427), (12777, 23316, 444), (12777, 23317, 427), (12777, 23318, 444), (12777, 23319, 427);
-
 -- Lieutenant Rachel Vaccar <Outland Armor Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=12778;
 
--- Master Sergeant Biggins <Accessories Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12781 AND `item` IN 
-    (15196, 16342, 18440, 18441, 18442, 18443, 18444, 18445, 18447, 18448, 18449, 18452, 18453, 18454, 18455, 18456, 18457, 18854, 18856, 18857, 18858, 18859, 
-    18862, 18863, 18864, 25829, 28118, 28119, 28120, 28123, 28234, 28235, 28236, 28237, 28238, 28246, 28247, 28362, 28363, 28379, 28380, 29593, 30348, 30349, 
-    30350, 30351, 31838, 31839, 31840, 31841, 31852, 31853, 31854, 31855, 32453, 32455, 37864, 38589, 44957);
 
--- Captain O'Neal <Weapons Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12782 AND `item` IN (12584, 18825, 18827, 18830, 18833, 18836, 18838, 18843, 18847, 18855, 18865, 18867, 18869, 18873, 18876, 23451, 23452, 23453, 23454, 23455, 23456);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES 
-    (12782, 12584, 2291), (12782, 18825, 2291), (12782, 18827, 2291), (12782, 18830, 2257), (12782, 18833, 2291), (12782, 18836, 2291), (12782, 18838, 2291),
-    (12782, 18843, 2291), (12782, 18847, 2291), (12782, 18855, 2291), (12782, 18865, 2291), (12782, 18867, 2257), (12782, 18869, 2257), (12782, 18873, 2257), 
-    (12782, 18876, 2257), (12782, 23451, 2291), (12782, 23452, 2257), (12782, 23453, 2291), (12782, 23454, 2291), (12782, 23455, 2291), (12782, 23456, 2291);
 
 -- Lieutenant Karter <War Mount Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=12783 AND `item` IN (29465, 29467, 29468, 29471, 35906);
 DELETE FROM `npc_vendor` WHERE `entry`=12783 AND `item` IN (18241, 18242, 18243, 18244);
 INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12783, 18241, 423), (12783, 18242, 423), (12783, 18243, 423), (12783, 18244, 423);
-
--- Sergeant Major Clate <Legacy Armor Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12785 AND `item` IN
-    (16437, 16440, 16441, 16442, 16443, 16444, 16446, 16448, 16449, 16450, 16451, 16452, 16453, 16454, 16455, 16456, 16457, 16459, 16462, 16463, 16465, 16466, 16467, 16468, 
-    16471, 16472, 16473, 16474, 16475, 16476, 16477, 16478, 16479, 16480, 16483, 16484, 17578, 17579, 17580, 17581, 17583, 17584, 17602, 17603, 17604, 17605, 17607, 17608, 
-    23272, 23273, 23274, 23275, 23276, 23277, 23278, 23279, 23280, 23281, 23282, 23283, 23284, 23285, 23286, 23287, 23288, 23289, 23290, 23291, 23292, 23293, 23294, 23295, 23296, 23297, 23298, 23299,
-    23300, 23301, 23302, 23303, 23304, 23305, 23306, 23307, 23308, 23309, 23310, 23311, 23312, 23313, 23314, 23315, 23316, 23317, 23318, 23319, 29594, 29595, 29596, 29597, 29598, 29599, 
-    29606, 29607, 29608, 29609, 29610, 29611);
-DELETE FROM `npc_vendor` WHERE `entry`=12785 AND `item` IN 
-    (117, 159, 1179, 1205, 1645, 1708, 2287, 2593, 2594, 2595, 2596, 2723, 3770, 3771, 4536, 4537, 4538, 4539, 4540, 4541, 4542, 4544, 4599, 4601, 4602, 4604, 4605, 4606, 4607, 4608, 8766, 8948, 8950, 8952, 8953);
-
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES 
-    (12785, 117), (12785, 159), (12785, 1179), (12785, 1205), (12785, 1645), (12785, 1708), (12785, 2287), (12785, 2593), (12785, 2594), (12785, 2595), (12785, 2596), 
-    (12785, 2723), (12785, 3770), (12785, 3771), (12785, 4536), (12785, 4537), (12785, 4538), (12785, 4539), (12785, 4540), (12785, 4541), (12785, 4542), (12785, 4544), (12785, 4599),
-    (12785, 4601), (12785, 4602), (12785, 4604), (12785, 4605), (12785, 4606), (12785, 4607), (12785, 4608), (12785, 8766), (12785, 8948), (12785, 8950), (12785, 8952), (12785, 8953);
 
 -- Officer Areyn <Accessories Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=12805 AND `item` IN (18445, 18447, 18448, 18449, 18454, 18455, 18456, 18457, 18854, 18856, 18858, 18859, 18862, 18863, 18864);
@@ -428,8 +348,201 @@ INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
     (12805, 18854, 634), (12805, 18856, 634), (12805, 18858, 634), (12805, 18859, 634), (12805, 18862, 634), (12805, 18863, 634), (12805, 18864, 634);
 
 
+
+
+
+
+
+
+
+
+
+SET @Biggins     := 112781; -- Master Sergeant Biggins <Officer Accessories Quartermaster>, Vanilla
+SET @Clate       := 112785; -- Stone Guard Zarg <Food and Drink>, Vanilla
+
+
+DELETE FROM `creature_template` WHERE `entry` IN (@Biggins, @Clate);
+INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`, `KillCredit1`, `KillCredit2`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, 
+`exp`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `speed_swim`, `speed_flight`, `detection_range`, `scale`, `rank`, `dmgschool`, `DamageModifier`, `BaseAttackTime`, `RangeAttackTime`, 
+`BaseVariance`, `RangeVariance`, `unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, `trainer_type`, `trainer_spell`, `trainer_class`, `trainer_race`, `type`, `type_flags`, 
+`lootid`, `pickpocketloot`, `skinloot`, `PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`, `AIName`, `MovementType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `ExperienceModifier`, 
+`RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `spell_school_immune_mask`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES 
+
+(@Biggins, 0, 0, 0, 0, 0, 'Master Sergeant Biggins', 'Officer Accessories Quartermaster', NULL, 0, 55, 55, 0, 1078, 128, 1, 1.14286, 1, 1, 18, 1, 0, 0, 1.05, 2000, 2000, 1, 1, 1, 768, 2048, 0, 0, 0, 0, 0, 0, 7, 4096, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 2, 1, 2.6, 1, 0, 0, 1, 0, 0, 0, 'npc_ipp_pre_tbc', 12340),
+(@Clate, 0, 0, 0, 0, 0, 'Sergeant Major Clate', 'Food and Drink', NULL, 0, 55, 55, 0, 123, 4224, 1, 1.14286, 1, 1, 18, 1, 0, 0, 2.15, 2000, 2000, 1, 1, 1, 768, 2048, 0, 0, 0, 0, 0, 0, 7, 4096, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 2, 1, 2.6, 1, 0, 0, 1, 0, 0, 0, 'npc_ipp_pre_tbc', 12340);
+
+DELETE FROM `creature_template_addon` WHERE `entry` IN (@Biggins, @Clate);
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 
+(@Biggins, 0, 0, 0, 1, 0, 0, NULL),
+(@Clate, 0, 0, 0, 0, 0, 0, NULL);
+
+DELETE FROM `creature_template_locale` WHERE `entry` IN (@Biggins, @Clate);
+INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES 
+--
+(@Biggins, 'deDE', 'Hauptfeldwebel Biggins', 'Rüstmeister für Zubehör', 18019),
+(@Biggins, 'esES', 'Sargento primero Biggins', 'Intendente de accesorios', 18019),
+(@Biggins, 'esMX', 'Sargento primero Biggins', 'Intendente de accesorios', 18019),
+(@Biggins, 'frFR', 'Sergent-chef Socquet', 'Intendant des accessoires', 18019),
+(@Biggins, 'koKR', '정예근위병 비긴스', '보급품 병참장교', 18019),
+(@Biggins, 'ruRU', 'Старший сержант Биггинс', 'Начальник снабжения аксессуарами', 18019),
+(@Biggins, 'zhCN', '军士长贝金斯', '杂货军需官', 18019),
+(@Biggins, 'zhTW', '上士貝金斯', '雜貨軍需官', 18019),
+--
+(@Clate, 'deDE', 'Stabsfeldwebel Clate', 'Speis & Trank', 18019),
+(@Clate, 'esES', 'Alférez Clate', 'Alimentos y bebidas', 18019),
+(@Clate, 'esMX', 'Alférez Clate', 'Alimentos y bebidas', 18019),
+(@Clate, 'frFR', 'Sergent-major Clate', 'Nourriture & boissons', 18019),
+(@Clate, 'koKR', '선임하사 클레이트', '식료품 상인', 18019),
+(@Clate, 'ruRU', 'Старший сержант Клейт', 'Еда и напитки', 18019),
+(@Clate, 'zhCN', '克莱特军士长', '食物和饮料', 18019),
+(@Clate, 'zhTW', '士官長克萊特', '食物和飲料', 18019);
+
+DELETE FROM `creature_template_model` WHERE `CreatureID` IN (@Biggins, @Clate);
+INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES 
+(@Biggins, 0, 12669, 1, 1, 12340),
+(@Clate, 0, 12925, 1, 1, 12340);
+
+
+UPDATE `creature_template` SET `subname` = 'Officer Accessories Quartermaster' WHERE `entry` = 12781; 
+UPDATE `creature_template` SET `subname` = 'Weapons Quartermaster' WHERE `entry` = 12784; 
+UPDATE `creature_template` SET `subname` = 'Armor Quartermaster' WHERE `entry` = 12785;
+UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55 WHERE `entry`IN (26393, 26394); 
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_pre_tbc' WHERE `entry` IN (12805, 26393, 26394);
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (12781, 12784, 12785, 24671, 24672);
+
+
+DELETE FROM `creature` WHERE `guid` IN (133928, 133926, 133929, 612781, 612785, 624671, 624672, 626393, 626394);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
+--
+(612781, @Biggins, 0, -8777.4, 417.124, 103.921, 6.23553, 180), -- Master Sergeant Biggins <Officer Accessories Quartermaster>, Vanilla
+(133926, 12781, 0, -8777.4, 417.124, 103.921, 6.23553, 180),    -- Master Sergeant Biggins <Officer Accessories Quartermaster>, TBC
+(612785, @Clate, 0, -8771.31, 401.973, 109.665, 0.659191, 180), -- Sergeant Major Clate <Food and Drink>, Vanilla
+(133929, 12785, 0, -8771.31, 401.973, 109.665, 0.659191, 180),  -- Sergeant Major Clate <Armor Quartermaster>, TBC 
+(626394, 26394, 0, -8778.3, 432.142, 105.309, 4.17386, 180),    -- Captain O'Neal <Weapons Quartermaster>, Vanilla
+(624671, 24671, 0, -8778.3, 432.142, 105.309, 4.17386, 180),    -- Captain O'Neal <Weapons Quartermaster>, TBC
+(626393, 26393, 0, -8768.77, 401.647, 109.665, 2.22999, 180),   -- Captain Dirgehammer <Armor Quartermaster>, Vanilla
+(624672, 24672, 0, -8773.33, 427.279, 105.233, 3.84677, 180),   -- Captain Dirgehammer <Armor Quartermaster>, TBC
+(133928, 12784, 0, -8764.6, 413.632, 103.922, 0.693375, 180;    -- Lieutenant Jackspring <Weapons Quartermaster>, TBC 
+
+
+
+-- Master Sergeant Biggins <Officer Accessories Quartermaster> - Vanilla
+DELETE FROM `npc_vendor` WHERE `entry` = @Biggins;
+INSERT INTO `npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `VerifiedBuild`) VALUES 
+(@Biggins, 0, 15198, 0, 0, 1006, 0), (@Biggins, 0, 18606, 0, 0, 386, 0), (@Biggins, 0, 18839, 0, 0, 2354, 0), (@Biggins, 0, 18841, 0, 0, 2354, 0);
+
+-- Master Sergeant Biggins <Officer Accessories Quartermaster> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 12781;
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES
+(12781, 15196, 0, 0, 1007), (12781, 15198, 0, 0, 1006), (12781, 16342, 0, 0, 774), (12781, 18440, 0, 0, 1050), (12781, 18441, 0, 0, 986), (12781, 18442, 0, 0, 838),
+(12781, 18443, 0, 0, 491), (12781, 18444, 0, 0, 930), (12781, 18445, 0, 0, 492), (12781, 18447, 0, 0, 931), (12781, 18448, 0, 0, 492), (12781, 18449, 0, 0, 931),
+(12781, 18452, 0, 0, 492), (12781, 18453, 0, 0, 931), (12781, 18454, 0, 0, 492), (12781, 18455, 0, 0, 931), (12781, 18456, 0, 0, 492), (12781, 18457, 0, 0, 931), 
+(12781, 18606, 0, 0, 386), (12781, 18839, 0, 0, 460), (12781, 18841, 0, 0, 460), (12781, 18854, 0, 0, 634), (12781, 18856, 0, 0, 634), (12781, 18857, 0, 0, 634),
+(12781, 18858, 0, 0, 634), (12781, 18859, 0, 0, 634), (12781, 18862, 0, 0, 634), (12781, 18863, 0, 0, 634), (12781, 18864, 0, 0, 634), (12781, 25829, 0, 0, 125),
+(12781, 28118, 0, 0, 95), (12781, 28119, 0, 0, 95), (12781, 28120, 0, 0, 95), (12781, 28123, 0, 0, 99), (12781, 28234, 0, 0, 2404), (12781, 28235, 0, 0, 2404),
+(12781, 28236, 0, 0, 2404), (12781, 28237, 0, 0, 2404), (12781, 28238, 0, 0, 2404), (12781, 28244, 0, 0, 125), (12781, 28245, 0, 0, 125), (12781, 28246, 0, 0, 129),
+(12781, 28247, 0, 0, 129), (12781, 28362, 0, 0, 95), (12781, 28363, 0, 0, 99), (12781, 28379, 0, 0, 165), (12781, 28380, 0, 0, 165), (12781, 29593, 0, 0, 634),
+(12781, 30348, 0, 0, 2404), (12781, 30349, 0, 0, 2404), (12781, 30350, 0, 0, 2404), (12781, 30351, 0, 0, 2404), (12781, 31838, 0, 0, 1648), (12781, 31839, 0, 0, 1649),
+(12781, 31840, 0, 0, 1648), (12781, 31841, 0, 0, 1649), (12781, 31852, 0, 0, 1652), (12781, 31853, 0, 0, 1653), (12781, 31854, 0, 0, 1652), (12781, 31855, 0, 0, 1653),
+(12781, 32453, 0, 0, 1564), (12781, 32455, 0, 0, 460);
+
+-- Lieutenant Jackspring <Weapons Quartermaster> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 12784;
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES 
+(12784, 12584, 0, 0, 565), (12784, 18825, 0, 0, 565), (12784, 18827, 0, 0, 565), (12784, 18830, 0, 0, 131), (12784, 18833, 0, 0, 567), (12784, 18836, 0, 0, 567), (12784, 18838, 0, 0, 565),
+(12784, 18843, 0, 0, 565), (12784, 18847, 0, 0, 565), (12784, 18855, 0, 0, 567), (12784, 18865, 0, 0, 565), (12784, 18867, 0, 0, 131), (12784, 18869, 0, 0, 131), (12784, 18873, 0, 0, 131),
+(12784, 18876, 0, 0, 131), (12784, 23451, 0, 0, 565), (12784, 23452, 0, 0, 567), (12784, 23453, 0, 0, 567), (12784, 23454, 0, 0, 565), (12784, 23455, 0, 0, 131), (12784, 23456, 0, 0, 565);
+
+-- Sergeant Major Clate <Food and Drink> - Vanilla
+DELETE FROM `npc_vendor` WHERE `entry` = @Clate;
+INSERT INTO `npc_vendor` (`entry`, `item`) VALUES 
+(@Clate, 117), (@Clate, 159), (@Clate, 1179), (@Clate, 1205), (@Clate, 1645), (@Clate, 1708), (@Clate, 2287), (@Clate, 2593), (@Clate, 2594),
+(@Clate, 2595), (@Clate, 2596), (@Clate, 2723), (@Clate, 3770), (@Clate, 3771), (@Clate, 4536), (@Clate, 4537), (@Clate, 4538), (@Clate, 4539), 
+(@Clate, 4540), (@Clate, 4541), (@Clate, 4542), (@Clate, 4544), (@Clate, 4599), (@Clate, 4601), (@Clate, 4602), (@Clate, 4604), (@Clate, 4605), 
+(@Clate, 4606), (@Clate, 4607), (@Clate, 4608), (@Clate, 8766), (@Clate, 8948), (@Clate, 8950), (@Clate, 8952), (@Clate, 8953);
+
+DELETE FROM `npc_vendor` WHERE `entry` = 12785;
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
+(12785, 16437, 465), (12785, 16440, 541), (12785, 16441, 464), (12785, 16442, 542), (12785, 16443, 463), (12785, 16444, 465), (12785, 16446, 465), (12785, 16448, 541), (12785, 16449, 465),
+(12785, 16450, 542), (12785, 16451, 464), (12785, 16452, 463), (12785, 16453, 463), (12785, 16454, 541), (12785, 16455, 464), (12785, 16456, 542), (12785, 16457, 465), (12785, 16459, 465),
+(12785, 16462, 465), (12785, 16463, 541), (12785, 16465, 464), (12785, 16466, 463), (12785, 16467, 542), (12785, 16468, 465), (12785, 16471, 541), (12785, 16472, 465), (12785, 16473, 463),
+(12785, 16474, 464), (12785, 16475, 542), (12785, 16476, 465), (12785, 16477, 463), (12785, 16478, 464), (12785, 16479, 542), (12785, 16480, 465), (12785, 16483, 465), (12785, 16484, 541),
+(12785, 17578, 464), (12785, 17579, 542), (12785, 17580, 465), (12785, 17581, 463), (12785, 17583, 465), (12785, 17584, 541), (12785, 17602, 464), (12785, 17603, 542), (12785, 17604, 465),
+(12785, 17605, 463), (12785, 17607, 465), (12785, 17608, 541), (12785, 23272, 652), (12785, 23273, 653), (12785, 23274, 428), (12785, 23275, 427), (12785, 23276, 444), (12785, 23277, 427),
+(12785, 23278, 427), (12785, 23279, 428), (12785, 23280, 428), (12785, 23281, 427), (12785, 23282, 428), (12785, 23283, 427), (12785, 23284, 428), (12785, 23285, 427), (12785, 23286, 428),
+(12785, 23287, 427), (12785, 23288, 428), (12785, 23289, 427), (12785, 23290, 428), (12785, 23291, 427), (12785, 23292, 652), (12785, 23293, 653), (12785, 23294, 652), (12785, 23295, 653),
+(12785, 23296, 653), (12785, 23297, 652), (12785, 23298, 652), (12785, 23299, 653), (12785, 23300, 652), (12785, 23301, 653), (12785, 23302, 653), (12785, 23303, 652), (12785, 23304, 653),
+(12785, 23305, 652), (12785, 23306, 444), (12785, 23307, 427), (12785, 23308, 444), (12785, 23309, 427), (12785, 23310, 444), (12785, 23311, 427), (12785, 23312, 444), (12785, 23313, 427),
+(12785, 23314, 444), (12785, 23315, 427), (12785, 23316, 444), (12785, 23317, 427), (12785, 23318, 444), (12785, 23319, 427), (12785, 29594, 427), (12785, 29595, 428), (12785, 29596, 652),
+(12785, 29597, 653), (12785, 29598, 444), (12785, 29599, 427), (12785, 29606, 465), (12785, 29607, 541), (12785, 29608, 542), (12785, 29609, 463), (12785, 29610, 464), (12785, 29611, 465);
+
+
+-- Lieutenant Tristia <Armor Quartermaster> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 23446;
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES 
+(23446, 32785, 0, 0, 1911), (23446, 32786, 0, 0, 1911), (23446, 32787, 0, 0, 1911), (23446, 32788, 0, 0, 1911), (23446, 32789, 0, 0, 1911), (23446, 32790, 0, 0, 1911), 
+(23446, 32791, 0, 0, 1911), (23446, 32792, 0, 0, 1911), (23446, 32793, 0, 0, 1911), (23446, 32794, 0, 0, 1911), (23446, 32795, 0, 0, 1911), (23446, 32796, 0, 0, 1911), 
+(23446, 32797, 0, 0, 1923), (23446, 32798, 0, 0, 1923), (23446, 32799, 0, 0, 1923), (23446, 32800, 0, 0, 1923), (23446, 32801, 0, 0, 1923), (23446, 32802, 0, 0, 1923), 
+(23446, 32803, 0, 0, 1923), (23446, 32804, 0, 0, 1923), (23446, 32805, 0, 0, 1923), (23446, 32806, 0, 0, 1923), (23446, 32807, 0, 0, 1923), (23446, 32808, 0, 0, 1923), 
+(23446, 32809, 0, 0, 1935), (23446, 32810, 0, 0, 1935), (23446, 32811, 0, 0, 1935), (23446, 32812, 0, 0, 1935), (23446, 32813, 0, 0, 1935), (23446, 32814, 0, 0, 1935),
+(23446, 32816, 0, 0, 1935), (23446, 32817, 0, 0, 1935), (23446, 32818, 0, 0, 1935), (23446, 32819, 0, 0, 1935), (23446, 32820, 0, 0, 1935), (23446, 32821, 0, 0, 1935), 
+(23446, 32979, 0, 0, 1923), (23446, 32980, 0, 0, 1935), (23446, 32981, 0, 0, 1911), (23446, 32988, 0, 0, 1923), (23446, 32989, 0, 0, 1935), (23446, 32990, 0, 0, 1911),
+(23446, 32997, 0, 0, 1935), (23446, 32998, 0, 0, 1923), (23446, 32999, 0, 0, 1911), (23446, 33056, 0, 0, 129), (23446, 33057, 0, 0, 129), (23446, 33064, 0, 0, 129), 
+(23446, 33065, 0, 0, 127), (23446, 33066, 0, 0, 127), (23446, 33067, 0, 0, 127), (23446, 33068, 0, 0, 127);
+
+-- Captain O'Neal <Weapons Quartermaster> - Vanilla
+DELETE FROM `npc_vendor` WHERE `entry` IN (12782, 26394);
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES 
+(26394, 12584, 2291), (26394, 18825, 2291), (26394, 18827, 2291), (26394, 18830, 2257), (26394, 18833, 2291), (26394, 18836, 2291), (26394, 18838, 2291),
+(26394, 18843, 2291), (26394, 18847, 2291), (26394, 18855, 2291), (26394, 18865, 2291), (26394, 18867, 2257), (26394, 18869, 2257), (26394, 18873, 2257), 
+(26394, 18876, 2257), (26394, 23451, 2291), (26394, 23452, 2257), (26394, 23453, 2291), (26394, 23454, 2291), (26394, 23455, 2291), (26394, 23456, 2291);
+
+-- Captain O'Neil <Weapons Quartermaster> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 24671;
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES 
+(24671, 28940, 0, 0, 2242), (24671, 28941, 0, 0, 2242), (24671, 28942, 0, 0, 2237), (24671, 28943, 0, 0, 2237), (24671, 28944, 0, 0, 2239),
+(24671, 28945, 0, 0, 2237), (24671, 28946, 0, 0, 2240), (24671, 28947, 0, 0, 2240), (24671, 28948, 0, 0, 2237), (24671, 28949, 0, 0, 2237),
+(24671, 28950, 0, 0, 2240), (24671, 28951, 0, 0, 2239), (24671, 28952, 0, 0, 2240), (24671, 28953, 0, 0, 2239), (24671, 28954, 0, 0, 2240),
+(24671, 28955, 0, 0, 2240), (24671, 28956, 0, 0, 2239), (24671, 28957, 0, 0, 2238), (24671, 28959, 0, 0, 2237), (24671, 28960, 0, 0, 2237);
+
+-- Captain Dirgehammer <Armor Quartermaster> - Vanilla
+DELETE FROM `npc_vendor` WHERE `entry` IN (12777, 26393);
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
+(26393, 16437, 465), (26393, 16440, 541), (26393, 16441, 464), (26393, 16442, 542), (26393, 16443, 463), (26393, 16444, 465), (26393, 16446, 465), (26393, 16448, 541), (26393, 16449, 465),
+(26393, 16450, 542), (26393, 16451, 464), (26393, 16452, 463), (26393, 16453, 463), (26393, 16454, 541), (26393, 16455, 464), (26393, 16456, 542), (26393, 16457, 465), (26393, 16459, 465),
+(26393, 16462, 465), (26393, 16463, 541), (26393, 16465, 464), (26393, 16466, 463), (26393, 16467, 542), (26393, 16468, 465), (26393, 16471, 541), (26393, 16472, 465), (26393, 16473, 463),
+(26393, 16474, 464), (26393, 16475, 542), (26393, 16476, 465), (26393, 16477, 463), (26393, 16478, 464), (26393, 16479, 542), (26393, 16480, 465), (26393, 16483, 465), (26393, 16484, 541),
+(26393, 17578, 464), (26393, 17579, 542), (26393, 17580, 465), (26393, 17581, 463), (26393, 17583, 465), (26393, 17584, 541), (26393, 17602, 464), (26393, 17603, 542), (26393, 17604, 465),
+(26393, 17605, 463), (26393, 17607, 465), (26393, 17608, 541), (26393, 23272, 652), (26393, 23273, 653), (26393, 23274, 428), (26393, 23275, 427), (26393, 23276, 444), (26393, 23277, 427),
+(26393, 23278, 427), (26393, 23279, 428), (26393, 23280, 428), (26393, 23281, 427), (26393, 23282, 428), (26393, 23283, 427), (26393, 23284, 428), (26393, 23285, 427), (26393, 23286, 428),
+(26393, 23287, 427), (26393, 23288, 428), (26393, 23289, 427), (26393, 23290, 428), (26393, 23291, 427), (26393, 23292, 652), (26393, 23293, 653), (26393, 23294, 652), (26393, 23295, 653),
+(26393, 23296, 653), (26393, 23297, 652), (26393, 23298, 652), (26393, 23299, 653), (26393, 23300, 652), (26393, 23301, 653), (26393, 23302, 653), (26393, 23303, 652), (26393, 23304, 653),
+(26393, 23305, 652), (26393, 23306, 444), (26393, 23307, 427), (26393, 23308, 444), (26393, 23309, 427), (26393, 23310, 444), (26393, 23311, 427), (26393, 23312, 444), (26393, 23313, 427),
+(26393, 23314, 444), (26393, 23315, 427), (26393, 23316, 444), (26393, 23317, 427), (26393, 23318, 444), (26393, 23319, 427), (26393, 29594, 427), (26393, 29595, 428), (26393, 29596, 652),
+(26393, 29597, 653), (26393, 29598, 444), (26393, 29599, 427), (26393, 29606, 465), (26393, 29607, 541), (26393, 29608, 542), (26393, 29609, 463), (26393, 29610, 464), (26393, 29611, 465);
+
+-- Captain Dirgehammer <Armor Quartermaster> - TBC
+DELETE FROM `npc_vendor` WHERE `entry` = 24672;
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost`) VALUES 
+(24672, 28613, 0, 0, 2259), (24672, 28614, 0, 0, 2261), (24672, 28615, 0, 0, 2263), (24672, 28616, 0, 0, 2265), (24672, 28617, 0, 0, 2267), (24672, 28618, 0, 0, 2261),
+(24672, 28619, 0, 0, 2263), (24672, 28620, 0, 0, 2265), (24672, 28622, 0, 0, 2267), (24672, 28623, 0, 0, 2259), (24672, 28624, 0, 0, 2261), (24672, 28625, 0, 0, 2263),
+(24672, 28626, 0, 0, 2265), (24672, 28627, 0, 0, 2267), (24672, 28628, 0, 0, 2259), (24672, 28679, 0, 0, 2259), (24672, 28680, 0, 0, 2261), (24672, 28681, 0, 0, 2263),
+(24672, 28683, 0, 0, 2267), (24672, 28684, 0, 0, 2261), (24672, 28685, 0, 0, 2263), (24672, 28686, 0, 0, 2265), (24672, 28687, 0, 0, 2267), (24672, 28688, 0, 0, 2259),
+(24672, 28689, 0, 0, 2259), (24672, 28690, 0, 0, 2261), (24672, 28691, 0, 0, 2263), (24672, 28692, 0, 0, 2265), (24672, 28693, 0, 0, 2267), (24672, 28694, 0, 0, 2259),
+(24672, 28695, 0, 0, 2261), (24672, 28696, 0, 0, 2263), (24672, 28697, 0, 0, 2265), (24672, 28698, 0, 0, 2267), (24672, 28699, 0, 0, 2259), (24672, 28700, 0, 0, 2261),
+(24672, 28701, 0, 0, 2263), (24672, 28702, 0, 0, 2265), (24672, 28703, 0, 0, 2267), (24672, 28704, 0, 0, 2261), (24672, 28705, 0, 0, 2263), (24672, 28706, 0, 0, 2265),
+(24672, 28707, 0, 0, 2267), (24672, 28708, 0, 0, 2259), (24672, 28709, 0, 0, 2259), (24672, 28710, 0, 0, 2261), (24672, 28711, 0, 0, 2263), (24672, 28712, 0, 0, 2265),
+(24672, 28713, 0, 0, 2267), (24672, 28714, 0, 0, 2267), (24672, 28715, 0, 0, 2263), (24672, 28716, 0, 0, 2261), (24672, 28717, 0, 0, 2259), (24672, 28718, 0, 0, 2265),
+(24672, 28719, 0, 0, 2261), (24672, 28720, 0, 0, 2263), (24672, 28721, 0, 0, 2265), (24672, 28722, 0, 0, 2267), (24672, 28723, 0, 0, 2259), (24672, 28724, 0, 0, 2265),
+(24672, 31589, 0, 0, 2261), (24672, 31590, 0, 0, 2263), (24672, 31591, 0, 0, 2265), (24672, 31592, 0, 0, 2267), (24672, 31593, 0, 0, 2259), (24672, 31620, 0, 0, 2261),
+(24672, 31622, 0, 0, 2263), (24672, 31623, 0, 0, 2265), (24672, 31624, 0, 0, 2267), (24672, 31625, 0, 0, 2259), (24672, 31630, 0, 0, 2259), (24672, 31631, 0, 0, 2261),
+(24672, 31632, 0, 0, 2263), (24672, 31633, 0, 0, 2265), (24672, 31634, 0, 0, 2267), (24672, 31640, 0, 0, 2259), (24672, 31641, 0, 0, 2261), (24672, 31642, 0, 0, 2263),
+(24672, 31643, 0, 0, 2265), (24672, 31644, 0, 0, 2267);
+
+
+
 /* Hide certain vendor items until the player has reached the progression tier for them */
-DELETE FROM `conditions` WHERE `SourceGroup` IN (12777, 12782);
+DELETE FROM `conditions` WHERE `SourceGroup` IN (12777, 12782, 26394);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
 `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
 --
@@ -482,29 +595,39 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (23, 12777, 17607, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain Dirgehammer will not sell Marshals Satin Sandals until the player has completed PROGRESSION_ONYXIA'),
 (23, 12777, 17608, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain Dirgehammer will not sell Marshals Satin Gloves until the player has completed PROGRESSION_ONYXIA'),
 --
-(23, 12782, 12584, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Longsword until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18825, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Aegis until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18827, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Handaxe until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18830, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Sunderer until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18833, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Bullseye until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18836, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Repeater until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18838, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Dirk until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18843, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Right Hand Blade until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18847, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Left Hand Blade until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18855, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Hand Cannon until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18865, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Punisher until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18867, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Battle Hammer until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18869, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Glaive until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18873, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Stave until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 18876, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Claymore until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 23451, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Mageblade until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 23452, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Tome of Power until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 23453, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Tome of Restoration until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 23454, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Warhammer until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 23455, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Demolisher until the player has completed PROGRESSION_ONYXIA'),
-(23, 12782, 23456, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Swiftblade until the player has completed PROGRESSION_ONYXIA');
+(23, 26394, 12584, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Longsword until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18825, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Aegis until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18827, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Handaxe until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18830, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Sunderer until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18833, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Bullseye until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18836, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Repeater until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18838, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Dirk until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18843, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Right Hand Blade until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18847, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Left Hand Blade until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18855, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Hand Cannon until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18865, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Punisher until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18867, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Battle Hammer until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18869, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Glaive until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18873, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Stave until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 18876, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Claymore until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 23451, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Mageblade until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 23452, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Tome of Power until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 23453, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Tome of Restoration until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 23454, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Warhammer until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 23455, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Demolisher until the player has completed PROGRESSION_ONYXIA'),
+(23, 26394, 23456, 0, 0, 8, 0, 66002, 0, 0, 0, 0, 0, '', 'Captain O\'Neal will not sell Grand Marshal\'s Swiftblade until the player has completed PROGRESSION_ONYXIA');
 
- 
+
+UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_pre_tbc' WHERE `guid` IN (61936, 61940, 61942, 61944, 61945, 61946, 61947, 61949, 61951);
+
+-- WotLK pvp vendors
+DELETE FROM `creature` WHERE `id1` IN 
+(12777,  -- Captain Dirgehammer <Armor Quartermaster>
+ 12782,  -- Captain O'Neal <Weapons Quartermaster>
+ 34075,  -- Captain Dirgehammer <Armor Quartermaster>
+ 34081); -- Captain O'Neal <Jewelcrafting Quartermaster>
+
+
 -- Summon Felsteed (Warlock)
 DELETE FROM `quest_offer_reward` WHERE `ID`=4488;
 INSERT INTO `quest_offer_reward` (`ID`, `RewardText`) VALUES 

--- a/sql/world/base/zone_stormwind.sql
+++ b/sql/world/base/zone_stormwind.sql
@@ -525,7 +525,7 @@ INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `ExtendedCost
 
 
 /* Hide certain vendor items until the player has reached the progression tier for them */
-DELETE FROM `conditions` WHERE `SourceGroup` IN (12777, 12782, 26394);
+DELETE FROM `conditions` WHERE `SourceGroup` IN (12777, 12782, 12783, 26394);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
 `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
 --

--- a/sql/world/base/zone_stormwind.sql
+++ b/sql/world/base/zone_stormwind.sql
@@ -377,7 +377,7 @@ UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55 WHERE `entry`IN 
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_pre_tbc' WHERE `entry` IN (12805, 26393, 26394);
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (12781, 12784, 12785, 20278, 23396, 23446, 24671, 24672);
 
-UPDATE `creature_template_addon` SET `mount` = 0 WHERE `entry`= 12783;
+UPDATE `creature_template_addon` SET `mount` = 0 WHERE `entry` = 12783;
 
 
 DELETE FROM `creature` WHERE `guid` IN (133928, 133926, 133929, 612781, 612783, 612785, 623446, 624671, 624672, 626393, 626394, 720278, 723396);
@@ -391,7 +391,7 @@ INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `posit
 (624671, 24671, 0, -8778.3, 432.142, 105.309, 4.17386, 180),    -- Captain O'Neal <Weapons Quartermaster>, TBC
 (626393, 26393, 0, -8768.77, 401.647, 109.665, 2.22999, 180),   -- Captain Dirgehammer <Armor Quartermaster>, Vanilla
 (624672, 24672, 0, -8773.33, 427.279, 105.233, 3.84677, 180),   -- Captain Dirgehammer <Armor Quartermaster>, TBC
-(133928, 12784, 0, -8764.6, 413.632, 103.922, 0.693375, 180,    -- Lieutenant Jackspring <Weapons Quartermaster>, TBC 
+(133928, 12784, 0, -8764.6, 413.632, 103.922, 0.693375, 180),    -- Lieutenant Jackspring <Weapons Quartermaster>, TBC 
 (720278, 20278, 0, -8789.08, 425.681, 105.233, 5.68294, 180),   -- Vixton Pinchwhistle <Arena Vendor>, TBC
 (723396, 23396, 0, -8786.12, 428.386, 105.233, 5.5871, 180),    -- Krixel Pinchwhistle <Arena Vendor>, TBC
 (623446, 23446, 0, -8785.74, 420.484, 105.233, 0.701937, 180),  -- Lieutenant Tristia <Armor Quartermaster>, TBC

--- a/src/IndividualProgressionAwarenessScripts.cpp
+++ b/src/IndividualProgressionAwarenessScripts.cpp
@@ -384,6 +384,33 @@ public:
     }
 };
 
+class npc_ipp_pre_tbc : public CreatureScript
+{
+public:
+    npc_ipp_pre_tbc() : CreatureScript("npc_ipp_pre_tbc") { }
+
+    struct npc_ipp_pre_tbcAI: ScriptedAI
+    {
+        explicit npc_ipp_pre_tbcAI(Creature* creature) : ScriptedAI(creature) { };
+
+        bool CanBeSeen(Player const* player) override
+        {
+            if (player->IsGameMaster() || !sIndividualProgression->enabled)
+            {
+                return true;
+            }
+            
+            Player* target = ObjectAccessor::FindConnectedPlayer(player->GetGUID());            
+            return sIndividualProgression->isBeforeProgression(target,PROGRESSION_PRE_TBC);
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_ipp_pre_tbcAI(creature);
+    }
+};
+
 class npc_ipp_tbc : public CreatureScript
 {
 public:
@@ -638,6 +665,7 @@ void AddSC_mod_individual_progression_awareness()
     new npc_ipp_si();          // Scourge Invasion
     new npc_ipp_pre_naxx40();  // Scourge Invasion
     new npc_ipp_naxx40();
+    new npc_ipp_pre_tbc();     // vanilla pvp vendors
     new npc_ipp_tbc();
     new npc_ipp_tbc_pre_t4();
     new npc_ipp_tbc_t4();

--- a/src/IndividualProgressionAwarenessScripts.cpp
+++ b/src/IndividualProgressionAwarenessScripts.cpp
@@ -158,6 +158,32 @@ public:
     }
 };
 
+class gobject_ipp_pre_tbc : public GameObjectScript
+{
+public:
+    gobject_ipp_pre_tbc() : GameObjectScript("gobject_ipp_pre_tbc") { }
+
+    struct gobject_ipp_pre_tbcAI: GameObjectAI
+    {
+        explicit gobject_ipp_pre_tbcAI(GameObject* object) : GameObjectAI(object) { };
+
+        bool CanBeSeen(Player const* player) override
+        {
+            if (player->IsGameMaster() || !sIndividualProgression->enabled)
+            {
+                return true;
+            }
+            Player* target = ObjectAccessor::FindConnectedPlayer(player->GetGUID());
+            return sIndividualProgression->isBeforeProgression(target, PROGRESSION_PRE_TBC);
+        }
+    };
+
+    GameObjectAI* GetAI(GameObject* object) const override
+    {
+        return new gobject_ipp_pre_tbcAI(object);
+    }
+};
+
 class gobject_ipp_tbc : public GameObjectScript
 {
 public:
@@ -657,6 +683,7 @@ void AddSC_mod_individual_progression_awareness()
     new gobject_ipp_aqwar();   // AQ war crystals
     new gobject_ipp_si();      // Scourge Invasion
     new gobject_ipp_naxx40();
+    new gobject_ipp_pre_tbc(); // stormwind pvp room
     new gobject_ipp_tbc();
     new gobject_ipp_wotlk();
     new npc_ipp_preaq();       // Cenarion Hold NPCs


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/247

Adding missing TBC pvp vendors to Orgrimmar and Stormwind

this causes issues with how it's currently done.

adding new npcs where needed and lots of phasing in and out of npcs according to progression level.

also trying to make this compatible with upgrading an existing server.

