### PR TITLE
fixes in Azshara

### DIFF
--- a/sql/world/base/zone_azshara.sql
+++ b/sql/world/base/zone_azshara.sql
@@ -1,9 +1,9 @@
 /* smart scripts */
-UPDATE `creature_template` SET `AIName` = '' WHERE `entry` IN (6125);
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` IN (193, 6125);
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN 
-(6116, 6117, 6118, 6126, 6127, 6148, 6187, 6188, 6189, 6190, 6193, 6194, 6195, 6196, 6198, 6199, 6200, 6201, 6202, 6350, 6372, 6377, 6379, 6647, 6648, 8408, 8660, 8762);
+(6116, 6117, 6118, 6126, 6127, 6131, 6140, 6146, 6147, 6148, 6187, 6188, 6189, 6190, 6193, 6194, 6195, 6196, 6198, 6199, 6200, 6201, 6202, 6350, 6372, 6377, 6378, 6379, 6380, 6647, 6648, 7885, 7886, 8408, 8578, 8660, 8761, 8762);
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN 
-(6116, 6117, 6118, 6125, 6126, 6127, 6148, 6187, 6188, 6189, 6190, 6193, 6194, 6195, 6196, 6198, 6199, 6200, 6201, 6202, 6350, 6372, 6377, 6379, 6647, 6648, 8408, 8660, 8762);
+(193, 6116, 6117, 6118, 6125, 6126, 6127, 6131, 6140, 6146, 6147, 6148, 6187, 6188, 6189, 6190, 6193, 6194, 6195, 6196, 6198, 6199, 6200, 6201, 6202, 6350, 6372, 6377, 6378, 6379, 6380, 6647, 6648, 7885, 7886, 8408, 8578, 8660, 8761, 8762);
 
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
 `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
