### PR TITLE
Loatheb fixes

### DIFF
--- a/src/naxx40Scripts/boss_loatheb_40.cpp
+++ b/src/naxx40Scripts/boss_loatheb_40.cpp
@@ -24,7 +24,7 @@ enum Spells
     SPELL_NECROTIC_AURA                         = 55593,
 	// SPELL_CORRUPTED_MIND                     = 29201, // this triggers the following spells on targets (based on class): 29185, 29194, 29196, 29198
     // SPELL_POISON_AURA                        = 29865, // does 200 dmg every second for 6 seconds with 1200 extra damage at the end. should do 196 dmg every 6 seconds. no extra damage at the end.
-    SPELL_POISON_SHOCK                          = 22595, // does 180 aoe poison damage. if we change the damage to 196 and let loatheb recast this every 6 seconds it's a possible fix for poison aura.
+    SPELL_POISON_SHOCK                          = 22595, // does 180-220 aoe poison damage. if we let loatheb recast this every 6 seconds it's a possible fix for poison aura.
     SPELL_INEVITABLE_DOOM                       = 29204,
     SPELL_REMOVE_CURSE                          = 30281  // He periodically removes all curses on himself
 };
@@ -181,9 +181,7 @@ public:
 				*/
 				case EVENT_POISON_SHOCK:
 				{
-				     int32 bp0 = 195;
-					 
-	                if (me->CastCustomSpell(me, SPELL_POISON_SHOCK, &bp0, 0, 0, true) == SPELL_CAST_OK)
+	                if (me->CastSpell(me, SPELL_POISON_SHOCK, true) == SPELL_CAST_OK)
                     {
                         events.RepeatEvent(6000);
 					}

--- a/src/naxx40Scripts/boss_loatheb_40.cpp
+++ b/src/naxx40Scripts/boss_loatheb_40.cpp
@@ -146,7 +146,7 @@ public:
                 }
                 case EVENT_CORRUPTED_MIND:
                 {
-                    me->CastCustomSpell(me, SPELL_CORRUPTED_MIND, &bp0, 0, 0, false);
+                    me->CastSpell(me, SPELL_CORRUPTED_MIND, true);
                     events.RepeatEvent(10000);
                     break;
                 }
@@ -167,7 +167,7 @@ public:
                 }
                 case EVENT_REMOVE_CURSE:
                 {
-                    me->CastCustomSpell(me, SPELL_REMOVE_CURSE, &bp0, 0, 0, false);
+                    me->CastSpell(me, SPELL_REMOVE_CURSE, true);
                     events.RepeatEvent(30000);
                     break;
                 }

--- a/src/naxx40Scripts/boss_loatheb_40.cpp
+++ b/src/naxx40Scripts/boss_loatheb_40.cpp
@@ -146,7 +146,7 @@ public:
                 }
                 case EVENT_CORRUPTED_MIND:
                 {
-                    me->CastSpell(me, SPELL_CORRUPTED_MIND, true);
+                    me->CastSpell(me->GetVictim(), SPELL_CORRUPTED_MIND, true);
                     events.RepeatEvent(10000);
                     break;
                 }

--- a/src/naxx40Scripts/boss_loatheb_40.cpp
+++ b/src/naxx40Scripts/boss_loatheb_40.cpp
@@ -21,29 +21,21 @@
 
 enum Spells
 {
-    SPELL_NECROTIC_AURA                         = 55593,
-    SPELL_DEATHBLOOM                            = 29865,
+    SPELL_CORRUPTED_MIND                        = 29201, // this triggers the following spells on targets (based on class): 29185, 29194, 29196, 29198
+    SPELL_DEATHBLOOM                            = 29865, // poison aura
     SPELL_INEVITABLE_DOOM                       = 29204,
-    SPELL_BERSERK                               = 26662
+    SPELL_REMOVE_CURSE                          = 30281  // He periodically removes all curses on himself
 };
 
 enum Events
 {
-    EVENT_NECROTIC_AURA                         = 1,
-    EVENT_DEATHBLOOM                            = 2,
-    EVENT_INEVITABLE_DOOM                       = 3,
-    EVENT_BERSERK                               = 4,
-    EVENT_SUMMON_SPORE                          = 5,
-    EVENT_NECROTIC_AURA_FADING                  = 6,
-    EVENT_NECROTIC_AURA_REMOVED                 = 7
+    EVENT_DEATHBLOOM                            = 1,
+    EVENT_INEVITABLE_DOOM                       = 2,
+    EVENT_SUMMON_SPORE                          = 3,
+    EVENT_CORRUPTED_MIND                        = 4,
+    EVENT_REMOVE_CURSE                          = 5
 };
 
