### PR TITLE
Now also checking achievements for progression kills

### DIFF
--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -226,52 +226,52 @@ void IndividualProgression::checkKillProgression(Player* killer, Creature* kille
             return;
         }
 
-        if (killed->GetEntry() == HALION || killer->HasAchieved(HALION_KILLS)) // 4820
+        if (killed->GetEntry() == HALION || killer->HasAchieved(HALION_KILL)) // 4815
         {
             UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_5);
             return;
         }
-        else if (killed->GetEntry() == LICH_KING || killer->HasAchieved(LICH_KING_KILLS)) // 4687
+        else if (killed->GetEntry() == LICH_KING || killer->HasAchieved(LICH_KING_KILL)) // 4597
         {
             UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_4);
             return;
         }
-        else if (killed->GetEntry() == ANUBARAK || killer->HasAchieved(ANUB_ARAK_KILLS)) // 1232
+        else if (killed->GetEntry() == ANUBARAK || killer->HasAchieved(ANUB_ARAK_KILL)) // 3916
         {
             UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_3);
             return;
         }
-        else if (killed->GetEntry() == YOGGSARON || killer->HasAchieved(YOGG_SARON_KILLS)) // 2883
+        else if (killed->GetEntry() == YOGGSARON)
         {
             UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_2);
             return;
         }
-        else if (killed->GetEntry() == KELTHUZAD || killer->HasAchieved(KEL_THUZAD_KILLS)) // 1390
+        else if (killed->GetEntry() == KELTHUZAD || killer->HasAchieved(KEL_THUZAD_KILL)) // 575
         {
             UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_1);
             return;
         }
-        else if (killed->GetEntry() == KILJAEDEN || killer->HasAchieved(KIL_JAEDEN_KILLS)) // 1090
+        else if (killed->GetEntry() == KILJAEDEN || killer->HasAchieved(KIL_JAEDEN_KILL)) // 698
         {
             UpdateProgressionState(killer, PROGRESSION_TBC_TIER_5);
             return;
         }
-        else if (killed->GetEntry() == ZULJIN|| killer->HasAchieved(ZUL_JIN_KILLS)) // 1084
+        else if (killed->GetEntry() == ZULJIN|| killer->HasAchieved(ZUL_JIN_KILL)) // 691
         {
             UpdateProgressionState(killer, PROGRESSION_TBC_TIER_4);
             return;
         }
-        else if (killed->GetEntry() == ILLIDAN || killer->HasAchieved(ILLIDAN_KILLS)) // 1089
+        else if (killed->GetEntry() == ILLIDAN || killer->HasAchieved(ILLIDAN_KILL)) // 697
         {
             UpdateProgressionState(killer, PROGRESSION_TBC_TIER_3);
             return;
         }
-        else if (killed->GetEntry() == KAELTHAS|| killer->HasAchieved(KAEL_THAS_KILLS)) // 1088
+        else if (killed->GetEntry() == KAELTHAS|| killer->HasAchieved(KAEL_THAS_KILL)) // 696
         {
             UpdateProgressionState(killer, PROGRESSION_TBC_TIER_2);
             return;
         }
