### PR TITLE
fix Naxx40 entrance again

### DIFF
--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -51,10 +51,14 @@ public:
 
     bool OnGossipHello(Player* player, GameObject* /*go*/) override
     {
-        if (((!sIndividualProgression->requireNaxxStrath || player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_REWARDED) && isAttuned(player)) || (isExcludedFromProgression(player) && (player->GetLevel() <= IP_LEVEL_TBC)))
+        if ((!sIndividualProgression->requireNaxxStrath || player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_REWARDED) && (player->GetLevel() <= IP_LEVEL_TBC))
         {
             player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
-            player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
+			
+			if ((isAttuned(player)) || (isExcludedFromProgression(player) && (player->GetLevel() <= IP_LEVEL_TBC)))
+			{
+                player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
+			}
         }
         return true;
     }


### PR DESCRIPTION
was possible to enter at 71+

still had issues with raid being set to 10man wotlk version 

this happened when you were in a party of let's say 5.
the player is nr3 in the group and is attuned.
nr1 in the group is not attuned.
then when clicking the crystal it would set the raid difficulty to 10man wotlk because it first checked player 1
the raid difficulty was already set for the group and even though the player clicking the crystal was attuned he would still get teleported to the 10man wotlk version.

should now no longer be possible.
now raid difficulty gets set to naxx40 version before checking if the player is attuned.