### PR TITLE
Fix duplicate quest reward for "Supplying the Front"

### DIFF
--- a/sql/world/base/vanilla_quest_levels.sql
+++ b/sql/world/base/vanilla_quest_levels.sql
@@ -331,7 +331,7 @@ UPDATE quest_template SET RequiredItemCount1 = 6 WHERE ID=1322;
 UPDATE quest_template SET RequiredItemCount1 = 10 WHERE ID=1424;
 
 /*  Supplying the Front  */
-UPDATE quest_template SET RewardItem1 = 0, RewardAmount1 = 0 WHERE ID=1578;
+UPDATE quest_template SET RewardItem1 = 3609, RewardItem2 = 0, RewardAmount2 = 0 WHERE ID=1578;
 
 /*  Dragonmaw Shinbones  */
 UPDATE quest_template SET RequiredItemId1 = 7134, RequiredItemId2 = 0, RequiredItemCount1 = 8, RequiredItemCount2 = 0 WHERE ID=1846;

--- a/sql/world/base/vanilla_quest_levels.sql
+++ b/sql/world/base/vanilla_quest_levels.sql
@@ -331,7 +331,7 @@ UPDATE quest_template SET RequiredItemCount1 = 6 WHERE ID=1322;
 UPDATE quest_template SET RequiredItemCount1 = 10 WHERE ID=1424;
 
 /*  Supplying the Front  */
-UPDATE quest_template SET RewardItem1 = 3609 WHERE ID=1578;
+UPDATE quest_template SET RewardItem1 = 0, RewardAmount1 = 0 WHERE ID=1578;
 
 /*  Dragonmaw Shinbones  */
 UPDATE quest_template SET RequiredItemId1 = 7134, RequiredItemId2 = 0, RequiredItemCount1 = 8, RequiredItemCount2 = 0 WHERE ID=1846;


### PR DESCRIPTION
Just a really small fix to the duplicate quest reward of Supplying the Front.

In TBC, this quest rewards two items:
(1) `Plans: Heavy Copper Longsword`
(2) `Plans: Copper Chain Vest`

Whereas in Vanilla, this quest only rewards `Plans: Copper Chain Vest`.
`vanilla_quest_levels.sql` changes the reward item (1) to `Plans: Copper Chain Vest`, which results in the player obtaining the recipe twice.

https://www.wowhead.com/classic/quest=1578/supplying-the-front
https://www.wowhead.com/tbc/quest=1578/supplying-the-front