### PR TITLE
fixes in Westfall

### DIFF
--- a/data/sql/world/base/zone_westfall.sql
+++ b/data/sql/world/base/zone_westfall.sql
@@ -17,7 +17,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (98, 0, 0, 0, 4, 0, 30, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                           'Riverpaw Taskmaster - On Aggro - Say Line 0'),
 (98, 0, 1, 0, 74, 0, 100, 0, 0, 0, 15000, 16000, 30, 30, 11, 3229, 96, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,          'Riverpaw Taskmaster - Friendly Between 0-30% Health - Cast Quick Bloodlust'),
 (98, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                        'Riverpaw Taskmaster - Between 0-15% Health - Flee For Assist (No Repeat)'),
-(115, 0, 0, 0, 0, 0, 100, 0, 2000, 6000, 14000, 22000, 0, 0, 11, 7342, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,      'Harvest Reaper - Within 0-5 Range - Cast Wide Slash'), -- test!
+(115, 0, 0, 0, 0, 0, 100, 0, 2000, 6000, 14000, 22000, 0, 0, 11, 7342, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,      'Harvest Reaper - Within 0-5 Range - Cast Wide Slash'),
 (117, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Riverpaw Gnoll - On Aggro - Say Line 0'),
 (117, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Riverpaw Gnoll - Between 0-15% Health - Flee For Assist (No Repeat)'),
 (121, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Defias Pathstalker - On Aggro - Say Line 0'),
@@ -25,10 +25,10 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (121, 0, 2, 0, 105, 0, 100, 0, 0, 0, 25200, 39100, 0, 5, 11, 11972, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,          'Defias Pathstalker - Target Casting - Cast Shield Bash'),
 (121, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Defias Pathstalker - Between 0-15% Health - Flee For Assist (No Repeat)'),
 (122, 0, 0, 0, 4, 0, 15, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Defias Highwayman - On Aggro - Say Line 0 (No Repeat)'),
-(122, 0, 1, 0, 67, 0, 100, 0, 1000, 3000, 1000, 3000, 0, 5, 11, 7159, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,        'Defias Highwayman - Behind Target  - Cast Backstab'), -- test!
+(122, 0, 1, 0, 67, 0, 100, 0, 1000, 3000, 1000, 3000, 0, 5, 11, 7159, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,        'Defias Highwayman - Behind Target  - Cast Backstab'),
 (122, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Defias Highwayman - Between 0-15% Health - Flee For Assist (No Repeat)'),
 (123, 0, 0, 0, 4, 0, 30, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Riverpaw Mongrel - On Aggro - Say Line 0'),
-(123, 0, 1, 0, 0, 0, 100, 1, 2300, 35400, 0, 0, 0, 0, 11, 8016, 96, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Riverpaw Mongrel - Within 0-5 Range - Cast Spirit Decay (No Repeat)'), -- test!
+(123, 0, 1, 0, 0, 0, 100, 1, 2300, 35400, 0, 0, 0, 0, 11, 8016, 96, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Riverpaw Mongrel - Within 0-5 Range - Cast Spirit Decay (No Repeat)'),
 (123, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Riverpaw Mongrel - Between 0-15% Health - Flee For Assist (No Repeat)'),
 (124, 0, 0, 0, 4, 0, 30, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Riverpaw Brute - On Aggro - Say Line 0'),
 (124, 0, 1, 0, 0, 0, 100, 0, 3000, 16000, 19000, 21000, 0, 0, 11, 13730, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Riverpaw Brute - In Combat - Cast Demoralizing Shout'),
@@ -41,7 +41,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (127, 0, 1, 0, 106, 0, 100, 0, 0, 0, 17000, 31000, 0, 8, 11, 11831, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,          'Murloc Tidehunter - Within 0-8 Range - Cast Frost Nova'),
 (127, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Murloc Tidehunter - Between 0-15% Health - Flee For Assist (No Repeat)'),
 (154, 0, 0, 0, 0, 0, 90, 0, 5000, 16000, 20000, 28000, 0, 0, 11, 12166, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,     'Greater Fleshripper - Within 0-5 Range - Cast Muscle Tear'),
-(157, 0, 0, 0, 9, 0, 100, 1, 0, 0, 500, 1000, 10, 25, 11, 6268, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,              'Goretusk - Within 6-15 Range - Cast Rushing Charge (No Repeat)'), -- test!
+(157, 0, 0, 0, 9, 0, 100, 1, 0, 0, 500, 1000, 10, 25, 11, 6268, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Goretusk - Within 6-15 Range - Cast Rushing Charge (No Repeat)'),
 (171, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Murloc Warrior - Between 0-15% Health - Flee For Assist (No Repeat)'),
 (391, 0, 0, 0, 0, 0, 100, 0, 1000, 2000, 2000, 5000, 0, 0, 11, 3584, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,        'Old Murk-Eye - In Combat - Cast Volatile Infection'),
 (391, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Old Murk-Eye - Between 0-15% Health - Flee For Assist'),
@@ -81,7 +81,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (504, 0, 2, 0, 0, 0, 100, 0, 6000, 14000, 20000, 31000, 0, 0, 11, 12024, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Defias Trapper - In Combat - Cast Net'),
 (504, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Defias Trapper - Between 0-15% Health - Flee For Assist (No Repeat)'),
 (506, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Sergeant Brashclaw - On Aggro - Say Line 0'),
-(506, 0, 1, 0, 0, 0, 90, 0, 1000, 1000, 30000, 38000, 0, 0, 11, 3136, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,        'Sergeant Brashclaw - In Combat - Cast Frenzied Command'), -- test!
+(506, 0, 1, 0, 0, 0, 90, 0, 1000, 1000, 30000, 38000, 0, 0, 11, 3136, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,        'Sergeant Brashclaw - In Combat - Cast Frenzied Command'),
 (506, 0, 2, 0, 0, 0, 100, 0, 2000, 5000, 10000, 18000, 0, 0, 11, 5164, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,      'Sergeant Brashclaw - Within 0-5 Range - Cast Knockdown'),
 (506, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Sergeant Brashclaw - Between 0-15% Health - Flee For Assist (No Repeat)'),
 (513, 0, 0, 0, 0, 0, 100, 0, 11000, 13900, 20500, 33000, 0, 0, 11, 12024, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,   'Murloc Netter - In Combat - Cast Net'),

--- a/data/sql/world/base/zone_westfall.sql
+++ b/data/sql/world/base/zone_westfall.sql
@@ -123,10 +123,10 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 
 -- Gina MacGregor <Trade Supplies>
-DELETE FROM `npc_vendor` WHERE `entry`=843 AND `item`=39354;
+DELETE FROM `npc_vendor` WHERE `entry` = 843 AND `item` = 39354;
 
 -- Christopher Hewen <General Trade Goods Vendor>
-DELETE FROM `npc_vendor` WHERE `entry`=8934 AND `item` IN (10648, 14341, 18256, 30817, 39354);
+DELETE FROM `npc_vendor` WHERE `entry` = 8934 AND `item` IN (10648, 14341, 18256, 30817, 39354);
 
 -- Restore Defias Pillager to original Fireball spell (was nerfed in 2.3)
 DELETE FROM `creature_template_spell` WHERE `CreatureID` = 589 AND `Index` = 0;

--- a/data/sql/world/base/zone_westfall.sql
+++ b/data/sql/world/base/zone_westfall.sql
@@ -1,3 +1,127 @@
+/* smart scripts */
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` IN (199, 7051);
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN 
+(95, 98, 115, 117, 121, 122, 123, 124, 125, 126, 127, 154, 157, 171, 391, 449, 452, 453, 456, 458, 462, 500, 501, 504, 506, 513, 517, 519, 520, 547, 573, 589, 590, 832, 834, 846, 1065, 1236, 1424);
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN 
+(95, 98, 115, 117, 121, 122, 123, 124, 125, 126, 127, 154, 157, 171, 199, 391, 449, 452, 453, 456, 458, 462, 500, 501, 504, 506, 513, 517, 519, 520, 547, 573, 589, 590, 832, 834, 846, 1065, 1236, 1424, 7051);
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
+`event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+--
+(95, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                           'Defias Smuggler - On Aggro - Say Line 0'),
+(95, 0, 1, 0, 0, 0, 100, 0, 0, 0, 2000, 4000, 0, 0, 11, 10277, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,              'Defias Smuggler - In Combat - Cast Throw'),
+(95, 0, 2, 0, 67, 0, 100, 0, 1000, 7000, 5000, 5000, 0, 5, 11, 7159, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,         'Defias Smuggler - Behind Target - Cast Backstab'),
+(95, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                        'Defias Smuggler - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(98, 0, 0, 0, 4, 0, 30, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                           'Riverpaw Taskmaster - On Aggro - Say Line 0'),
+(98, 0, 1, 0, 74, 0, 100, 0, 0, 0, 15000, 16000, 30, 30, 11, 3229, 96, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,          'Riverpaw Taskmaster - Friendly Between 0-30% Health - Cast Quick Bloodlust'),
+(98, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                        'Riverpaw Taskmaster - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(115, 0, 0, 0, 0, 0, 100, 0, 2000, 6000, 14000, 22000, 0, 0, 11, 7342, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,      'Harvest Reaper - Within 0-5 Range - Cast Wide Slash'), -- test!
+(117, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Riverpaw Gnoll - On Aggro - Say Line 0'),
+(117, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Riverpaw Gnoll - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(121, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Defias Pathstalker - On Aggro - Say Line 0'),
+(121, 0, 1, 0, 67, 0, 65, 0, 1000, 7000, 4000, 4000, 0, 5, 11, 7159, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,         'Defias Pathstalker - Behind Target - Cast Backstab'),
+(121, 0, 2, 0, 105, 0, 100, 0, 0, 0, 25200, 39100, 0, 5, 11, 11972, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,          'Defias Pathstalker - Target Casting - Cast Shield Bash'),
+(121, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Defias Pathstalker - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(122, 0, 0, 0, 4, 0, 15, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Defias Highwayman - On Aggro - Say Line 0 (No Repeat)'),
+(122, 0, 1, 0, 67, 0, 100, 0, 1000, 3000, 1000, 3000, 0, 5, 11, 7159, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,        'Defias Highwayman - Behind Target  - Cast Backstab'), -- test!
+(122, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Defias Highwayman - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(123, 0, 0, 0, 4, 0, 30, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Riverpaw Mongrel - On Aggro - Say Line 0'),
+(123, 0, 1, 0, 0, 0, 100, 1, 2300, 35400, 0, 0, 0, 0, 11, 8016, 96, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Riverpaw Mongrel - Within 0-5 Range - Cast Spirit Decay (No Repeat)'), -- test!
+(123, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Riverpaw Mongrel - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(124, 0, 0, 0, 4, 0, 30, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Riverpaw Brute - On Aggro - Say Line 0'),
+(124, 0, 1, 0, 0, 0, 100, 0, 3000, 16000, 19000, 21000, 0, 0, 11, 13730, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Riverpaw Brute - In Combat - Cast Demoralizing Shout'),
+(124, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Riverpaw Brute - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(125, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Riverpaw Overseer - On Aggro - Say Line 0'),
+(125, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Riverpaw Overseer - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(126, 0, 0, 0, 0, 0, 85, 0, 6000, 9000, 24000, 32000, 0, 0, 11, 7357, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,       'Murloc Coastrunner - Within 0-5 Range - Cast Poisonous Stab'),
+(126, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Murloc Coastrunner - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(127, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 3616, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Murloc Tidehunter - On Respawn - Cast Poison Proc'),
+(127, 0, 1, 0, 106, 0, 100, 0, 0, 0, 17000, 31000, 0, 8, 11, 11831, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,          'Murloc Tidehunter - Within 0-8 Range - Cast Frost Nova'),
+(127, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Murloc Tidehunter - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(154, 0, 0, 0, 0, 0, 90, 0, 5000, 16000, 20000, 28000, 0, 0, 11, 12166, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,     'Greater Fleshripper - Within 0-5 Range - Cast Muscle Tear'),
+(157, 0, 0, 0, 9, 0, 100, 1, 0, 0, 500, 1000, 10, 25, 11, 6268, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,              'Goretusk - Within 6-15 Range - Cast Rushing Charge (No Repeat)'), -- test!
+(171, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Murloc Warrior - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(391, 0, 0, 0, 0, 0, 100, 0, 1000, 2000, 2000, 5000, 0, 0, 11, 3584, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,        'Old Murk-Eye - In Combat - Cast Volatile Infection'),
+(391, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Old Murk-Eye - Between 0-15% Health - Flee For Assist'),
+(449, 0, 0, 0, 4, 0, 5, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                           'Defias Knuckleduster - On Aggro - Say Line 0'),
+(449, 0, 1, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Defias Knuckleduster - On Respawn - Cast Thrash Proc'),
+(449, 0, 2, 0, 105, 0, 100, 0, 0, 0, 7000, 15000, 0, 5, 11, 12555, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,           'Defias Knuckleduster - Target Casting - Cast Pummel'),
+(449, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Defias Knuckleduster - Between 0-15% Health - Flee For Assist'),
+(452, 0, 0, 0, 4, 0, 10, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Riverpaw Bandit - On Aggro - Say Line 0'),
+(452, 0, 1, 0, 67, 0, 100, 0, 1000, 3000, 2000, 13000, 0, 5, 11, 7159, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,       'Riverpaw Bandit - Behind Target - Cast Backstab'),
+(452, 0, 2, 0, 0, 0, 85, 0, 2000, 9000, 16000, 39000, 0, 0, 11, 7357, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,       'Riverpaw Bandit - Within 0-5 Range - Cast Poisonous Stab'),
+(452, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Riverpaw Bandit - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(453, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Riverpaw Mystic - On Aggro - Say Line 0'),
+(453, 0, 1, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 9532, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,              'Riverpaw Mystic - In Combat - Cast Lightning Bolt'),
+(453, 0, 2, 0, 74, 0, 100, 0, 5000, 10000, 60000, 60000, 50, 40, 11, 9532, 65, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,  'Riverpaw Mystic - Friendly Between 0-50% Health - Cast Healing Wave'),
+(453, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Riverpaw Mystic - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(456, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 9532, 9532, 64, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Murloc Minor Oracle - In Combat - Cast Lightning Bolt'),
+(456, 0, 1, 0, 14, 0, 100, 0, 130, 40, 30000, 40000, 0, 0, 11, 332, 65, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,         'Murloc Minor Oracle - Friendly Missing 130 Health - Cast Healing Wave'),
+(456, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Murloc Minor Oracle - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(458, 0, 0, 0, 1, 0, 100, 1, 1000, 1000, 0, 0, 0, 0, 11, 8656, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Murloc Hunter - Out of Combat - Cast Summon Crawler (No Repeat)'),
+(458, 0, 1, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 30, 60, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Murloc Hunter - Outside 30 Range - Start Combat Movement'),
+(458, 0, 2, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 5, 30, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Murloc Hunter - Within 5-30 Range - Stop Combat Movement'),
+(458, 0, 3, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 0, 5, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Murloc Hunter - Within 0-5 Range - Start Combat Movement'),
+(458, 0, 4, 0, 9, 0, 100, 0, 0, 0, 2000, 4000, 5, 30, 11, 10277, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Murloc Hunter - IWithin 5-30 Range - Cast Throw'),
+(458, 0, 5, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Murloc Hunter - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(462, 0, 0, 0, 0, 0, 100, 0, 3000, 3000, 8000, 17000, 0, 0, 11, 5708, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,       'Vultros - Within 0-5 Range - Cast Swoop'),
+(500, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Riverpaw Scout - On Aggro - Say Line 0'),
+(500, 0, 1, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 30, 60, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Riverpaw Scout - Outside 30 Range - Start Combat Movement'),
+(500, 0, 2, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 5, 30, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Riverpaw Scout - Within 5-30 Range - Stop Combat Movement'),
+(500, 0, 3, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 0, 5, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Riverpaw Scout - Within 0-5 Range - Start Combat Movement'),
+(500, 0, 4, 0, 9, 0, 100, 0, 0, 0, 2000, 4000, 5, 30, 11, 6660, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Riverpaw Scout - Within 5-30 Range - Cast Shoot'),
+(500, 0, 5, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Riverpaw Scout - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(501, 0, 0, 0, 4, 0, 10, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Riverpaw Herbalist - On Aggro - Say Line 0'),
+(501, 0, 1, 0, 0, 0, 100, 0, 1000, 1000, 120000, 120000, 0, 0, 11, 3369, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Riverpaw Herbalist - In Combat - Cast Potion Strength II'),
+(501, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Riverpaw Herbalist - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(504, 0, 0, 0, 4, 0, 5, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                           'Defias Trapper - On Aggro - Say Line 0'),
+(504, 0, 1, 0, 67, 0, 100, 0, 2300, 4700, 2400, 7300, 0, 5, 11, 2589, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,        'Defias Trapper - Behind Target - Cast Backstab'),
+(504, 0, 2, 0, 0, 0, 100, 0, 6000, 14000, 20000, 31000, 0, 0, 11, 12024, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Defias Trapper - In Combat - Cast Net'),
+(504, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Defias Trapper - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(506, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Sergeant Brashclaw - On Aggro - Say Line 0'),
+(506, 0, 1, 0, 0, 0, 90, 0, 1000, 1000, 30000, 38000, 0, 0, 11, 3136, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,        'Sergeant Brashclaw - In Combat - Cast Frenzied Command'), -- test!
+(506, 0, 2, 0, 0, 0, 100, 0, 2000, 5000, 10000, 18000, 0, 0, 11, 5164, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,      'Sergeant Brashclaw - Within 0-5 Range - Cast Knockdown'),
+(506, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Sergeant Brashclaw - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(513, 0, 0, 0, 0, 0, 100, 0, 11000, 13900, 20500, 33000, 0, 0, 11, 12024, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,   'Murloc Netter - In Combat - Cast Net'),
+(513, 0, 1, 0, 9, 0, 100, 0, 0, 0, 5000, 9000, 0, 5, 11, 11971, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,              'Murloc Netter - In Combat - Cast Sunder Armor'),
+(513, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Murloc Netter - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(517, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 3000, 0, 0, 11, 9734, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,              'Murloc Oracle - In Combat - Cast Holy Smite'),
+(517, 0, 1, 0, 74, 0, 100, 0, 0, 0, 48800, 53700, 50, 40, 11, 6074, 1, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,          'Murloc Oracle - Friendly Between 0-50% Health - Cast Renew'),
+(517, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Murloc Oracle - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(519, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Slark - On Respawn - Cast Thrash Proc'),
+(519, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Slark - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(520, 0, 0, 0, 0, 0, 100, 0, 6000, 12000, 21000, 33000, 0, 0, 11, 9080, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,     'Brack - Within 0-5 Range - Cast Hamstring'),
+(520, 0, 1, 0, 0, 0, 100, 0, 25000, 25000, 47000, 56000, 0, 0, 11, 6016, 1, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,    'Brack - Within 0-5 Range - Cast Pierce Armor'),
+(520, 0, 2, 0, 0, 0, 100, 0, 11000, 11000, 11000, 25000, 0, 0, 11, 11976, 1, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,   'Brack - Within 0-5 Range - Cast Strike'),
+(520, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Brack - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(547, 0, 0, 0, 4, 0, 80, 0, 0, 0, 0, 0, 0, 0, 11, 6268, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                      'Great Goretusk - On Aggro - Cast Rushing Charge'),
+(573, 0, 0, 0, 0, 0, 100, 0, 2000, 4000, 11000, 16000, 0, 0, 11, 5568, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,       'Foe Reaper 4000 - In Combat - Cast Trample'),
+(589, 0, 0, 0, 1, 0, 100, 0, 1000, 1000, 900000, 900000, 0, 0, 11, 12544, 32, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Defias Pillager - Out of Combat - Cast Frost Armor'),
+(589, 0, 1, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Defias Pillager - On Aggro - Say Line 0'),
+(589, 0, 2, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 19816, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Defias Pillager - In Combat - Cast Fireball'),
+(589, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Defias Pillager - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(590, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                          'Defias Looter - On Aggro - Say Line 0'),
+(590, 0, 1, 0, 67, 0, 100, 0, 3000, 4000, 2000, 9000, 0, 5, 11, 7159, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,        'Defias Looter - Behind Target - Cast Backstab'),
+(590, 0, 2, 0, 0, 0, 80, 0, 2000, 6000, 38000, 48000, 0, 0, 11, 6713, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,       'Defias Looter - Within 0-5 Range - Cast Disarm'),
+(590, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       'Defias Looter - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(832, 0, 0, 0, 0, 0, 100, 0, 1000, 10000, 16000, 26000, 0, 0, 11, 6982, 64, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Dust Devil - In Combat - Cast Gust of Wind'),
+(834, 0, 0, 1, 1, 0, 100, 0, 30000, 600000, 120000, 600000, 0, 0, 4, 1018, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Coyote - Out of Combat - Play Sound 1018'),
+(834, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 393, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                      'Coyote - Out of Combat - Play Emote 393'),
+(846, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 11919, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Rotten Ghoul - In Combat - Cast Poison Proc'),
+(1065, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                         'Riverpaw Shaman - On Aggro - Say Line 0'),
+(1065, 0, 1, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 9532, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Riverpaw Shaman - In Combat - Cast Lightning Bolt'),
+(1065, 0, 2, 0, 74, 0, 100, 0, 0, 0, 60000, 60000, 40, 40, 11, 913, 1, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,          'Riverpaw Shaman - Friendly Between 0-40% Health - Cast Healing Wave'),
+(1065, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Riverpaw Shaman - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(1236, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                         'Kobold Digger - On Aggro - Say Line 0'),
+(1236, 0, 1, 0, 0, 0, 100, 0, 6000, 12000, 46000, 50000, 0, 0, 11, 6016, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,    'Kobold Digger - Within 0-5 Range - Cast Pierce Armor'),
+(1236, 0, 2, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Kobold Digger - Between 0-30% Health - Flee For Assist (No Repeat)'),
+(1424, 0, 0, 0, 0, 0, 100, 0, 4000, 6000, 15000, 18000, 0, 0, 11, 6546, 32, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,    'Master Digger - Within 0-5 Range - Cast Rend'),
+(1424, 0, 1, 0, 0, 0, 100, 0, 9000, 12000, 12000, 15000, 0, 0, 11, 25710, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,   'Master Digger - Within 0-5 Range - Cast Heroic Strike'),
+(1424, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Master Digger - Between 0-15% Health - Flee For Assist (No Repeat)');
+
+
 -- Gina MacGregor <Trade Supplies>
 DELETE FROM `npc_vendor` WHERE `entry`=843 AND `item`=39354;
 
@@ -5,6 +129,5 @@ DELETE FROM `npc_vendor` WHERE `entry`=843 AND `item`=39354;
 DELETE FROM `npc_vendor` WHERE `entry`=8934 AND `item` IN (10648, 14341, 18256, 30817, 39354);
 
 -- Restore Defias Pillager to original Fireball spell (was nerfed in 2.3)
-DELETE FROM `creature_template_spell` WHERE `CreatureID`=589 AND `Index`=0;
+DELETE FROM `creature_template_spell` WHERE `CreatureID` = 589 AND `Index` = 0;
 INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES (589, 0, 19816, 12340);
-UPDATE `smart_scripts` SET `action_param1` = 19816 WHERE `entryorguid`=589 AND `source_type`=0 AND `id`=2 AND `link`=0;


### PR DESCRIPTION
some of the changes;
- Riverpaw Brute, fix Demoralizing Shout
- Young Fleshripper no longer casts Screech
- Riverpaw Mystic now casts Healing Wave
- Murloc Hunter, fix ranged combat
- Riverpaw Scout, fix ranged combat
- Defias Trapper now only casts Backstab while behind target
- Murloc Oracle, fix Renew
- Foe Reaper 4000, fix Trample
- Defias Looter now only casts Backstab while behind target
- Riverpaw Shaman, fix Healing Wave
- Malformed Defias Drone no longer casts Battle Stance