### PR TITLE
Remove RDF from SimpleConfigOverride config option

### DIFF
--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -293,8 +293,8 @@ IndividualProgression.PvPGearRequirements = 1
 # IndividualProgression.DisableRDF
 #        Description: Enable or disable the Random Dungeon Finder feature within the context of Individual Progression. 
 #        Queuing for specific dungeons and Holiday Events will still be possible. (Use DungeonFinder.OptionsMask in worldserver.conf to completely disable the LFG tool.)
-#        Default:     0 - Enabled
-#                     1 - Disabled
+#        Default:     0 - RDF Enabled
+#                     1 - RDF Disabled
 #
 IndividualProgression.DisableRDF = 0
 

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -293,7 +293,6 @@ IndividualProgression.PvPGearRequirements = 1
 # IndividualProgression.DisableRDF
 #        Description: Enable or disable the Random Dungeon Finder feature within the context of Individual Progression. 
 #        Queuing for specific dungeons and Holiday Events will still be possible. (Use DungeonFinder.OptionsMask in worldserver.conf to completely disable the LFG tool.)
-#        Please note that the LFG tool is disabled (except for Holiday events) by default if SimpleConfigOverride is enabled.
 #        Default:     0 - Enabled
 #                     1 - Disabled
 #

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -290,6 +290,15 @@ IndividualProgression.AllowEarlyDungeonSet2 = 1
 #
 IndividualProgression.PvPGearRequirements = 1
 
+# IndividualProgression.DisableRDF
+#        Description: Enable or disable the Random Dungeon Finder feature within the context of Individual Progression. 
+#        Queuing for specific dungeons and Holiday Events will still be possible. (Use DungeonFinder.OptionsMask in worldserver.conf to completely disable the LFG tool.)
+#        Please note that the LFG tool is disabled (except for Holiday events) by default if SimpleConfigOverride is enabled.
+#        Default:     0 - Enabled
+#                     1 - Disabled
+#
+IndividualProgression.DisableRDF = 0
+
 # IndividualProgression.ExcludeAccounts
 #        Description: Enable or disable the exclusion of accounts from Individual Progression.
 #        This is useful for accounts that are used for bots, testing, or other purposes where progression should not be enforced.

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -290,14 +290,6 @@ IndividualProgression.AllowEarlyDungeonSet2 = 1
 #
 IndividualProgression.PvPGearRequirements = 1
 
-# IndividualProgression.DisableRDF
-#        Description: Enable or disable the Random Dungeon Finder feature within the context of Individual Progression. 
-#        Queuing for specific dungeons and Holiday Events will still be possible. (Use DungeonFinder.OptionsMask in worldserver.conf to completely disable the LFG tool.)
-#        Default:     0 - Enabled
-#                     1 - Disabled
-#
-IndividualProgression.DisableRDF = 0
-
 # IndividualProgression.ExcludeAccounts
 #        Description: Enable or disable the exclusion of accounts from Individual Progression.
 #        This is useful for accounts that are used for bots, testing, or other purposes where progression should not be enforced.

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -168,7 +168,6 @@ IndividualProgression.FishingFix = 1
 #                     Water Breath Timer to 1 Minute (Vanilla value, changed to 3 Minutes in WotLK)
 #                     Disable Quest Object sparkle and object quest markers (added in patch 2.3)
 #                     Enable PlayerSettings (required by Individual Progression module)
-#                     Disable the LFG tool, aside from special Holiday events otherwise inaccessible
 #                     Do not enforce DBC Item Attributes, so that Vanilla item changes can override client values
 #
 #        Default:   1 - Enabled
@@ -294,7 +293,6 @@ IndividualProgression.PvPGearRequirements = 1
 # IndividualProgression.DisableRDF
 #        Description: Enable or disable the Random Dungeon Finder feature within the context of Individual Progression. 
 #        Queuing for specific dungeons and Holiday Events will still be possible. (Use DungeonFinder.OptionsMask in worldserver.conf to completely disable the LFG tool.)
-#        Please note that the LFG tool is disabled (except for Holiday events) by default if SimpleConfigOverride is enabled.
 #        Default:     0 - Enabled
 #                     1 - Disabled
 #

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -354,7 +354,7 @@ public:
             sWorld->setBoolConfig(CONFIG_DBC_ENFORCE_ITEM_ATTRIBUTES, false);
         }
 
-        if (IndividualProgression->DisableRDF)
+        if (sIndividualProgression->DisableRDF)
         {
             sWorld->setIntConfig(CONFIG_LFG_OPTIONSMASK, 4);
         }        

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -352,6 +352,11 @@ public:
             sWorld->setBoolConfig(CONFIG_LOW_LEVEL_REGEN_BOOST, false);
             sWorld->setBoolConfig(CONFIG_DBC_ENFORCE_ITEM_ATTRIBUTES, false);
         }
