### PR TITLE
Do not phase NPCs that are required for quest completion

### DIFF
--- a/sql/world/base/zz_optional_vanilla_phasing.sql
+++ b/sql/world/base/zz_optional_vanilla_phasing.sql
@@ -26,8 +26,6 @@ UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_naxx40' WHERE `map` = 0 AND 
 /* 2.0+ - NPCs/Gobjects added in Eastern/Kalimdor during TBC pre-patch or more */
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (
 11701, -- Mor'Vek, Un'Goro
-16288, -- Advisor Sorrelon, The Sepulcher
-17092, -- Advisor Duskingdawn, Tarren Mill
 17093, -- Magistrix Elosai, Freewind Post
 17094, -- Nemeth Hawkeye, Grom'gol Base Camp
 17095, -- Balandar Brightstar, Brackenwall Village


### PR DESCRIPTION
These two NPCs are required to turn in the following low level Belf-only quests.

https://www.wowhead.com/tbc/quest=9189/delivery-to-the-sepulcher
https://www.wowhead.com/tbc/quest=9425/report-to-tarren-mill

So we should not phase them out, otherwise these quests cannot be completed until the player reaches TBC progression.