### PR TITLE
fixes in Swamp of Sorrows

### DIFF
--- a/sql/world/base/zone_swamp_of_sorrows.sql
+++ b/sql/world/base/zone_swamp_of_sorrows.sql
@@ -11,7 +11,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 --
 (743, 0, 0, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 7966, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                     'Wyrmkin Dreamwalker - On Aggro - Cast Thorns Aura'),
 (743, 0, 1, 0, 14, 0, 100, 0, 1000, 40, 12000, 15000, 0, 0, 11, 12160, 64, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,      'Wyrmkin Dreamwalker - Friendly Missing 1000 Health - Cast Rejuvenation'),
-(743, 0, 2, 0, 0, 0, 100, 0, 6000, 11000, 15000, 18000, 0, 0, 11, 15970, 64, 0, 0, 0, 0, 5, 30, 0, 0, 0, 0, 0, 0, 0,   'Wyrmkin Dreamwalker - Within 0-30 Range - Cast Sleep'),
+(743, 0, 2, 0, 0, 0, 100, 0, 6000, 11000, 15000, 18000, 0, 0, 11, 15970, 64, 0, 0, 0, 0, 6, 30, 0, 0, 0, 0, 0, 0, 0,   'Wyrmkin Dreamwalker - Within 0-30 Range - Cast Sleep'),
 (744, 0, 0, 0, 9, 0, 100, 0, 0, 0, 6000, 9000, 0, 5, 11, 15496, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,              'Green Scalebane - Within 0-5 Range - Cast Cleave'),
 (745, 0, 0, 0, 0, 0, 100, 0, 1000, 5000, 15000, 25000, 0, 0, 11, 9128, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,       'Scalebane Captain - In Combat - Cast Battle Shout'),
 (745, 0, 1, 0, 9, 0, 100, 0, 0, 0, 9000, 21000, 0, 5, 11, 13730, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,             'Scalebane Captain - Within 0-5 Range - Cast Demoralizing Shout'),


### PR DESCRIPTION
some of the changes:
- Marsh Flesheater, now announces his enrage
- Marsh Inkspewer, flee for assist at 15% health
- Elder Dragonkin, fix Acid Splash
- Lost Ones now flee for assist at 15% health
- Lost One Seer, fix Earthgrab Totem
- Lost One Riftseeker now casts Rift Beacon
- Lost One Chieftain now calls for help at 30% health, lost Rend
- Swamp Jaguar lost Claw
- Shadow Panther lost Claw, now casts Stealth
- Deathstrike Tarantula now casts Fatal Bite
- Mire Lord lost Mirkfallon Fungus
- Somnus, fix Corrosive Acid Breath, Wing Flap, Strike and Sleep
- Lord Captain Wyrmak now casts Acid Breath
- Lost One Mudlurker had no smart script, now casts backstab and flees at 15% health
- Molt Thorn, fix Thorn Volley
- Wyrmkin Dreamwalker, fix Rejuvenation and Sleep
- Jarquia now announces his enrage
- Lost One Hunter did not have smart scripts, fixed ranged combat and now has Poisoned Shot