### PR TITLE
Hp adjustments on player login

### DIFF
--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -63,6 +63,25 @@ void IndividualProgression::CheckAdjustments(Player* player) const
         // This lets us add haste spells back to quivers
         player->RemoveAura(RANGED_HASTE_SPELL);
         player->CastSpell(player, RANGED_HASTE_SPELL, false);
+    }	
+}
+
+void IndividualProgression::CheckHPAdjustments(Player* player) const
+{
+    if (!enabled)
+    {
+        return;
+    }
+
+    // Player is still in Vanilla content - give Vanilla health adjustment
+    if (!hasPassedProgression(player, PROGRESSION_PRE_TBC) || (!hasPassedProgression(player, PROGRESSION_PRE_TBC) && (player->GetLevel() <= IP_LEVEL_VANILLA)))
+    {
+        player->SetMaxHealth(player->GetMaxHealth() * vanillaHealthAdjustment);
+    }
+    // Player is in TBC content - give TBC health adjustment
+    else if (!hasPassedProgression(player, PROGRESSION_TBC_TIER_5) || (!hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (player->GetLevel() <= IP_LEVEL_TBC)))
+    {
+        player->SetMaxHealth(player->GetMaxHealth() * tbcHealthAdjustment);
     }
 }
 

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -253,6 +253,7 @@ public:
     void UpdateProgressionState(Player* player, ProgressionState newState) const;
     static void ForceUpdateProgressionState(Player* player, ProgressionState newState);
     void CheckAdjustments(Player* player) const;
+	void CheckHPAdjustments(Player* player) const;
     void ApplyGearStatsTuning(Player* player, float& computedAdjustment, ItemTemplate const* item) const;
     void ComputeGearTuning(Player* player, float& computedAdjustment, ItemTemplate const* item) const;
     void AdjustVanillaStats(Player* player) const;

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -37,7 +37,6 @@ public:
         sIndividualProgression->CheckHPAdjustments(player);
         sIndividualProgression->checkIPProgression(player);
 
-
         if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_MOLTEN_CORE)) && (player->GetQuestStatus(PROGRESSION_FLAG_MC) != QUEST_STATUS_REWARDED))
         {
             Quest const* quest = sObjectMgr->GetQuestTemplate(PROGRESSION_FLAG_MC);
@@ -508,9 +507,6 @@ public:
         uint8 otherPlayerState = groupLeader->GetPlayerSetting("mod-individual-progression", SETTING_PROGRESSION_STATE).value;
         return (currentState == otherPlayerState);
     }
-
-
-
 
     void OnPlayerCreatureKill(Player* killer, Creature* killed) override
     {

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -34,7 +34,9 @@ public:
         }
 
         sIndividualProgression->CheckAdjustments(player);
+        sIndividualProgression->CheckHPAdjustments(player);
         sIndividualProgression->checkIPProgression(player);
+
 
         if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_MOLTEN_CORE)) && (player->GetQuestStatus(PROGRESSION_FLAG_MC) != QUEST_STATUS_REWARDED))
         {
@@ -225,7 +227,7 @@ public:
     void OnPlayerMapChanged(Player* player) override
     {
         sIndividualProgression->CheckAdjustments(player);
-        sIndividualProgression->checkIPProgression(player);
+		sIndividualProgression->checkIPProgression(player);
     }
 
     void OnPlayerLevelChanged(Player* player, uint8 /*oldLevel*/) override
@@ -262,12 +264,14 @@ public:
         {
             return;
         }
+		
         float gearAdjustment = 0.0;
         for (uint8 i = EQUIPMENT_SLOT_START; i < EQUIPMENT_SLOT_END; ++i)
         {
             if (Item* item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
                 sIndividualProgression->ComputeGearTuning(player, gearAdjustment, item->GetTemplate());
         }
+		
         // Player is still in Vanilla content - give Vanilla health adjustment
         if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC) || (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC) && (player->GetLevel() <= IP_LEVEL_VANILLA)))
         {
@@ -505,6 +509,9 @@ public:
         return (currentState == otherPlayerState);
     }
 
+
+
+
     void OnPlayerCreatureKill(Player* killer, Creature* killed) override
     {
         if (killed->GetCreatureTemplate()->rank > CREATURE_ELITE_NORMAL)
@@ -537,7 +544,7 @@ public:
     }
 
     void OnPlayerUpdateArea(Player* player, uint32 /*oldArea*/, uint32 newArea) override
-    {       
+    {
         switch (newArea) {
             case AREA_DARKSHORE:
                 if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_AQ)) && (sIndividualProgression->isBeforeProgression(player, PROGRESSION_AQ_WAR)))


### PR DESCRIPTION
power and healing adjustments were made on player login, but no hp adjustments.
hp adjustments were only made on gear changes or when buffs were received.
now I'm also doing an hp adjustment on player login.

I did notice something that's a bit strange. 
If you log out with an improved prayer of fortitude (70 stamina)
When you log back in you lost the improved part of it. 16 stamina (160 health) is lost.
the game doesn't remember it was the improved version and you get the standard 54 stamina instead.

with the default adjustment for TBC 
IndividualProgression.TBCHealthAdjustment = 0.8
everything gets the nerf. including buffs. so the stamina buff give 43-56 stamina instead.