### PR TITLE
Check progression instead of Death Knight class

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -365,10 +365,10 @@ public:
         {
             return true;
         }
-        if (mapid == MAP_ONYXIAS_LAIR && player->GetLevel() <= IP_LEVEL_TBC && (!player->HasItemCount(ITEM_DRAKEFIRE_AMULET) || player->getClass() == CLASS_DEATH_KNIGHT))
+        if (mapid == MAP_ONYXIAS_LAIR && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && !player->HasItemCount(ITEM_DRAKEFIRE_AMULET))
         {
             return false;
-        }        
+        }       
         if (mapid == MAP_BLACKWING_LAIR && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_MOLTEN_CORE))
         {
             return false;

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -435,7 +435,7 @@ public:
             {
                 return false;
             }
-            if (instanceTemplate->Parent == MAP_NORTHREND && mapid == MAP_NAXXRAMAS && player->GetLevel() <= IP_LEVEL_TBC && !isAttuned(player))  
+            if (instanceTemplate->Parent == MAP_NORTHREND && mapid == MAP_NAXXRAMAS && player->GetLevel() <= IP_LEVEL_TBC && (!isAttuned(player) ||  sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5) ))  
             {
                 return false;
             }

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -52,7 +52,6 @@ public:
     static bool HandleViewIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player)
     {
         player = PlayerIdentifier::FromTargetOrSelf(handler);
-
         Player* target = player->GetConnectedPlayer();
         uint32 progressionLevel = target->GetPlayerSetting("mod-individual-progression", SETTING_PROGRESSION_STATE).value;
         std::string playername = target->GetName();
@@ -76,25 +75,25 @@ public:
     }
 
     static bool HandleTeleIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player, std::string location)
-    {
-        player = PlayerIdentifier::FromTargetOrSelf(handler);
-		 
+    {	 
         if (location != "naxx40" && location != "onyxia40")
         {
             handler->PSendSysMessage("|cff00ffff{}|r is not a valid teleport location.", location);
             return false;
         }
 
+        player = PlayerIdentifier::FromTargetOrSelf(handler);
         Player* target = player->GetConnectedPlayer();
+        uint32 progressionLevel = target->GetPlayerSetting("mod-individual-progression", SETTING_PROGRESSION_STATE).value;
         std::string playername = target->GetName();
-
-        if ((location == "naxx40") && (target->GetLevel() <= IP_LEVEL_TBC) && (target->getClass() != CLASS_DEATH_KNIGHT) && isAttuned(target))
+        
+        if (location == "naxx40" && ((progressionLevel < PROGRESSION_TBC_TIER_5 && isAttuned(target)) || target->IsGameMaster()))
         {
             target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
             target->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
             return true;
         }
-        else if ((location == "onyxia40" && target->GetLevel() < IP_LEVEL_TBC) && (target->getClass() != CLASS_DEATH_KNIGHT) && target->HasItemCount(ITEM_DRAKEFIRE_AMULET))
+        else if (location == "onyxia40" && ((progressionLevel < PROGRESSION_TBC_TIER_5 && target->HasItemCount(ITEM_DRAKEFIRE_AMULET)) || target->IsGameMaster()))
         {
             target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
             target->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -86,7 +86,7 @@ public:
         Player* target = player->GetConnectedPlayer();
         uint32 progressionLevel = target->GetPlayerSetting("mod-individual-progression", SETTING_PROGRESSION_STATE).value;
         std::string playername = target->GetName();
-        
+
         if (location == "naxx40" && ((progressionLevel < PROGRESSION_TBC_TIER_5 && isAttuned(target)) || target->IsGameMaster()))
         {
             target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);

--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -51,7 +51,7 @@ public:
 
     bool OnGossipHello(Player* player, GameObject* /*go*/) override
     {
-        if ((isExcludedFromProgression(player) && (player->GetLevel() <= IP_LEVEL_TBC) && (player->getClass() != CLASS_DEATH_KNIGHT))  || 
+        if ((isExcludedFromProgression(player) && (player->GetLevel() <= IP_LEVEL_TBC))  || 
             ((!sIndividualProgression->requireNaxxStrath || player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_REWARDED) && (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5))))
         {
             player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);

--- a/src/vanillaScripts/instance_onyxias_lair.cpp
+++ b/src/vanillaScripts/instance_onyxias_lair.cpp
@@ -148,8 +148,9 @@ public:
     bool OnTrigger(Player* player, AreaTrigger const* /*areaTrigger*/) override
     {       
         ChatHandler handler(player->GetSession());
+		uint32 progressionLevel = player->GetPlayerSetting("mod-individual-progression", SETTING_PROGRESSION_STATE).value;
 	
-        if ((player->GetLevel() <= IP_LEVEL_TBC) && (player->getClass() != CLASS_DEATH_KNIGHT) && (player->HasItemCount(ITEM_DRAKEFIRE_AMULET) ||  isExcludedFromProgression(player)))
+        if (player->GetLevel() <= IP_LEVEL_TBC && progressionLevel < PROGRESSION_TBC_TIER_5 && (player->HasItemCount(ITEM_DRAKEFIRE_AMULET) ||  isExcludedFromProgression(player)))
         {
             player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
             player->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);
@@ -162,9 +163,9 @@ public:
         {
             handler.PSendSysMessage("You must have the Drakefire Amulet in your inventory to enter this version of Onyxia\'s Lair.");
         }	
-        else if (player->getClass() == CLASS_DEATH_KNIGHT)
+        else if (progressionLevel > PROGRESSION_TBC_TIER_4)
         {
-            handler.PSendSysMessage("Death knights are not allowed to enter this version of Onyxia\'s Lair.");
+            handler.PSendSysMessage("Your progression level is too high to enter this version of Onyxia\'s Lair.");
         }	
         return true;
     }


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/pull/652

It was pointed out to me that it's possible for death knights to start at progression 0.
So when that's the case they need to be able to enter Onyxia40 and Naxx40.

I'll check progression level now instead.
So far I've changed it for Onyxia40. 
I've tested that and it works.
Still have to make changes for Naxx40