### PR TITLE
New ip commands

### DIFF
--- a/sql/world/base/cs_individualProgression.sql
+++ b/sql/world/base/cs_individualProgression.sql
@@ -1,3 +1,5 @@
-DELETE FROM `command` WHERE `name` IN ('individualProgression set');
+DELETE FROM `command` WHERE `name` IN ('individualProgression set', 'ip set', 'ip tele');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
-('individualProgression set', 2, 'Syntax: .individualProgression set $player $progressionLevel\nSets the player to the given progression level.');
+('individualprogression set', 2, 'Syntax: .individualprogression set $player $progressionLevel\n Sets the player to the given progression level.'),
+('ip set', 2, 'Syntax: .ip set $player $progressionLevel\n Sets the player to the given progression level.'),
+('ip tele', 2, 'Syntax: .ip tele $player $location\n Teleports the player to the given location.');

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -3,6 +3,7 @@
 #include "ScriptMgr.h"
 #include "Tokenize.h"
 #include "IndividualProgression.h"
+#include "naxxramas_40.h"
 
 using namespace Acore::ChatCommands;
 
@@ -44,6 +45,19 @@ public:
         return true;
     }
 
+    static bool isAttuned(Player* player)
+    {
+        if ((player->GetQuestStatus(NAXX40_ATTUNEMENT_1) == QUEST_STATUS_REWARDED) || 
+            (player->GetQuestStatus(NAXX40_ATTUNEMENT_2) == QUEST_STATUS_REWARDED) ||
+            (player->GetQuestStatus(NAXX40_ATTUNEMENT_3) == QUEST_STATUS_REWARDED))
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
 
     static bool HandleTeleIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player, std::string location)
     {
@@ -59,7 +73,7 @@ public:
         {
             Player* target = player->GetConnectedPlayer();
 
-            if ((location == "naxx40") && (target->GetLevel() <= IP_LEVEL_TBC) && (target->getClass() != CLASS_DEATH_KNIGHT))
+            if ((location == "naxx40") && (target->GetLevel() <= IP_LEVEL_TBC) && (target->getClass() != CLASS_DEATH_KNIGHT) && isAttuned(target))
             {
                 target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
                 target->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -45,7 +45,7 @@ public:
     }
 
 
-    static bool HandleTeleIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player, string location)
+    static bool HandleTeleIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player, std::string location)
     {
         player = PlayerIdentifier::FromTargetOrSelf(handler);
         

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -48,8 +48,8 @@ public:
     static bool HandleTeleIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player, std::string location)
     {
         player = PlayerIdentifier::FromTargetOrSelf(handler);
-        
-        if (location != 'naxx40' && location != 'onyxia40')
+		 
+        if (location != "naxx40" && location != "onyxia40")
         {
             handler->SendSysMessage("Invalid teleport location.");
             return false;
@@ -57,16 +57,18 @@ public:
 
         if (player && player->GetConnectedPlayer())
         {
-            if ((location == 'naxx40') && (player->GetLevel() <= IP_LEVEL_TBC) && (player->getClass() != CLASS_DEATH_KNIGHT))
+            Player* target = player->GetConnectedPlayer();
+
+            if ((location == "naxx40") && (target->GetLevel() <= IP_LEVEL_TBC) && (target->getClass() != CLASS_DEATH_KNIGHT))
             {
-                player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
-                player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
+                target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                target->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
                 return true;
             }
-            else if (location == 'onyxia40' && player->GetLevel() < IP_LEVEL_WOTLK)
+            else if (location == "onyxia40" && target->GetLevel() < IP_LEVEL_WOTLK)
             {
-                player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
-                player->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);
+                target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                target->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);
                 return true;
             }
             else

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -15,12 +15,14 @@ public:
     {
         static ChatCommandTable individualProgressionTable =
         {
-            { "set",    HandleSetIndividualProgressionCommand, SEC_GAMEMASTER,    Console::Yes },
+            { "set",    HandleSetIndividualProgressionCommand, SEC_GAMEMASTER,    Console::Yes },            
+            { "tele",   HandleTeleIndividualProgressionCommand, SEC_GAMEMASTER,    Console::Yes },        
         };
 
         static ChatCommandTable commandTable =
         {
-            { "individualProgression", individualProgressionTable },
+            { "individualprogression", individualProgressionTable },
+            { "ip", individualProgressionTable },
         };
 
         return commandTable;
@@ -42,6 +44,38 @@ public:
         return true;
     }
 
+
+    static bool HandleTeleIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player, string location)
+    {
+        player = PlayerIdentifier::FromTargetOrSelf(handler);
+        
+        if (location != 'naxx40' && location != 'onyxia40')
+        {
+            handler->SendSysMessage("Invalid teleport location.");
+            return false;
+        }
+
+        if (player && player->GetConnectedPlayer())
+        {
+            if ((location == 'naxx40') && (player->GetLevel() <= IP_LEVEL_TBC) && (player->getClass() != CLASS_DEATH_KNIGHT))
+            {
+                player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
+                return true;
+            }
+            else if (location == 'onyxia40' && player->GetLevel() < IP_LEVEL_WOTLK)
+            {
+                player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                player->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);
+                return true;
+            }
+            else
+            {
+                handler->SendSysMessage("You are not allowed to teleport to this location.");
+                return false;
+            }
+        }
+    }
 
 };
 


### PR DESCRIPTION
you can now also change your progression tier with:
.ip set [tier]

example:
.ip set 8
this will set your progression to the beginning of TBC.
https://github.com/ZhengPeiRu21/mod-individual-progression/wiki/List-of-Progression-Tiers
if no player is targeted it will set the progression tier for yourself.
logging out and back in may be required for changes to take effect.

----

.ip tele [instance]

example:
.ip tele naxx40
this will teleport you to naxx40. restrictions still apply.
you can also teleport your selected target to the instance
available options are: onyxia40 and naxx40
case sensitive