### PR TITLE
fix Arzeth the Merciless worldserver error

### DIFF
--- a/sql/world/base/zone_hellfire_peninsula.sql
+++ b/sql/world/base/zone_hellfire_peninsula.sql
@@ -1,0 +1,22 @@
+/* smart scripts */
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN 
+(19354);
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN 
+(19354);
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
+`event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+--
+(19354, 0, 0, 0, 0, 0, 100, 0, 8000, 12000, 8000, 14000, 0, 0, 11, 16856, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,      'Arzeth the Merciless - In Combat - Cast Mortal Strike'),
+(19354, 0, 1, 0, 106, 0, 100, 0, 12000, 14000, 12000, 14000, 0, 30, 11, 15245, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Arzeth the Merciless - Within 0-30 Range - Cast Shadow Bolt Volley'),
+(19354, 0, 2, 3, 8, 0, 100, 513, 35460, 0, 0, 0, 0, 0, 36, 20680, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Arzeth the Merciless - On Spell Hit - Update Template'),
+(19354, 0, 3, 4, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                      'Arzeth the Merciless - Link - Say Line 0'),
+(19354, 0, 4, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,                     'Arzeth the Merciless - Link - Attack Start'),
+(19354, 0, 5, 0, 1, 0, 100, 0, 35000, 45000, 40000, 90000, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,         'Arzeth the Merciless - OOC - Say Line 0'),
+(19354, 0, 6, 0, 7, 0, 100, 512, 0, 0, 0, 0, 0, 0, 36, 19354, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Arzeth the Merciless - On Evade - Update Template');
+
+
+-- fix Arzeth the Merciless worldserver error
+UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1 WHERE `id1` = 19354;


### PR DESCRIPTION
First waypoint was set to 0 in the creature table, this needs to be 1.
Also, you get a worldserver error if you start a creature path both in the creature table and with a smart_scripts entry.
you have to use one or the other.