-        else if (killed->GetEntry() == MALCHEZAAR || killer->HasAchieved(MALCHEZAAR_KILLS)) //  1083
+        else if (killed->GetEntry() == MALCHEZAAR || killer->HasAchieved(MALCHEZAAR_KILL)) //  690
         {
             UpdateProgressionState(killer, PROGRESSION_TBC_TIER_1);
             return;
@@ -281,22 +281,22 @@ void IndividualProgression::checkKillProgression(Player* killer, Creature* kille
             UpdateProgressionState(killer, PROGRESSION_NAXX40);
             return;
         }
-        else if (killed->GetEntry() == CTHUN || killer->HasAchieved(C_THUN_KILLS)) // 1101
+        else if (killed->GetEntry() == CTHUN || killer->HasAchieved(C_THUN_KILL)) // 687
         {
             UpdateProgressionState(killer, PROGRESSION_AQ);
             return;
         }
-        else if (killed->GetEntry() == NEFARIAN || killer->HasAchieved(NEFARIAN_KILLS)) // 1100
+        else if (killed->GetEntry() == NEFARIAN || killer->HasAchieved(NEFARIAN_KILL)) // 685
         {
             UpdateProgressionState(killer, PROGRESSION_BLACKWING_LAIR);
             return;
         }
-        else if (killed->GetEntry() == ONYXIA || killer->HasAchieved(ONYXIAS_KILLS)) // 684
+        else if (killed->GetEntry() == ONYXIA || killer->HasAchieved(ONYXIAS_KILL)) // 684
         {
             UpdateProgressionState(killer, PROGRESSION_ONYXIA);
             return;
         }
-        else if (killed->GetEntry() == RAGNAROS || killer->HasAchieved(RAGNAROS_KILLS)) // 1099
+        else if (killed->GetEntry() == RAGNAROS || killer->HasAchieved(RAGNAROS_KILL)) // 686
         {
             UpdateProgressionState(killer, PROGRESSION_MOLTEN_CORE);
             return;

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -208,7 +208,7 @@ bool IndividualProgression::hasCustomProgressionValue(uint32 creatureEntry)
 }
 
 
-void IndividualProgression::checkKillProgression(Player* killer, Creature* killed)
+void IndividualProgression::checkKillProgression(Player* killer, Creature* /*killed*/)
 {
         if (!enabled)
         {
@@ -225,53 +225,81 @@ void IndividualProgression::checkKillProgression(Player* killer, Creature* kille
         {
             return;
         }
-        switch (killed->GetEntry())
+
+        if (killed->GetEntry(HALION) || killer->CompletedAchievement(HALION_KILLS)) // 4820
         {
-            case RAGNAROS:
-                UpdateProgressionState(killer, PROGRESSION_MOLTEN_CORE);
-                break;
-            case ONYXIA:
-                UpdateProgressionState(killer, PROGRESSION_ONYXIA);
-                break;
-            case NEFARIAN:
-                UpdateProgressionState(killer, PROGRESSION_BLACKWING_LAIR);
-                break;
-            case CTHUN:
-                UpdateProgressionState(killer, PROGRESSION_AQ);
-                break;
-            case KELTHUZAD_40:
-                UpdateProgressionState(killer, PROGRESSION_NAXX40);
-                break;
-            case MALCHEZAAR:
-                UpdateProgressionState(killer, PROGRESSION_TBC_TIER_1);
-                break;
-            case KAELTHAS:
-                UpdateProgressionState(killer, PROGRESSION_TBC_TIER_2);
-                break;
-            case ILLIDAN:
-                UpdateProgressionState(killer, PROGRESSION_TBC_TIER_3);
-                break;
-            case ZULJIN:
-                UpdateProgressionState(killer, PROGRESSION_TBC_TIER_4);
-                break;
-            case KILJAEDEN:
-                UpdateProgressionState(killer, PROGRESSION_TBC_TIER_5);
-                break;
-            case KELTHUZAD:
-                UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_1);
-                break;
-            case YOGGSARON:
-                UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_2);
-                break;
-            case ANUBARAK:
-                UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_3);
-                break;
-            case LICH_KING:
-                UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_4);
-                break;
-            case HALION:
-                UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_5);
-                break;
+            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_5);
+            return;
+        }
+        else if (killed->GetEntry(LICH_KING) || killer->CompletedAchievement(LICH_KING_KILLS)) // 4687
+        {
+            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_4);
+            return;
+        }
+        else if (killed->GetEntry(ANUBARAK) || killer->CompletedAchievement(ANUB_ARAK_KILLS)) // 1232
+        {
+            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_3);
+            return;
+        }
+        else if (killed->GetEntry(YOGGSARON) || killer->CompletedAchievement(YOGG_SARON_KILLS)) // 2883
+        {
+            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_2);
+            return;
+        }
+        else if (killed->GetEntry(KELTHUZAD) || killer->CompletedAchievement(KEL_THUZAD_KILLS)) // 1390
+        {
+            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_1);
+            return;
+        }
+        else if (killed->GetEntry(KILJAEDEN) || killer->CompletedAchievement(KIL_JAEDEN_KILLS)) // 1090
+        {
+            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_5);
+            return;
+        }
+        else if (killed->GetEntry(ZULJIN) || killer->CompletedAchievement(ZUL_JIN_KILLS)) // 1084
+        {
+            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_4);
+            return;
+        }
+        else if (killed->GetEntry(ILLIDAN) || killer->CompletedAchievement(ILLIDAN_KILLS)) // 1089
+        {
+            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_3);
+            return;
+        }
+        else if (killed->GetEntry(KAELTHAS) || killer->CompletedAchievement(KAEL_THAS_KILLS)) // 1088
+        {
+            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_2);
+            return;
+        }
+        else if (killed->GetEntry(MALCHEZAAR) || killer->CompletedAchievement(MALCHEZAAR_KILLS)) //  1083
+        {
+            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_1);
+            return;
+        }
+        else if (killed->GetEntry(KELTHUZAD_40) || killed->GetEntry(KELTHUZAD_40))
+        {
+            UpdateProgressionState(killer, PROGRESSION_NAXX40);
+            return;
+        }
+        else if (killed->GetEntry(CTHUN) || killer->CompletedAchievement(C_THUN_KILLS)) // 1101
+        {
+            UpdateProgressionState(killer, PROGRESSION_AQ);
+            return;
+        }
+        else if (killed->GetEntry(NEFARIAN) || killer->CompletedAchievement(NEFARIAN_KILLS)) // 1100
+        {
+            UpdateProgressionState(killer, PROGRESSION_BLACKWING_LAIR);
+            return;
+        }
+        else if (killed->GetEntry(ONYXIA) || killer->CompletedAchievement(ONYXIAS_LAIR)) // 684
+        {
+            UpdateProgressionState(killer, PROGRESSION_ONYXIA);
+            return;
+        }
+        else if (killed->GetEntry(RAGNAROS) || killer->CompletedAchievement(RAGNAROS_KILLS)) // 1099
+        {
+            UpdateProgressionState(killer, PROGRESSION_MOLTEN_CORE);
+            return;
         }
 }
 

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -208,99 +208,146 @@ bool IndividualProgression::hasCustomProgressionValue(uint32 creatureEntry)
 }
 
 
