### PR TITLE
fix: remove redeclaration of variable

### DIFF
--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -106,7 +106,6 @@ enum ProgressionZones
 
 enum ProgressionAreas
 {
-    AREA_AZSHARA                         = 16,
     AREA_THE_DARK_PORTAL                 = 72,
     AREA_DREADMAUL_ROCK                  = 249,
     AREA_RUINS_OF_THAURISSAN             = 250,


### PR DESCRIPTION
compatibility with recent acore
- https://github.com/azerothcore/azerothcore-wotlk/blob/88342576e070476f4866a82873bc9b1080e1ab99/src/server/game/Maps/AreaDefines.h#L34