### PR TITLE
fix Sapphiron Animation

### DIFF
--- a/src/naxx40Scripts/boss_sapphiron_40.cpp
+++ b/src/naxx40Scripts/boss_sapphiron_40.cpp
@@ -117,11 +117,14 @@ public:
 
         void InitializeAI() override
         {
-            me->SummonGameObject(GO_SAPPHIRON_BIRTH, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), 0, 0, 0, 0, 0, 0);
-            me->SetVisible(false);
-            me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
-            me->SetReactState(REACT_PASSIVE);
-            ScriptedAI::InitializeAI();
+            if (pInstance->GetBossState(BOSS_SAPPHIRON) != DONE)
+            {
+                me->SummonGameObject(GO_SAPPHIRON_BIRTH, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), 0, 0, 0, 0, 0, 0);
+                me->SetVisible(false);
+                me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+                me->SetReactState(REACT_PASSIVE);
+                ScriptedAI::InitializeAI();
+            }
         }
 
         bool IsInRoom()


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/511

"when you relog after Sapphiron is killed, the pile of bones is back and does the whole animation that he initially has when you encounter him, where the bones join together into the full dragon"

this PR stops this from happening
the animation only plays if Sapphiron hasn't been killed yet.