+void IndividualProgression::checkIPProgression(Player* killer)
+{
+    if (!enabled || disableDefaultProgression)
+    {
+        return;
+    }
+
+    if (killer->HasAchieved(HALION_KILL)) // 4815
+    {
+        UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_5);
+        return;
+    }
+    else if (killer->HasAchieved(LICH_KING_KILL)) // 4597
+    {
+        UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_4);
+        return;
+    }
+    else if (killer->HasAchieved(ANUB_ARAK_KILL)) // 3916
+    {
+        UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_3);
+        return;
+    }
+    else if (killer->HasAchieved(KEL_THUZAD_KILL)) // 575
+    {
+        UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_1);
+        return;
+    }
+    else if (killer->HasAchieved(KIL_JAEDEN_KILL)) // 698
+    {
+        UpdateProgressionState(killer, PROGRESSION_TBC_TIER_5);
+        return;
+    }
+    else if (killer->HasAchieved(ZUL_JIN_KILL)) // 691
+    {
+        UpdateProgressionState(killer, PROGRESSION_TBC_TIER_4);
+        return;
+    }
+    else if (killer->HasAchieved(ILLIDAN_KILL)) // 697
+    {
+        UpdateProgressionState(killer, PROGRESSION_TBC_TIER_3);
+        return;
+    }
+    else if (killer->HasAchieved(KAEL_THAS_KILL)) // 696
+    {
+        UpdateProgressionState(killer, PROGRESSION_TBC_TIER_2);
+        return;
+    }
+    else if (killer->HasAchieved(MALCHEZAAR_KILL)) //  690
+    {
+        UpdateProgressionState(killer, PROGRESSION_TBC_TIER_1);
+        return;
+    }
+    else if (killer->HasAchieved(C_THUN_KILL)) // 687
+    {
+        UpdateProgressionState(killer, PROGRESSION_AQ);
+        return;
+    }
+    else if (killer->HasAchieved(NEFARIAN_KILL)) // 685
+    {
+        UpdateProgressionState(killer, PROGRESSION_BLACKWING_LAIR);
+        return;
+    }
+    else if (killer->HasAchieved(ONYXIAS_KILL)) // 684
+    {
+        UpdateProgressionState(killer, PROGRESSION_ONYXIA);
+        return;
+    }
+    else if (killer->HasAchieved(RAGNAROS_KILL)) // 686
+    {
+        UpdateProgressionState(killer, PROGRESSION_MOLTEN_CORE);
+        return;
+    }
+}
+
 void IndividualProgression::checkKillProgression(Player* killer, Creature* killed)
 {
-        if (!enabled)
-        {
-            return;
-        }
+    if (!enabled)
+    {
+        return;
+    }
 
-        if (hasCustomProgressionValue(killed->GetEntry()))
-        {
-            UpdateProgressionState(killer, static_cast<ProgressionState>(customProgressionMap[killed->GetEntry()]));
-            return;
-        }
+    if (hasCustomProgressionValue(killed->GetEntry()))
+    {
+        UpdateProgressionState(killer, static_cast<ProgressionState>(customProgressionMap[killed->GetEntry()]));
+        return;
+    }
 
-        if (disableDefaultProgression)
-        {
-            return;
-        }
+    if (disableDefaultProgression)
+    {
+        return;
+    }
 
-        if (killed->GetEntry() == HALION || killer->HasAchieved(HALION_KILL)) // 4815
-        {
-            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_5);
-            return;
-        }
-        else if (killed->GetEntry() == LICH_KING || killer->HasAchieved(LICH_KING_KILL)) // 4597
-        {
-            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_4);
-            return;
-        }
-        else if (killed->GetEntry() == ANUBARAK || killer->HasAchieved(ANUB_ARAK_KILL)) // 3916
-        {
-            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_3);
-            return;
-        }
-        else if (killed->GetEntry() == YOGGSARON)
-        {
-            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_2);
-            return;
-        }
-        else if (killed->GetEntry() == KELTHUZAD || killer->HasAchieved(KEL_THUZAD_KILL)) // 575
-        {
-            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_1);
-            return;
-        }
-        else if (killed->GetEntry() == KILJAEDEN || killer->HasAchieved(KIL_JAEDEN_KILL)) // 698
-        {
-            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_5);
-            return;
-        }
-        else if (killed->GetEntry() == ZULJIN|| killer->HasAchieved(ZUL_JIN_KILL)) // 691
-        {
-            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_4);
-            return;
-        }
-        else if (killed->GetEntry() == ILLIDAN || killer->HasAchieved(ILLIDAN_KILL)) // 697
-        {
-            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_3);
-            return;
-        }
-        else if (killed->GetEntry() == KAELTHAS|| killer->HasAchieved(KAEL_THAS_KILL)) // 696
-        {
-            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_2);
-            return;
-        }
-        else if (killed->GetEntry() == MALCHEZAAR || killer->HasAchieved(MALCHEZAAR_KILL)) //  690
-        {
-            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_1);
-            return;
-        }
-        else if (killed->GetEntry() == KELTHUZAD_40)
-        {
-            UpdateProgressionState(killer, PROGRESSION_NAXX40);
-            return;
-        }
-        else if (killed->GetEntry() == CTHUN || killer->HasAchieved(C_THUN_KILL)) // 687
-        {
-            UpdateProgressionState(killer, PROGRESSION_AQ);
-            return;
-        }
-        else if (killed->GetEntry() == NEFARIAN || killer->HasAchieved(NEFARIAN_KILL)) // 685
-        {
-            UpdateProgressionState(killer, PROGRESSION_BLACKWING_LAIR);
-            return;
-        }
-        else if (killed->GetEntry() == ONYXIA || killer->HasAchieved(ONYXIAS_KILL)) // 684
-        {
-            UpdateProgressionState(killer, PROGRESSION_ONYXIA);
-            return;
-        }
-        else if (killed->GetEntry() == RAGNAROS || killer->HasAchieved(RAGNAROS_KILL)) // 686
-        {
+    switch (killed->GetEntry())
+    {
+        case RAGNAROS:
             UpdateProgressionState(killer, PROGRESSION_MOLTEN_CORE);
-            return;
-        }
+            break;
+        case ONYXIA:
+            UpdateProgressionState(killer, PROGRESSION_ONYXIA);
+            break;
+        case NEFARIAN:
+            UpdateProgressionState(killer, PROGRESSION_BLACKWING_LAIR);
+            break;
+        case CTHUN:
+            UpdateProgressionState(killer, PROGRESSION_AQ);
+            break;
+        case KELTHUZAD_40:
+            UpdateProgressionState(killer, PROGRESSION_NAXX40);
+            break;
+        case MALCHEZAAR:
+            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_1);
+            break;
+        case KAELTHAS:
+            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_2);
+            break;
+        case ILLIDAN:
+            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_3);
+            break;
+        case ZULJIN:
+            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_4);
+            break;
+        case KILJAEDEN:
+            UpdateProgressionState(killer, PROGRESSION_TBC_TIER_5);
+            break;
+        case KELTHUZAD:
+            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_1);
+            break;
+        case YOGGSARON:
+            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_2);
+            break;
+        case ANUBARAK:
+            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_3);
+            break;
+        case LICH_KING:
+            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_4);
+            break;
+        case HALION:
+            UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_5);
+            break;
+    }
 }
 
 

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -208,7 +208,7 @@ bool IndividualProgression::hasCustomProgressionValue(uint32 creatureEntry)
 }
 
 
