### PR TITLE
dummies phasing + some adjustments

### DIFF
--- a/sql/world/base/dungeon_onyxia.sql
+++ b/sql/world/base/dungeon_onyxia.sql
@@ -1052,3 +1052,10 @@ INSERT INTO `areatrigger_scripts` (`entry`, `ScriptName`) VALUES
 (2848, 'onyxia_entrance_trigger');
 
 UPDATE `gameobject` SET `spawnMask` = 7 WHERE `map` = 249;
+
+/* Classic onyxia head quest locale fix for non EN langs */
+/* Was set as Garrosh, correct warchief is Thrall */
+UPDATE `quest_template_locale` SET `Objectives` = 'Bringt Onyxias Kopf zu Thrall in Orgrimmar.' WHERE `ID` = 7490 AND `locale` = 'deDE';
+UPDATE `quest_template_locale` SET `Objectives` = 'LLeva la cabeza de Onyxia a Thrall a Orgrimmar.' WHERE `ID` = 7490 AND `locale` = 'esES';
+UPDATE `quest_template_locale` SET `Objectives` = 'LLeva la cabeza de Onyxia a Thrall a Orgrimmar.' WHERE `ID` = 7490 AND `locale` = 'esMX';
+UPDATE `quest_template_locale` SET `Objectives` = 'Apportez la tête de Onyxia à Thrall à Orgrimmar.' WHERE `ID` = 7490 AND `locale` = 'frFR';

--- a/sql/world/base/tbc_creatures.sql
+++ b/sql/world/base/tbc_creatures.sql
@@ -12969,7 +12969,15 @@ UPDATE `creature_template` SET `ArmorModifier` = 0.978999 WHERE `entry`=23393;
 UPDATE `creature_template` SET `speed_walk` = 2.0, `speed_run` = 1.71429, `DamageModifier` = 32.0, `HealthModifier` = 90.0 WHERE `entry`=23394;
 
 /*  Krixel Pinchwhistle  */
-UPDATE `creature_template` SET `subname` = 'Arena Vendor', `speed_walk` = 1.1 WHERE `entry`=23396;
+UPDATE `creature_template` SET `subname` = 'Arena Vendor', `speed_walk` = 1.1 WHERE `entry` = 23396;
+UPDATE `creature_template_locale` SET Title = 'Arenaverkäufer' WHERE `entry` = 23396 AND `locale` = 'deDE';
+UPDATE `creature_template_locale` SET Title = 'Vendedor de arena' WHERE `entry` = 23396 AND `locale` = 'esES';
+UPDATE `creature_template_locale` SET Title = 'Vendedor de arena' WHERE `entry` = 23396 AND `locale` = 'esMX';
+UPDATE `creature_template_locale` SET Title = 'Vendeur de l''arène' WHERE `entry` = 23396 AND `locale` = 'frFR';
+UPDATE `creature_template_locale` SET Title = '2시즌 투기장 상인' WHERE `entry` = 23396 AND `locale` = 'koKR';
+UPDATE `creature_template_locale` SET Title = 'Продавец экипировки арены' WHERE `entry` = 23396 AND `locale` = 'ruRU';
+UPDATE `creature_template_locale` SET Title = '竞技场商人' WHERE `entry` = 23396 AND `locale` = 'zhCN';
+UPDATE `creature_template_locale` SET Title = '競技場商人' WHERE `entry` = 23396 AND `locale` = 'zhTW';
 
 /*  Illidari Blood Lord  */
 UPDATE `creature_template` SET `speed_walk` = 1.6, `speed_run` = 1.42857, `DamageModifier` = 29.0, `HealthModifier` = 40.0 WHERE `entry`=23397;

--- a/sql/world/base/zone_dustwallow_marsh.sql
+++ b/sql/world/base/zone_dustwallow_marsh.sql
@@ -1,0 +1,6 @@
+SET @CGUID    := 670000;
+
+/* Old Vanilla Varian Wrynn Npc in Alcaz during Vanilla phases */
+DELETE FROM `creature` WHERE `id1` = 11699 AND `map` = 1;
+INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES
+(@CGUID+1, 11699, 0, 0, 1, 0, 0, 1, 1, 1, -2744.03, -4994.2, 8.26564, 0.0392587, 300, 0, 0, 4121, 0, 0, 0, 0, 0, 'npc_ipp_pre_naxx40', 0, 'Varian Wrynn in Alcaz (Vanilla)');

--- a/sql/world/base/zz_optional_aq_quest_nerf.sql
+++ b/sql/world/base/zz_optional_aq_quest_nerf.sql
@@ -4,8 +4,8 @@
    Increases the Rep for The Hand of the Righteous by 40 times, so only about 5 turn-ins are necessary instead of 200.
    Feel free to adjust to taste - divide RewardFactionOverride1 by 100 to get the amount of rep that would be awarded 
    Sql edit example: 5 turn-ins = 800000 rep, 1 turn-in = 4000000 rep */