+
+        if (IndividualProgression->DisableRDF)
+        {
+            sWorld->setIntConfig(CONFIG_LFG_OPTIONSMASK, 4);
+        }        
     }
 };
 

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -307,6 +307,7 @@ private:
         sIndividualProgression->LoadCustomProgressionEntries(sConfigMgr->GetOption<std::string>("IndividualProgression.CustomProgression", ""));
         sIndividualProgression->earlyDungeonSet2 = sConfigMgr->GetOption<bool>("IndividualProgression.AllowEarlyDungeonSet2", true);
         sIndividualProgression->pvpGearRequirements = sConfigMgr->GetOption<bool>("IndividualProgression.PvPGearRequirements", true);
+        sIndividualProgression->DisableRDF = sConfigMgr->GetOption<bool>("IndividualProgression.DisableRDF", false);
         sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", false);
         sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "");
     }

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -346,7 +346,6 @@ public:
         if (sIndividualProgression->simpleConfigOverride)
         {
             sWorld->setIntConfig(CONFIG_WATER_BREATH_TIMER, 60000);
-            sWorld->setIntConfig(CONFIG_LFG_OPTIONSMASK, 4);
             sWorld->setBoolConfig(CONFIG_OBJECT_QUEST_MARKERS, false);
             sWorld->setBoolConfig(CONFIG_OBJECT_SPARKLES, false);
             sWorld->setBoolConfig(CONFIG_PLAYER_SETTINGS_ENABLED, true);

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -226,7 +226,7 @@ public:
     std::map<uint32, uint8> customProgressionMap;
     questXpMapType questXpMap;
     float vanillaPowerAdjustment, vanillaHealthAdjustment, tbcPowerAdjustment, tbcHealthAdjustment, vanillaHealingAdjustment, tbcHealingAdjustment, previousGearTuning;
-    bool enabled, questXpFix, hunterPetLevelFix, enforceGroupRules, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, requireNaxxStrath, pvpGearRequirements, excludeAccounts;
+    bool enabled, questXpFix, hunterPetLevelFix, enforceGroupRules, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, requireNaxxStrath, pvpGearRequirements, DisableRDF, excludeAccounts;
     int progressionLimit, startingProgression, tbcRacesProgressionLevel, deathKnightProgressionLevel, deathKnightStartingProgression;
     std::string excludedAccountsRegex;
 

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -1019,37 +1019,6 @@ public:
         }
     }
 
-    void OnPlayerQueueRandomDungeon(Player* player, uint32& rDungeonId) override
-    {
-        // List of exceptions for seasonal event dungeons
-        std::set<uint32> seasonalEventDungeons = { 285, 286, 287, 288 };
-        if (seasonalEventDungeons.find(rDungeonId) != seasonalEventDungeons.end())
-        {
-            return;
-        }
-
-        // Check if RDF is disabled in the context of Individual Progression
-        if (sConfigMgr->GetOption<bool>("IndividualProgression.DisableRDF", false))
-        {
-            ChatHandler(player->GetSession()).SendNotification("The Random Dungeon feature is currently disabled by the Individual Progression module.");
-            rDungeonId = 1000; // Set dungeon ID to an invalid value to cancel the queuing
-            return;
-        }
-
-        if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC) || (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC) && (player->GetLevel() <= IP_LEVEL_VANILLA)))
-        {
-            rDungeonId = RDF_CLASSIC;
-        }
-        else if ((rDungeonId == RDF_WRATH_OF_THE_LICH_KING && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5)) || (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (player->GetLevel() <= IP_LEVEL_TBC)))
-        {
-            rDungeonId = RDF_THE_BURNING_CRUSADE;
-        }
-        else if ((rDungeonId == RDF_WRATH_OF_THE_LICH_KING_HEROIC && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5)) || (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (player->GetLevel() <= IP_LEVEL_TBC)))
-        {
-            rDungeonId = RDF_THE_BURNING_CRUSADE_HEROIC;
-        }
-    }
-
     bool OnPlayerCanEquipItem(Player* player, uint8 /*slot*/, uint16& /*dest*/, Item* pItem, bool /*swap*/, bool /*not_loading*/) override
     {
         if (sIndividualProgression->pvpGearRequirements)


### PR DESCRIPTION
removed RDF from the SimpleConfigOverride
including it in the SimpleConfigOverride complicates things
because if you wanted to enable the RDF you were forced to change several other settings as well.

it's all very confusing
I'm trying to make it simple.

With disableRDF in the Individual Progression config file you can now enable/disable the RDF.
that's it. no need to edit the worldserver.conf file for this any more.

it's also very clear now when it's disabled. can't even select dungeons anymore.