-void IndividualProgression::checkKillProgression(Player* killer, Creature* /*killed*/)
+void IndividualProgression::checkKillProgression(Player* killer, Creature* killed)
 {
         if (!enabled)
         {

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -226,77 +226,77 @@ void IndividualProgression::checkKillProgression(Player* killer, Creature* kille
             return;
         }
 
-        if (killed->GetEntry(HALION) || killer->CompletedAchievement(HALION_KILLS)) // 4820
+        if (killed->GetEntry() == HALION || killer->HasAchieved(HALION_KILLS)) // 4820
         {
             UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_5);
             return;
         }
-        else if (killed->GetEntry(LICH_KING) || killer->CompletedAchievement(LICH_KING_KILLS)) // 4687
+        else if (killed->GetEntry() == LICH_KING || killer->HasAchieved(LICH_KING_KILLS)) // 4687
         {
             UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_4);
             return;
         }
-        else if (killed->GetEntry(ANUBARAK) || killer->CompletedAchievement(ANUB_ARAK_KILLS)) // 1232
+        else if (killed->GetEntry() == ANUBARAK || killer->HasAchieved(ANUB_ARAK_KILLS)) // 1232
         {
             UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_3);
             return;
         }
-        else if (killed->GetEntry(YOGGSARON) || killer->CompletedAchievement(YOGG_SARON_KILLS)) // 2883
+        else if (killed->GetEntry() == YOGGSARON || killer->HasAchieved(YOGG_SARON_KILLS)) // 2883
         {
             UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_2);
             return;
         }