-UPDATE quest_template SET RewardFactionOverride1=800000, RewardFactionOverride2=0,RewardFactionOverride3=0,RewardFactionOverride4=0,RewardFactionOverride5=0 WHERE ID=8301;
-UPDATE quest_template SET RewardFactionOverride1=800000, RewardFactionOverride2=0,RewardFactionOverride3=0,RewardFactionOverride4=0,RewardFactionOverride5=0 WHERE ID=8302;
+UPDATE `quest_template` SET `RewardFactionOverride1` = 800000, `RewardFactionOverride2` = 0, `RewardFactionOverride3` = 0, `RewardFactionOverride4` = 0, `RewardFactionOverride5` = 0 WHERE `ID` = 8301;
+UPDATE `quest_template` SET `RewardFactionOverride1` = 800000, `RewardFactionOverride2` = 0, `RewardFactionOverride3` = 0, `RewardFactionOverride4` = 0, `RewardFactionOverride5` = 0 WHERE `ID` = 8302;
 
 /* Revert drop rate for Nightmare_corruption to nerfed WotLK drop rate */
 UPDATE `creature_loot_template` SET `Chance` = 100 WHERE `Item` = 21146;

--- a/sql/world/base/zz_optional_attunements.sql
+++ b/sql/world/base/zz_optional_attunements.sql
@@ -4,3 +4,6 @@ DELETE FROM `dungeon_access_requirements` WHERE `dungeon_access_id` IN (20, 26);
 INSERT INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES 
 (20, 1, 8182, 'You must complete the quest "The Hand of Rastakhan" and be level 60 before entering Zul\'Gurub.', 2, NULL, 0, NULL),    
 (26, 1, 7761, 'You must complete the quest "Blackhand\'s Command" and be level 60 before entering Blackwing Lair.', 2, NULL, 0, NULL);
+
+/* Optional attunement change intended when playing with bots (only the leader needs attunement) */
+-- UPDATE `dungeon_access_requirements` SET `leader_only` = 1;

--- a/sql/world/base/zz_optional_vanilla_phasing.sql
+++ b/sql/world/base/zz_optional_vanilla_phasing.sql
@@ -10,6 +10,8 @@ UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_preaq' WHERE `map` = 0 AND `
 /* 1.9 - AQ */
 /* AQ meeting stone phased until pre-aq phase (at least) */
 UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_preaq' WHERE `map` = 1 AND `id` IN (185322);
+/* Landro for TCG promotion in Booty Bay */
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_aq' WHERE `entry` = 17249;
 
 /* 1.11 - Naxxramas */
 /* Naxx Vanilla meeting stone phased until appropriate phase */
@@ -40,6 +42,7 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (
 17218, -- Huraan, Southshore
 17223, -- Ambassador Rualeth, Aerie Peak
 17238, -- Anchorite Truuen, Western Plaguelands
+21045, -- Landro Hired Bodyguard, Booty Bay
 22931, -- Gorrim, Emerald Sanctuary, Flight Master
 23131, -- Blood Knight Honor Guard, Orgrimmar
 24366, -- Nizzle, Rebel Camp, Flight Master
@@ -141,3 +144,6 @@ UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_wotlk' WHERE `guid` IN (347,
 /* Hide barber in Kalimdor/Eastern Kingdom/Outland until WotLK - disabled by default, because most players will expect barbers to be there */
 /* UPDATE `creature` SET `ScriptName` = 'npc_ipp_wotlk' WHERE `map` IN (0, 1, 530) AND `id1` IN (29139, 29141, 29142, 29143, 29145);
 UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_wotlk' WHERE `map` IN (0, 1, 530) AND `id` IN (190683, 190684, 190697, 190698, 190699, 190704, 190710, 190711, 190712, 191028, 191029, 191030); */
+
+/* Hide training dummy in Kalimdor/Eastern Kingdom/Outland until WotLK - disabled by default, because most players will expect dummies to be there */
+/* UPDATE `creature` SET `ScriptName` = 'npc_training_dummy_ipp_wotlk' WHERE `map` IN (0, 1, 530) AND `id1` IN (31144, 31146, 32666, 32667); */


### PR DESCRIPTION
- Dummies in cities can now be phased until WotLK (optional) _(zz_optional_vanilla_phasing.sql & IndividualProgressionAwarenessScripts.cpp)_
- Fix some quest locales again (Onyxia head quest) _(dungeon_onyxia.sql)_
- Update Krixel Pinchwhistle locales too (Arena Vendor) _(tbc_creatures.sql)_
- Add the old Varian NPC during Vanilla in Alcaz prison (He disappear before TBC) _(zone_dustwallow_marsh.sql)_
- Landro and his bodyguards phased in Booty Bay (TCG promotional NPCs) _(zz_optional_vanilla_phasing.sql)_
- Add a dungeon attunement adjustment when playing with bots (optional) _(zz_optional_attunements.sql)_
- Minor sql spelling adjustment _(zz_optional_aq_quest_nerf.sql)_