### PR TITLE
fix mistake entrance naxx40

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -435,7 +435,7 @@ public:
             {
                 return false;
             }
-            if (instanceTemplate->Parent == MAP_NORTHREND && mapid == MAP_NAXXRAMAS && player->GetLevel() <= IP_LEVEL_TBC && (!isAttuned(player) ||  sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5) ))  
+            if (instanceTemplate->Parent == MAP_NORTHREND && mapid == MAP_NAXXRAMAS && player->GetLevel() <= IP_LEVEL_TBC && isAttuned(player) && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5) )  
             {
                 return false;
             }


### PR DESCRIPTION
I placed the ! in front of the wrong condition.

you had to be not attuned OR passed progression TBC tier 5.
that should of course be
you need to be attuned and NOT have passed progression TBC tier 5