-        else if (killed->GetEntry(KELTHUZAD) || killer->CompletedAchievement(KEL_THUZAD_KILLS)) // 1390
+        else if (killed->GetEntry() == KELTHUZAD || killer->HasAchieved(KEL_THUZAD_KILLS)) // 1390
         {
             UpdateProgressionState(killer, PROGRESSION_WOTLK_TIER_1);
             return;
         }
-        else if (killed->GetEntry(KILJAEDEN) || killer->CompletedAchievement(KIL_JAEDEN_KILLS)) // 1090
+        else if (killed->GetEntry() == KILJAEDEN || killer->HasAchieved(KIL_JAEDEN_KILLS)) // 1090
         {
             UpdateProgressionState(killer, PROGRESSION_TBC_TIER_5);
             return;
         }
-        else if (killed->GetEntry(ZULJIN) || killer->CompletedAchievement(ZUL_JIN_KILLS)) // 1084
+        else if (killed->GetEntry() == ZULJIN|| killer->HasAchieved(ZUL_JIN_KILLS)) // 1084
         {
             UpdateProgressionState(killer, PROGRESSION_TBC_TIER_4);
             return;
         }
-        else if (killed->GetEntry(ILLIDAN) || killer->CompletedAchievement(ILLIDAN_KILLS)) // 1089
+        else if (killed->GetEntry() == ILLIDAN || killer->HasAchieved(ILLIDAN_KILLS)) // 1089
         {
             UpdateProgressionState(killer, PROGRESSION_TBC_TIER_3);
             return;
         }
