### PR TITLE
fixes in Western Plaguelands

### DIFF
--- a/data/sql/world/base/zone_western_plaguelands.sql
+++ b/data/sql/world/base/zone_western_plaguelands.sql
@@ -213,8 +213,8 @@ DELETE FROM `creature` WHERE `id1` = 1848;
 INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (52725,  1848, 0, 0, 0, 0, 0, 1, 1, 1, 1061.03, -1912.26, 31.1128, 4.71571, 18000, 5, 0, 2915, 2163, 1, 0, 0, 0, '', 0, 0, NULL),
-(695026, 1848, 0, 0, 0, 0, 0, 1, 1, 1, 1123.73, -1714.49, 62.33, 0, 18000, 5, 0, 2915, 2163, 1, 0, 0, 0, '', 0, 0, NULL),
-(695027, 1848, 0, 0, 0, 0, 0, 1, 1, 1, 1071.86, -1766.24, 62.0725, 0.388769, 18000, 5, 0, 2915, 2163, 1, 0, 0, 0, '', 0, 0, NULL);
+(695026, 1848, 0, 0, 0, 0, 0, 1, 1, 1, 1123.73, -1714.49, 62.33, 0, 18000, 5, 0, 2915, 2163, 1, 0, 0, 0, '', 0, 0, NULL),          -- https://www.youtube.com/watch?v=pCwj-bglyV8
+(695027, 1848, 0, 0, 0, 0, 0, 1, 1, 1, 1071.86, -1766.24, 62.0725, 0.388769, 18000, 5, 0, 2915, 2163, 1, 0, 0, 0, '', 0, 0, NULL); -- https://www.youtube.com/watch?v=flejEU2n5EQ
 
 DELETE FROM `pool_creature` WHERE `pool_entry` = 368;
 INSERT INTO `pool_creature` (`guid`, `pool_entry`, `chance`, `description`) VALUES 


### PR DESCRIPTION
previously fixed several creatures for WPL in: https://github.com/ZhengPeiRu21/mod-individual-progression/pull/564
now I went over the rest.

some of the changes:
- Skeletal Flayer, fix Thrash
- Skeletal Executioner now casts Execute
- Skeletal Warlord now casts Backhand
- Skeletal Acolyte, fix Shadow Bolt Volley
- Soulless Ghoul, fix Frailty
- Freezing Ghoul, fix Flash Freeze
- Decaying Horror no longer casts Fungal Decay
- Scarlet Crusade members now have text on aggro
- Scarlet Hunter, fix ranged combat
- Scarlet Paladin, fix Holy Light
- Scarlet Magus now casts Fire Ward, fix Blast Wave
- Foulmane now casts Thrash
- Lord Maldazzar, fix Summon Skeleton, Shadow Bolt, Drain Life
- Lord Maldazzar, fix multiple spawn locations, respawn, wander distance
- Putridius, fix Putrid Stench, now casts Uppercut instead of Knock Away, no longer casts Altered Cauldron Toxin
- Araj the Summoner now casts Frost Armor
- Araj the Summoner now despawns Illusory Wraith on evade
- Scarlet Lumberjack now flees at 15% health
- Scarlet Medic, fix Flash Heal, Renew and Resist Arcane
- Jabbering Ghoul now announces his enrage
- Fallen Hero now has text on aggro
- Cavalier Durgen now casts Retribution Aura 
- Cavalier Durgen now has text on aggro and flees at 15% health
- Alexi Barov and Weldon Barov now have text on aggro, 
- Alexi Barov now casts Backstab, Sinister Strike, Rupture and Kick
- Weldon Barov now casts Demoralizing Shout, Hamstring, Cleave and Strike
- Huntsman Radley now summons Bloodshot out of Combat and flees at 15% health
- Huntsman Radley, fix ranged combat, didn't even have shoot ability!!