### PR TITLE
Naxx40 Logout Teleport

### DIFF
--- a/src/naxx40Scripts/instance_naxxramas.cpp
+++ b/src/naxx40Scripts/instance_naxxramas.cpp
@@ -829,7 +829,7 @@ public:
         InstanceScript* instance = player->GetInstanceScript();
         if (!instance)
             return false;
-		
+
         if ((instance->GetBossState(BOSS_MAEXXNA)  != DONE) ||
             (instance->GetBossState(BOSS_LOATHEB)  != DONE) ||
             (instance->GetBossState(BOSS_THADDIUS) != DONE) ||


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/162 and https://github.com/ZhengPeiRu21/mod-individual-progression/issues/602

When you log out inside Naxx40 and Onyxia40 you will now first get teleported outside.
So the next time you log back in you will find yourself outside the instance.

This will prevent a client crash that happened when you logged out for a while 
and tried to log back in with your character still inside Naxx40 or Onyxia40.

```
The instruction at "0x00524868" referenced memory at "0x00000018".
The memory could not be "read".
```

This bug has been around for too long.
Nobody has been able to find the solution.
for now, this will have to do.