-        else if (killed->GetEntry(KAELTHAS) || killer->CompletedAchievement(KAEL_THAS_KILLS)) // 1088
+        else if (killed->GetEntry() == KAELTHAS|| killer->HasAchieved(KAEL_THAS_KILLS)) // 1088
         {
             UpdateProgressionState(killer, PROGRESSION_TBC_TIER_2);
             return;
         }
-        else if (killed->GetEntry(MALCHEZAAR) || killer->CompletedAchievement(MALCHEZAAR_KILLS)) //  1083
+        else if (killed->GetEntry() == MALCHEZAAR || killer->HasAchieved(MALCHEZAAR_KILLS)) //  1083
         {
             UpdateProgressionState(killer, PROGRESSION_TBC_TIER_1);
             return;
         }
-        else if (killed->GetEntry(KELTHUZAD_40) || killed->GetEntry(KELTHUZAD_40))
+        else if (killed->GetEntry() == KELTHUZAD_40)
         {
             UpdateProgressionState(killer, PROGRESSION_NAXX40);
             return;
         }
-        else if (killed->GetEntry(CTHUN) || killer->CompletedAchievement(C_THUN_KILLS)) // 1101
+        else if (killed->GetEntry() == CTHUN || killer->HasAchieved(C_THUN_KILLS)) // 1101
         {
             UpdateProgressionState(killer, PROGRESSION_AQ);
             return;
         }
-        else if (killed->GetEntry(NEFARIAN) || killer->CompletedAchievement(NEFARIAN_KILLS)) // 1100
+        else if (killed->GetEntry() == NEFARIAN || killer->HasAchieved(NEFARIAN_KILLS)) // 1100
         {
             UpdateProgressionState(killer, PROGRESSION_BLACKWING_LAIR);
             return;
         }
-        else if (killed->GetEntry(ONYXIA) || killer->CompletedAchievement(ONYXIAS_KILLS)) // 684
+        else if (killed->GetEntry() == ONYXIA || killer->HasAchieved(ONYXIAS_KILLS)) // 684
         {
             UpdateProgressionState(killer, PROGRESSION_ONYXIA);
             return;
         }
