### PR TITLE
possible fix for startup lag

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -19,6 +19,11 @@ public:
 
     void OnPlayerLogin(Player* player) override
     {
+        if (!sIndividualProgression->enabled || isExcludedFromProgression(player))
+        {
+            return;
+        }
+        
         if (player->getClass() == CLASS_DEATH_KNIGHT && sIndividualProgression->deathKnightStartingProgression && !sIndividualProgression->hasPassedProgression(player, static_cast<ProgressionState>(sIndividualProgression->deathKnightStartingProgression)))
         {
             sIndividualProgression->UpdateProgressionState(player, static_cast<ProgressionState>(sIndividualProgression->deathKnightStartingProgression));


### PR DESCRIPTION
if you have a lot of RND bots on your server
this update may fix some startup lag issues.

you do need this setting
IndividualProgression.ExcludedAccountsRegex = "^RNDBOT.*"

RND bots will no longer get checked for progression updates when they log in.