### PR TITLE
possible fix for Naxx40 crash

### DIFF
--- a/src/naxx40Scripts/instance_naxxramas.cpp
+++ b/src/naxx40Scripts/instance_naxxramas.cpp
@@ -24,6 +24,7 @@
 #include "PassiveAI.h"
 #include "Player.h"
 #include "naxxramas.h"
+#include "IndividualProgression.h"
 
 struct LivingPoisonData
 {


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/602

players reported crashing the client when logging back inside naxx40 after having been offline for a while.

have to test this still
but this hopefully fixes the problem

the idea is that you're maybe placed inside the wotlk version which has restrictions you do not meet.
there is an area trigger at the entrance where I now teleport players level 70 or below to the naxx40 version.

you were already getting teleported to the naxx40 version when zoning in,
but not after having been offline for a while and logging back in.
so maybe it resets at some point, anyways, it's worth a shot