-        else if (killed->GetEntry(RAGNAROS) || killer->CompletedAchievement(RAGNAROS_KILLS)) // 1099
+        else if (killed->GetEntry() == RAGNAROS || killer->HasAchieved(RAGNAROS_KILLS)) // 1099
         {
             UpdateProgressionState(killer, PROGRESSION_MOLTEN_CORE);
             return;

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -291,7 +291,7 @@ void IndividualProgression::checkKillProgression(Player* killer, Creature* /*kil
             UpdateProgressionState(killer, PROGRESSION_BLACKWING_LAIR);
             return;
         }
-        else if (killed->GetEntry(ONYXIA) || killer->CompletedAchievement(ONYXIAS_LAIR)) // 684
+        else if (killed->GetEntry(ONYXIA) || killer->CompletedAchievement(ONYXIAS_KILLS)) // 684
         {
             UpdateProgressionState(killer, PROGRESSION_ONYXIA);
             return;

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -259,6 +259,7 @@ public:
     void AdjustTBCStats(Player* player) const;
     void AdjustWotLKStats(Player* player) const;
     bool hasCustomProgressionValue(uint32 creatureEntry);
+    void checkIPProgression(Player* player);	
     void checkKillProgression(Player* player, Creature* killed);
     static void LoadCustomProgressionEntries(const std::string& customProgressionString);
     static void AdjustStats(Player* player, float computedAdjustment, float computedHealingAdjustment);

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -94,20 +94,19 @@ enum ProgressionQuests
 
 enum ProgressionAchievements
 {
-    ONYXIAS_KILLS             = 684
-    MALCHEZAAR_KILLS          = 1083,
-    ZUL_JIN_KILLS             = 1084,
-    KAEL_THAS_KILLS           = 1088,
-    ILLIDAN_KILLS             = 1089,
-    KIL_JAEDEN_KILLS          = 1090,
-    RAGNAROS_KILLS            = 1099,
-    NEFARIAN_KILLS            = 1100,
-    C_THUN_KILLS              = 1101,
-    ANUB_ARAK_KILLS           = 1232,
-    KEL_THUZAD_KILLS          = 1390, // WotLK, naxx40 does not have an achievement
-    YOGG_SARON_KILLS          = 2883,
-    LICH_KING_KILLS           = 4687,
-    HALION_KILLS              = 4820
+    KEL_THUZAD_KILL      = 575, // WotLK, naxx40 does not have an achievement
+    ONYXIAS_KILL         = 684,
+    NEFARIAN_KILL        = 685,
+    RAGNAROS_KILL        = 686,
+    C_THUN_KILL          = 687,
+    MALCHEZAAR_KILL      = 690,
+    ZUL_JIN_KILL         = 691,
+    KAEL_THAS_KILL       = 696,
+    ILLIDAN_KILL         = 697,
+    KIL_JAEDEN_KILL      = 698,
+    ANUB_ARAK_KILL       = 3916,
+    LICH_KING_KILL       = 4597,
+    HALION_KILL          = 4815
 };
 
 enum ProgressionZones

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -92,6 +92,24 @@ enum ProgressionQuests
     PROGRESSION_FLAG_WOTLK_T5 = 66018
 };
 
+enum ProgressionAchievements
+{
+    ONYXIAS_KILLS             = 684
+    MALCHEZAAR_KILLS          = 1083,
+    ZUL_JIN_KILLS             = 1084,
+    KAEL_THAS_KILLS           = 1088,
+    ILLIDAN_KILLS             = 1089,
+    KIL_JAEDEN_KILLS          = 1090,
+    RAGNAROS_KILLS            = 1099,
+    NEFARIAN_KILLS            = 1100,
+    C_THUN_KILLS              = 1101,
+    ANUB_ARAK_KILLS           = 1232,
+    KEL_THUZAD_KILLS          = 1390, // WotLK, naxx40 does not have an achievement
+    YOGG_SARON_KILLS          = 2883,
+    LICH_KING_KILLS           = 4687,
+    HALION_KILLS              = 4820
+};
+
 enum ProgressionZones
 {
     ZONE_AZUREMYST       = 3524,

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -502,24 +502,25 @@ public:
         return (currentState == otherPlayerState);
     }
 
-
-
     void OnPlayerCreatureKill(Player* killer, Creature* killed) override
     {
-        sIndividualProgression->checkKillProgression(killer, killed);
-        Group* group = killer->GetGroup();
-        if (!group)
+        if (killed->GetCreatureTemplate()->rank > CREATURE_ELITE_NORMAL)
         {
-            return;
-        }
-        for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
-        {
-            Player* member = itr->GetSource();
-            if (!member)
-                continue;
+            sIndividualProgression->checkKillProgression(killer, killed);
+            Group* group = killer->GetGroup();
+            if (!group)
+            {
+                return;
+            }
+            for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+            {
+                Player* member = itr->GetSource();
+                if (!member)
+                    continue;
 
-            if (killer->IsAtLootRewardDistance(member))
-                sIndividualProgression->checkKillProgression(member, killed);
+                if (killer->IsAtLootRewardDistance(member))
+                    sIndividualProgression->checkKillProgression(member, killed);
+            }
         }
     }
 

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -32,7 +32,9 @@ public:
         {
             sIndividualProgression->UpdateProgressionState(player, static_cast<ProgressionState>(sIndividualProgression->startingProgression));
         }
+
         sIndividualProgression->CheckAdjustments(player);
+        sIndividualProgression->checkIPProgression(player);
 
         if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_MOLTEN_CORE)) && (player->GetQuestStatus(PROGRESSION_FLAG_MC) != QUEST_STATUS_REWARDED))
         {
@@ -501,6 +503,9 @@ public:
         uint8 otherPlayerState = groupLeader->GetPlayerSetting("mod-individual-progression", SETTING_PROGRESSION_STATE).value;
         return (currentState == otherPlayerState);
     }
+
+
+
 
     void OnPlayerCreatureKill(Player* killer, Creature* killed) override
     {


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/585

- now checking achievements as well for progression updates
- no longer checking progression after every creature kill. now only after boss kills.

Naxx40 and Yogg-Saron don't have an achievement. Yogg-Saron only has special condition achievements
so these only get a kill check.

tested this. it works.