@@ -17,6 +17,12 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (6126, 0, 0, 0, 9, 0, 100, 0, 0, 0, 20000, 45000, 0, 10, 11, 7098, 96, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Haldarr Trickster - In Combat - Cast Curse of Mending'),
 (6127, 0, 0, 0, 1, 0, 100, 1, 1000, 1000, 0, 0, 0, 0, 11, 11939, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,             'Haldarr Felsworn - Out of Combat - Cast Summon Imp'),
 (6127, 0, 1, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 20825, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Haldarr Felsworn - In Combat - Cast Shadow Bolt'),
+(6131, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 9672, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Draconic Mageweaver - In Combat - Cast Frostbolt'),
+(6131, 0, 1, 0, 9, 0, 100, 0, 0, 0, 15000, 18000, 0, 8, 11, 12557, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,           'Draconic Mageweaver - In Combat - Cast Cone of Cold'),
+(6140, 0, 0, 0, 9, 0, 100, 0, 0, 0, 11000, 15000, 0, 5, 11, 7367, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Hetaera - Within 0-5 Range - Cast Infected Bite'),
+(6140, 0, 1, 0, 0, 0, 100, 0, 8000, 12000, 15000, 20000, 0, 0, 11, 3391, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Hetaera - In Combat - Cast Thrash'),
+(6146, 0, 0, 0, 0, 0, 100, 0, 7000, 11000, 21000, 24000, 0, 0, 11, 11443, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,   'Cliff Breaker - In Combat - Cast Cripple'),
+(6147, 0, 0, 0, 0, 0, 100, 0, 7000, 10000, 11000, 14000, 0, 0, 11, 8147, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Cliff Thunderer - In Combat - Cast Thunderclap'),
 (6148, 0, 0, 0, 9, 0, 100, 0, 0, 0, 13000, 17000, 0, 5, 11, 11876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,           'Cliff Walker - Within 0-5 Range - Cast War Stomp'),
 (6187, 0, 0, 0, 0, 0, 100, 0, 2000, 5000, 13000, 18000, 0, 0, 11, 9128, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,      'Timbermaw Den Watcher - In Combat - Cast Battle Shout'),
 (6187, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Timbermaw Den Watcher - Between 0-15% Health - Flee For Assist (No Repeat)'),
@@ -75,7 +81,11 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (6372, 0, 0, 0, 0, 0, 100, 0, 10000, 19100, 25300, 46800, 0, 0, 11, 3604, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,   'Makrinni Snapclaw  - Within 0-5 Range - Cast Tendon Rip'),
 (6377, 0, 0, 0, 9, 0, 100, 0, 0, 0, 8000, 12000, 0, 20, 11, 12553, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Thunderhead Stagwing - Within 0-20 Range - Cast Shock'),
 (6377, 0, 1, 0, 106, 0, 100, 0, 7000, 10000, 12000, 17000, 0, 8, 11, 11019, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,  'Thunderhead Stagwing - Within 0-8 Range - Cast Wing Flap'),
+(6378, 0, 0, 0, 9, 0, 100, 0, 0, 0, 8000, 12000, 0, 20, 11, 12553, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Thunderhead Skystormer - Within 0-20 Range - Cast Shock'),
+(6378, 0, 1, 0, 0, 0, 100, 0, 9000, 16000, 40000, 45000, 0, 0, 11, 6535, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,    'Thunderhead Skystormer - In Combat - Cast Lightning Cloud'),
 (6379, 0, 0, 0, 9, 0, 100, 1, 0, 0, 0, 0, 5, 20, 11, 6268, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Thunderhead Patriarch - Within 5-20 Range - Cast Rushing Charge'),
+(6380, 0, 0, 0, 9, 0, 100, 0, 0, 0, 8000, 12000, 0, 20, 11, 12553, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Thunderhead Consort - Within 0-20 Range - Cast Shock'),
+(6380, 0, 1, 0, 0, 0, 100, 0, 3000, 9000, 9000, 13000, 0, 0, 11, 17157, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Thunderhead Consort - In Combat - Cast Lightning Breath'),
 --
 (6647, 0, 0, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 30, 60, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Magister Hawkhelm - Outside 30 Range - Start Combat Movement'),
 (6647, 0, 1, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 5, 30, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Magister Hawkhelm - Within 5-30 Range - Stop Combat Movement'),
@@ -85,11 +95,31 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (6648, 0, 0, 0, 0, 0, 100, 0, 7000, 12000, 19000, 23000, 0, 0, 11, 13445, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,   'Antilos - Within 0-5 Range - Cast Rend'),
 (6648, 0, 1, 0, 9, 0, 100, 0, 0, 0, 11000, 15000, 0, 5, 11, 40504, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Antilos - Within 0-5 Range - Cast Cleave'),
 (6648, 0, 2, 0, 0, 0, 100, 0, 11000, 15000, 12000, 15000, 0, 0, 11, 5708, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,   'Antilos - Within 0-5 Range - Cast Swoop'),
+--
+(7885, 0, 0, 0, 8, 0, 100, 1, 118, 0, 0, 0, 0, 0, 80, 619300, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Spitelash Battlemaster - On Spellhit \'Polymorph\' - Run Script'),
+(7885, 0, 1, 0, 8, 0, 100, 1, 12824, 0, 0, 0, 0, 0, 80, 619300, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Spitelash Battlemaster - On Spellhit \'Polymorph\' - Run Script'),
+(7885, 0, 2, 0, 8, 0, 100, 1, 12825, 0, 0, 0, 0, 0, 80, 619300, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Spitelash Battlemaster - On Spellhit \'Polymorph\' - Run Script'),
+(7885, 0, 3, 0, 8, 0, 100, 1, 12826, 0, 0, 0, 0, 0, 80, 619300, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Spitelash Battlemaster - On Spellhit \'Polymorph\' - Run Script'),
+(7885, 0, 4, 0, 9, 0, 100, 0, 0, 0, 20000, 30000, 5, 30, 11, 22120, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Spitelash Battlemaster - Within 5-30 Range - Cast Charge'),
+(7886, 0, 0, 0, 8, 0, 100, 1, 118, 0, 0, 0, 0, 0, 80, 619300, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Spitelash Enchantress - On Spellhit \'Polymorph\' - Run Script'),
+(7886, 0, 1, 0, 8, 0, 100, 1, 12824, 0, 0, 0, 0, 0, 80, 619300, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Spitelash Enchantress - On Spellhit \'Polymorph\' - Run Script'),
+(7886, 0, 2, 0, 8, 0, 100, 1, 12825, 0, 0, 0, 0, 0, 80, 619300, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Spitelash Enchantress - On Spellhit \'Polymorph\' - Run Script'),
+(7886, 0, 3, 0, 8, 0, 100, 1, 12826, 0, 0, 0, 0, 0, 80, 619300, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Spitelash Enchantress - On Spellhit \'Polymorph\' - Run Script'),
+(7886, 0, 4, 0, 0, 0, 100, 0, 0, 0, 5000, 5000, 0, 0, 11, 15790, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Spitelash Enchantress - In Combat - Cast Arcane Missiles'),
+(7886, 0, 5, 0, 0, 0, 100, 0, 5000, 9000, 18000, 24000, 0, 0, 11, 3443, 64, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Spitelash Enchantress - In Combat - Cast Enchanted Quickness'),
+(7886, 0, 6, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Spitelash Enchantress - Between 0-15% Health - Flee For Assist (No Repeat)'),
+--
 (8408, 0, 0, 0, 9, 0, 100, 0, 0, 0, 5000, 9000, 0, 5, 11, 11976, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Warlord Krellian - In Combat - Cast Strike'),
 (8408, 0, 1, 0, 106, 0, 100, 0, 4000, 8000, 12000, 17000, 0, 8, 11, 10968, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Warlord Krellian - Within 0-8 Range - Cast Demoralizing Roar'),
+(8578, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 20823, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Magus Rimtori - In Combat - Cast Fireball'),
+(8578, 0, 1, 0, 106, 0, 100, 0, 0, 0, 13000, 16000, 0, 8, 11, 11831, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,         'Magus Rimtori - Within 0-8 Range - Cast Frost Nova'),
+(8578, 0, 2, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 51347, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Magus Rimtori - On Just Summoned - Cast \'Teleport Visual Only\''),
+(8578, 0, 3, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                        'Magus Rimtori - On Aggro - Say Line 0'),
 (8660, 0, 0, 0, 0, 0, 100, 0, 0, 0, 4000, 6000, 0, 0, 11, 20793, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'The Evalcharr - In Combat - Cast Fireball'),
 (8660, 0, 1, 0, 0, 0, 100, 0, 8000, 13000, 12000, 15000, 0, 0, 11, 15797, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,   'The Evalcharr - In Combat - Cast Lightning Breath'),
 --
+(8761, 0, 0, 1, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 11, 8599, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Mosshoof Courser - Between 0-30% Health - Cast Enrage (No Repeat)'),
+(8761, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'Mosshoof Courser - On Enrage - Say Line 0'),
 (8762, 0, 0, 0, 9, 0, 100, 0, 0, 0, 9000, 14000, 0, 20, 11, 745, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Timberweb Recluse - Within 0-20 Range - Cast Web'),
 (8762, 0, 1, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 3616, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Timberweb Recluse - On Reset - Cast Poison Proc');
 


### PR DESCRIPTION
some of the changes:
- Antilos, fix Rend, Cleave,  Swoop and movement
- Haldarr Felsworn, now casts Shadow Bolt
- Cliff Walker, fix War Stomp, removed Faerie Fire
- Timbermaw now flee at 15% health
- Timbermaw Den Watcher, fix Battle Shout
- Timbermaw Shaman, fix Healing Wave
- Timbermaw Ursa, fix Thunder Clap
- Blood Elf Surveyor, fix Fire Nova
- Blood Elf Reclaimer, fix Renew and Heal
- Legashi Satyr, fix Mana Burn
- Legashi Rogue, fix Backstab and now casts Gouge
- Thunderhead Stagwing, fix Shock and Wing Flap
- Magister Hawkhelm, fix ranged combat
- Warlord Krellian, fix Demoralizing Roar
- Timberweb Recluse now has a poison proc
- Thunderhead Skystormer, fix Lightning Cloud
- Blue Dragonspawn, lost Strike
- Draconic Mageweaver, fix cone of cold and frostbolt
- Hetaera, fix Infected Bite and now casts Thrash
- Cliff Breaker, fix Cripple
- Cliff Thunderer, fix Thunderclap
- Thunderhead Consort, fix Lightning Breath