-enum Texts
-{
-    SAY_NECROTIC_AURA_APPLIED                   = 0,
-    SAY_NECROTIC_AURA_REMOVED                   = 1,
-    SAY_NECROTIC_AURA_FADING                    = 2
-};
 
 class boss_loatheb_40 : public CreatureScript
 {
@@ -110,11 +102,11 @@ public:
         {
             BossAI::JustEngagedWith(who);
             me->SetInCombatWithZone();
-            events.ScheduleEvent(EVENT_NECROTIC_AURA, 10000);
+            events.ScheduleEvent(EVENT_CORRUPTED_MIND, 5000);
             events.ScheduleEvent(EVENT_DEATHBLOOM, 5000);
             events.ScheduleEvent(EVENT_INEVITABLE_DOOM, 120000);
-            events.ScheduleEvent(EVENT_SUMMON_SPORE, 15000);
-            events.ScheduleEvent(EVENT_BERSERK, 720000);
+            events.ScheduleEvent(EVENT_SUMMON_SPORE, 13000);
+            events.ScheduleEvent(EVENT_REMOVE_CURSE, 5000);
             if (pInstance)
             {
                 pInstance->SetData(BOSS_LOATHEB, IN_PROGRESS);
@@ -147,22 +139,22 @@ public:
             switch (events.ExecuteEvent())
             {
                 case EVENT_SUMMON_SPORE:
+                {
                     me->CastSpell(me, SPELL_SUMMON_SPORE, true);
-                    events.RepeatEvent(35000);
+                    events.RepeatEvent(13000);
                     break;
-                case EVENT_NECROTIC_AURA:
-                    me->CastSpell(me, SPELL_NECROTIC_AURA, true);
-                    Talk(SAY_NECROTIC_AURA_APPLIED);
-                    events.ScheduleEvent(EVENT_NECROTIC_AURA_FADING, 14000);
-                    events.ScheduleEvent(EVENT_NECROTIC_AURA_REMOVED, 17000);
-                    events.RepeatEvent(20000);
+                }
+                case EVENT_CORRUPTED_MIND:
+                {
+                    me->CastCustomSpell(me, SPELL_CORRUPTED_MIND, &bp0, 0, 0, false);
+                    events.RepeatEvent(10000);
                     break;
+                }
                 case EVENT_DEATHBLOOM:
                 {
-                    //me->CastSpell(me, SPELL_DEATHBLOOM, false);
                     int32 bp0 = 33; // TODO: Amplitude should be 6k, but is 1k. 200 dmg after 6 seconds
                     me->CastCustomSpell(me, SPELL_DEATHBLOOM, &bp0, 0, 0, false);
-                    events.RepeatEvent(30000);
+                    events.RepeatEvent(12000);
                     break;
                 }
                 case EVENT_INEVITABLE_DOOM:
@@ -173,15 +165,12 @@ public:
                     events.RepeatEvent(doomCounter < 6 ? 30000 : 15000);
                     break;
                 }
-                case EVENT_BERSERK:
-                    me->CastSpell(me, SPELL_BERSERK, true);
+                case EVENT_REMOVE_CURSE:
+                {
+                    me->CastCustomSpell(me, SPELL_REMOVE_CURSE, &bp0, 0, 0, false);
+                    events.RepeatEvent(30000);
                     break;
-                case EVENT_NECROTIC_AURA_FADING:
-                    Talk(SAY_NECROTIC_AURA_FADING);
-                    break;
-                case EVENT_NECROTIC_AURA_REMOVED:
-                    Talk(SAY_NECROTIC_AURA_REMOVED);
-                    break;
+                }
             }
             DoMeleeAttackIfReady();
         }

--- a/src/naxx40Scripts/boss_loatheb_40.cpp
+++ b/src/naxx40Scripts/boss_loatheb_40.cpp
@@ -33,7 +33,6 @@ enum Events
 {
     // EVENT_CORRUPTED_MIND                     = 1,
 	EVENT_NECROTIC_AURA                         = 1,
-    // EVENT_POISON_AURA                        = 2,
 	EVENT_POISON_SHOCK                          = 2, 
     EVENT_INEVITABLE_DOOM                       = 3,
     EVENT_SUMMON_SPORE                          = 4,
@@ -116,7 +115,6 @@ public:
             me->SetInCombatWithZone();
             // events.ScheduleEvent(EVENT_CORRUPTED_MIND, 5000);
 		    events.ScheduleEvent(EVENT_NECROTIC_AURA, 10000);
-            // events.ScheduleEvent(EVENT_POISON_AURA, 5000);
 			events.ScheduleEvent(EVENT_POISON_SHOCK, 6000);
             events.ScheduleEvent(EVENT_INEVITABLE_DOOM, 120000);
             events.ScheduleEvent(EVENT_SUMMON_SPORE, 13000);
@@ -178,22 +176,6 @@ public:
 					{
 	                    events.RepeatEvent(100);						
                     }
-                    break;
-                }
-				*/
-				/*
-                case EVENT_POISON_AURA:
-                {
-                    // int32 bp0 = 33; // TODO: (200 dmg every 6 seconds) Amplitude should be 6k. DurationIndex should be 29 (12 seconds). no 1200 dmg afterwards
-                    // if (me->CastCustomSpell(me, SPELL_POISON_AURA, &bp0, 0, 0, false) == SPELL_CAST_OK)
-					if (me->CastSpell(me, SPELL_POISON_AURA, false) == SPELL_CAST_OK)
-					{	
-                        events.RepeatEvent(12000);
-					}
-					else
-					{
-						events.RepeatEvent(100);
-					}
                     break;
                 }
 				*/


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/525

- no longer casts Berserk
- no longer casts Deathbloom / poison aura
- now casts poison shock every 6 seconds to simulate the old poison aura spell.
- now casts Remove Curse on himself
- summons spores ever 13 seconds instead of 35


Loatheb should cast Necrotic Mind on players instead of Necrotic Aura
(doesn't work yet, needs new script which I can't get to work

