### PR TITLE
Fixes to Detect Magic spell

### DIFF
--- a/src/spellScripts/spellScripts.cpp
+++ b/src/spellScripts/spellScripts.cpp
@@ -32,22 +32,22 @@ class spell_detect_magic : public SpellScript
             else
             {
                 if (holyResist > 0.01)
-                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a holy resistance of: %.0f", holyResist);
+                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a holy resistance of: {}", holyResist);
 
                 if (fireResist > 0.01)
-                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a fire resistance of: %.0f", fireResist);
+                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a fire resistance of: {}", fireResist);
 
                 if (natureResist > 0.01)
-                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a nature resistance of: %.0f", natureResist);
+                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a nature resistance of: {}", natureResist);
 
                 if (frostResist > 0.01)
-                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a frost resistance of: %.0f", frostResist);
+                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a frost resistance of: {}", frostResist);
 
                 if (shadowResist > 0.01)
-                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a shadow resistance of: %.0f", shadowResist);
+                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a shadow resistance of: {}", shadowResist);
 
                 if (arcaneResist > 0.01)
-                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a arcane resistance of: %.0f", arcaneResist);
+                    ChatHandler(caster->GetSession()).PSendSysMessage("You detect a arcane resistance of: {}", arcaneResist);
             }
         }
     }


### PR DESCRIPTION
Detect Magic cannot be learned at mage trainers as the spell is not correctly labeled to be part of the mage's Arcane spec.
When learning the spell via chat commands, it appears in the General tab of the spellbook instead of Arcane.

To fix it, it is necessary to edit SkillLineAbility.dbc and also the client patch-V.mpq.
The fix is to simply add an entry to SkillLineAbility.dbc that adds Spell `2855` (Detect Magic) to Skillline `237` (Arcane) for Class `128` (Mage).

As I don't want to edit the entire `dbc.7z` archive in this PR, I have uploaded the modified dbc file [here - SkillLineAbility.zip](https://github.com/user-attachments/files/20824643/SkillLineAbility.zip) for review.
Otherwise someone with access to the repo can also make the changes to SkillLineAbility.dbc as described above and update the client patch after.

This PR mainly fixes the chat message when casting Detect Magic to display the actual resistance values instead of the format string.