### PR TITLE
fixes in Mulgore

### DIFF
--- a/data/sql/world/base/zone_mulgore.sql
+++ b/data/sql/world/base/zone_mulgore.sql
@@ -1,86 +1,79 @@
 /* smart scripts */
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (3058, 3068, 5807);
-DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (3058, 3068, 5807);
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` IN (2959, 3035, 3056, 5787);
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN 
+(2949, 2950, 2951, 2953, 2954, 2956, 2957, 2958, 2960, 2962, 2963, 2964, 2965, 2967, 2968, 2969, 2970, 2971, 2972, 2973, 2974, 2975, 2976, 2977, 2978, 2989, 2990, 3051, 3058, 3068, 3232, 5786, 5807);
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN 
+(2949, 2950, 2951, 2953, 2954, 2956, 2957, 2958, 2959, 2960, 2962, 2963, 2964, 2965, 2967, 2968, 2969, 2970, 2971, 2972, 2973, 2974, 2975, 2976, 2977, 2978, 2989, 2990, 3035, 3051, 3056, 3058, 3068, 3232, 5786, 5787, 5807);
+
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
 `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
 `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
 `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
 --
-(3058, 0, 0, 0, 9, 0, 100, 0, 11000, 15000, 11000, 15000, 0, 5, 11, 6730, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Arra chea   - Within 0-5 Range - Cast Head Butt'),
-(3068, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 269080, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,             'Mazzranache - On Resspawn - Start Waypoint'),
-(3068, 0, 1, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 10022, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Mazzranache - On Reset  - Cast Deadly Poison'),
-(3068, 0, 2, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 6268, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Mazzranache - On Aggro  - Cast Rushing Charge'),
-(5807, 0, 0, 0, 9, 0, 100, 0, 8000, 12000, 8000, 12000, 0, 5, 11, 12166, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,  'The Rake    - Within 0-5 Range - Cast Muscle Tear');
+(2949, 0, 0, 0, 0, 0, 100, 0, 0, 0, 9000, 14000, 0, 0, 11, 9739, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Palemane Tanner - In Combat - Cast Wrath'),
+(2949, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Palemane Tanner - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2950, 0, 0, 0, 2, 0, 100, 0, 0, 50, 21000, 25000, 0, 0, 11, 774, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,            'Palemane Skinner - Between 0-50% Health - Cast Rejuvenation'),
+(2950, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Palemane Skinner - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2951, 0, 1, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 30, 60, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Palemane Poacher - Outside 30 Range - Start Combat Movement'),
+(2951, 0, 2, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 5, 30, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Palemane Poacher - Within 5-30 Range - Stop Combat Movement'),
+(2951, 0, 3, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 0, 5, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Palemane Poacher - Within 0-5 Range - Start Combat Movement'),
+(2951, 0, 4, 0, 9, 0, 100, 0, 0, 0, 2000, 3000, 5, 30, 11, 6660, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Palemane Poacher - Within 5-30 Range - Cast Shoot'),
+(2951, 0, 5, 0, 9, 0, 100, 0, 0, 3000, 9000, 14000, 5, 30, 11, 1516, 0, 7, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,         'Palemane Poacher - Within 5-30 Range - Cast Quick Shot'),
+(2951, 0, 6, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Palemane Poacher - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2953, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 9532, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Bristleback Shaman - In Combat - Cast Lightning Bolt'),
+(2954, 0, 0, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 3385, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Bristleback Battleboar - On Aggro - Cast Boar Charge'),
+--
+(2956, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Palemane Poacher - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2957, 0, 0, 0, 0, 0, 100, 0, 6000, 10000, 19000, 24000, 0, 0, 11, 7272, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Elder Plainstrider - Between 20-40% Health - Cast Dust Cloud'),
+(2957, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Elder Plainstrider - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2958, 0, 0, 0, 9, 0, 100, 0, 0, 0, 45000, 45000, 0, 5, 11, 5781, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Prairie Wolf - Within 0-5 Range - Cast Threatening Growl'),
+(2960, 0, 0, 0, 9, 0, 100, 0, 0, 0, 45000, 45000, 0, 5, 11, 5781, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Prairie Wolf Alpha - Within 0-5 Range - Cast Threatening Growl'),
+--
+(2962, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Windfury Harpy - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2963, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 4000, 0, 0, 11, 9532, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Windfury Wind Witch - In Combat - Cast Lightning Bolt'),
+(2963, 0, 1, 0, 0, 0, 100, 0, 0, 3000, 11000, 16000, 0, 0, 11, 6982, 64, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,        'Windfury Wind Witch - In Combat - Cast Gust of Wind'),
+(2963, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Windfury Wind Witch - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2964, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 13322, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Windfury Sorceress - In Combat - Cast Frostbolt'),
+(2964, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Windfury Sorceress - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2965, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 9532, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Windfury Matriarch - In Combat - Cast Lightning Bolt'),
+(2965, 0, 1, 0, 74, 0, 100, 0, 0, 0, 18000, 24000, 50, 40, 11, 332, 64, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,         'Windfury Matriarch - Friendly Between 0-50% Health - Cast Healing Wave'),
+--
+(2967, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Galak Centaur - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2968, 0, 1, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 30, 60, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Galak Outrunner - Outside 30 Range - Start Combat Movement'),
+(2968, 0, 2, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 5, 30, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Galak Outrunner - Within 5-30 Range - Stop Combat Movement'),
+(2968, 0, 3, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 0, 5, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Galak Outrunner - Within 0-5 Range - Start Combat Movement'),
+(2968, 0, 4, 0, 9, 0, 100, 0, 0, 0, 2000, 4000, 5, 30, 11, 6660, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Galak Outrunner - Within 5-30 Range - Cast Shoot'),
+(2968, 0, 5, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Galak Outrunner - Between 0-15% Health - Flee For Assist (No Repeat)'),
+--
+(2969, 0, 0, 0, 9, 0, 100, 0, 0, 0, 15000, 21000, 0, 5, 11, 5708, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Wiry Swoop - Within 0-5 Range - Cast Swoop'),
+(2970, 0, 0, 0, 9, 0, 100, 0, 0, 0, 15000, 21000, 0, 0, 11, 5708, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Swoop - Within 0-5 Range - Cast Swoop'),
+(2971, 0, 0, 0, 9, 0, 100, 0, 0, 0, 15000, 21000, 0, 0, 11, 5708, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Taloned Swoop - Within 0-5 Range - Cast Swoop'),
+(2972, 0, 0, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 6268, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Kodo Calf - On Aggro - Cast Rushing Charge'),
+(2973, 0, 0, 0, 9, 0, 100, 0, 0, 0, 9000, 14000, 0, 8, 11, 5568, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,             'Kodo Bull - Within 0-8 Range - Cast Trample'),
+(2974, 0, 0, 0, 9, 0, 100, 0, 0, 0, 9000, 14000, 0, 8, 11, 5568, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,             'Kodo Matriarch - Within 0-8 Range - Cast Trample'),
+--
+(2975, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Venture Co. Hireling - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2976, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Venture Co. Laborer - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2977, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Venture Co. Taskmaster - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2978, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Venture Co. Worker - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2989, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Bael\'dun Digger - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2990, 0, 0, 0, 2, 0, 100, 0, 0, 50, 12000, 17000, 0, 0, 11, 2052, 64, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,          'Bael\'dun Appraiser - Between 0-50% Health - Cast Lesser Heal'),
+(2990, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Bael\'dun Appraiser - Between 0-15% Health - Flee For Assist (No Repeat)'),
+--
+(3051, 0, 0, 0, 0, 0, 100, 0, 1000, 3000, 15000, 30000, 0, 0, 11, 6673, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,      'Supervisor Fizsprocket - In Combat - Cast Battle Shout'),
+(3051, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Supervisor Fizsprocket - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(3058, 0, 0, 0, 9, 0, 100, 0, 0, 0, 11000, 15000, 0, 5, 11, 6730, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Arra\'chea - Within 0-5 Range - Cast Head Butt'),
+(3068, 0, 1, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 10022, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Mazzranache - On Respawn - Cast Deadly Poison'),
+(3068, 0, 2, 0, 9, 0, 100, 1, 0, 0, 0, 0, 0, 30, 11, 6268, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Mazzranache - Within 0-30 Range - Cast Rushing Charge'),
+(3232, 0, 0, 0, 9, 0, 100, 0, 0, 0, 14000, 20000, 0, 5, 11, 12166, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Bristleback Interloper - Within 0-5 Range - Cast Muscle Tear'),
+(5786, 0, 0, 0, 9, 0, 100, 0, 0, 0, 11000, 25300, 0, 20, 11, 12024, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Snagglespear - On Aggro - Cast Net'),
+(5786, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Snagglespear - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(5807, 0, 0, 0, 9, 0, 100, 0, 0, 0, 8000, 12000, 0, 5, 11, 12166, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'The Rake - Within 0-5 Range - Cast Muscle Tear');
 
--- update npc factions
-UPDATE `creature_template` SET `faction` = 14  WHERE `entry` IN (2966, 3229, 8554);       -- Battleboar, Squealer Thornmantle, Chief Sharptusk Thornmantle
-UPDATE `creature_template` SET `faction` = 57  WHERE `entry` IN (2989, 2990);       -- Bael'dun Digger, Appraiser
-UPDATE `creature_template` SET `faction` = 111 WHERE `entry` IN (2952, 2953, 2954); -- Bristleback Quilboar, Shaman, Battleboar
 
--- update npc names
-UPDATE `creature_template` SET `subname` = 'Journeyman Leatherworker'  WHERE `entry` = 3069;  -- Chaw Stronghide <Journeyman Leatherworker>
-UPDATE `creature_template` SET `subname` = 'Armorer and Shieldcrafter' WHERE `entry` = 3075;  -- Bronk Steelrage
-UPDATE `creature_template` SET `subname` = 'Fisherman'                 WHERE `entry` = 5938;  -- Uthan Stillwater <Fisherman>
-UPDATE `creature_template` SET `subname` = 'Skinner'                   WHERE `entry` = 6290;  -- Yonn Deepcut <Skinner>
-UPDATE `creature_template` SET `subname` = 'Journeyman Engineer'       WHERE `entry` = 10993; -- Twizwick Sprocketgrind <Journeyman Engineer>
+-- Mazzranache, waypoints
+UPDATE `creature` SET `spawntimesecs` = 9000, `MovementType` = 2, `currentwaypoint` = 1 WHERE `id1` = 3068;
 
-UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55 WHERE `entry` IN (3210, 3211, 7975); -- guards
-
-
-DELETE FROM `npc_trainer` WHERE `ID` IN (3069, 3690, 5938, 5939, 6290, 10993);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES 
-(3069,  -380000), -- Chaw Stronghide <Journeyman Leatherworker>
-(3690,  -450000), -- Kar Stormsinger <Riding Trainer>
-(5938,  -360000), -- Uthan Stillwater <Fisherman>
-(5939,  -350000), -- Vira Younghoof <First Aid Trainer>
-(6290,  -400000), -- Yonn Deepcut <Skinner>
-(10993, -340000); -- Twizwick Sprocketgrind <Journeyman Engineer>
-
-
-/* Quests */
-
--- The Hunt Begins
-DELETE FROM `quest_offer_reward` WHERE `ID` = 747;
-INSERT INTO `quest_offer_reward` (`ID`, `RewardText`) VALUES 
-(747, 'The tauren of Narache thank you, $n. You show much promise.');
-
--- The Hunter's Way
-DELETE FROM `quest_offer_reward` WHERE `ID` = 861;
-INSERT INTO `quest_offer_reward` (`ID`, `RewardText`) VALUES 
-(861, 'Skorn Whitecloud is a wise tauren. He has hunted for years and years, and although his body is old, his spirit burns fiercely. We are honored to have him with us.$B$B
- If Skorn sent you to me, then you too must have the hunter\'s spirit. And to have gathered these claws shows your burgeoning skills.$B$BPerhaps you are ready to walk the path.');
-
--- The Hunt Begins
-DELETE FROM `quest_request_items` WHERE `ID` = 747;
-INSERT INTO `quest_request_items` (`ID`, `EmoteOnComplete`, `CompletionText`) VALUES 
-(747, 1, 'Providing meat and feathers for the tribe is the first step in proving yourself as a hunter before the Chief.');
-
--- Wildmane Cleansing
-DELETE FROM `quest_request_items` WHERE `ID` = 760;
-INSERT INTO `quest_request_items` (`ID`, `EmoteOnComplete`, `CompletionText`) VALUES 
-(760, 1, 'The last water well remains fetid and poisonous, $N. You must not delay!');
-
-
-UPDATE `quest_template` SET `Flags` = 0 WHERE `ID` = 1518; -- Call of Earth (Shaman)
-
-UPDATE `quest_template_addon` SET `SpecialFlags` = 0 WHERE `ID` IN (
-747,  -- The Hunt Begins
-750,  -- The Hunt Continues
-752,  -- A Humble Task
-753,  -- A Humble Task
-755,  -- Rites of the Earthmother
-757,  -- Rite of Strength
-763,  -- Rites of the Earthmother
-780,  -- The Battleboars
-1518, -- Call of Earth (Shaman)
-1520, -- Call of Earth (Shaman)
-1521, -- Call of Earth (Shaman)
-1656, -- A Task Unfinished
-3093, -- Rune-Inscribed Note
-3376  -- Break Sharptusk!
-);
-
-    
 DELETE FROM `creature_addon` WHERE `guid` = 26908;
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 
 (26908, 269080, 0, 0, 0, 0, 0, NULL);
@@ -151,3 +144,72 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 (269080, 62, -1709.83, -507.869, -12.8309, NULL, 0, 0, 0, 100, 0),
 (269080, 63, -1729.44, -528.724, -13.8673, NULL, 0, 0, 0, 100, 0),
 (269080, 64, -1731.65, -542.165, -13.1692, NULL, 0, 0, 0, 100, 0);
+
+
+-- update npc factions
+UPDATE `creature_template` SET `faction` = 14  WHERE `entry` IN (2966, 3229, 8554);       -- Battleboar, Squealer Thornmantle, Chief Sharptusk Thornmantle
+UPDATE `creature_template` SET `faction` = 57  WHERE `entry` IN (2989, 2990);       -- Bael'dun Digger, Appraiser
+UPDATE `creature_template` SET `faction` = 111 WHERE `entry` IN (2952, 2953, 2954); -- Bristleback Quilboar, Shaman, Battleboar
+
+-- update npc names
+UPDATE `creature_template` SET `subname` = 'Journeyman Leatherworker'  WHERE `entry` = 3069;  -- Chaw Stronghide <Journeyman Leatherworker>
+UPDATE `creature_template` SET `subname` = 'Armorer and Shieldcrafter' WHERE `entry` = 3075;  -- Bronk Steelrage
+UPDATE `creature_template` SET `subname` = 'Fisherman'                 WHERE `entry` = 5938;  -- Uthan Stillwater <Fisherman>
+UPDATE `creature_template` SET `subname` = 'Skinner'                   WHERE `entry` = 6290;  -- Yonn Deepcut <Skinner>
+UPDATE `creature_template` SET `subname` = 'Journeyman Engineer'       WHERE `entry` = 10993; -- Twizwick Sprocketgrind <Journeyman Engineer>
+
+UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55 WHERE `entry` IN (3210, 3211, 7975); -- guards
+
+
+DELETE FROM `npc_trainer` WHERE `ID` IN (3069, 3690, 5938, 5939, 6290, 10993);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES 
+(3069,  -380000), -- Chaw Stronghide <Journeyman Leatherworker>
+(3690,  -450000), -- Kar Stormsinger <Riding Trainer>
+(5938,  -360000), -- Uthan Stillwater <Fisherman>
+(5939,  -350000), -- Vira Younghoof <First Aid Trainer>
+(6290,  -400000), -- Yonn Deepcut <Skinner>
+(10993, -340000); -- Twizwick Sprocketgrind <Journeyman Engineer>
+
+
+/* Quests */
+
+-- The Hunt Begins
+DELETE FROM `quest_offer_reward` WHERE `ID` = 747;
+INSERT INTO `quest_offer_reward` (`ID`, `RewardText`) VALUES 
+(747, 'The tauren of Narache thank you, $n. You show much promise.');
+
+-- The Hunter's Way
+DELETE FROM `quest_offer_reward` WHERE `ID` = 861;
+INSERT INTO `quest_offer_reward` (`ID`, `RewardText`) VALUES 
+(861, 'Skorn Whitecloud is a wise tauren. He has hunted for years and years, and although his body is old, his spirit burns fiercely. We are honored to have him with us.$B$B
+ If Skorn sent you to me, then you too must have the hunter\'s spirit. And to have gathered these claws shows your burgeoning skills.$B$BPerhaps you are ready to walk the path.');
+
+-- The Hunt Begins
+DELETE FROM `quest_request_items` WHERE `ID` = 747;
+INSERT INTO `quest_request_items` (`ID`, `EmoteOnComplete`, `CompletionText`) VALUES 
+(747, 1, 'Providing meat and feathers for the tribe is the first step in proving yourself as a hunter before the Chief.');
+
+-- Wildmane Cleansing
+DELETE FROM `quest_request_items` WHERE `ID` = 760;
+INSERT INTO `quest_request_items` (`ID`, `EmoteOnComplete`, `CompletionText`) VALUES 
+(760, 1, 'The last water well remains fetid and poisonous, $N. You must not delay!');
+
+
+UPDATE `quest_template` SET `Flags` = 0 WHERE `ID` = 1518; -- Call of Earth (Shaman)
+
+UPDATE `quest_template_addon` SET `SpecialFlags` = 0 WHERE `ID` IN (
+747,  -- The Hunt Begins
+750,  -- The Hunt Continues
+752,  -- A Humble Task
+753,  -- A Humble Task
+755,  -- Rites of the Earthmother
+757,  -- Rite of Strength
+763,  -- Rites of the Earthmother
+780,  -- The Battleboars
+1518, -- Call of Earth (Shaman)
+1520, -- Call of Earth (Shaman)
+1521, -- Call of Earth (Shaman)
+1656, -- A Task Unfinished
+3093, -- Rune-Inscribed Note
+3376  -- Break Sharptusk!
+);


### PR DESCRIPTION
WIP

some of the changes:
- Palemane members now flee at 15% health
- Palemane Poacher, fix ranged combat
- Adult Plainstrider no longer casts Dust Cloud
- Elder Plainstrider, fix Dust Cloud
- Prairie Stalker and Flatland Cougar no longer cast Tendon Rip
- Windfury Harpies now flee at 15% health
- Windfury Harpy no longer casts Lightning Bolt
- Windfury Wind Witch, fix Gust of Wind
- Galak Centaur and Outrunner now flee at 15% health
- Galak Centaur no longer casts Improved Blocking
- Galak Outrunner, fix ranged combat
- Kodo Matriarch, fix Trample
- Venture Co. Laborer and Worker no longer cast Pierce Armor
- Bael'dun Digger no longer casts Pierce Armor
- Supervisor Fizsprocket now casts Battle Shout
- Ghost Howl no longer casts Threatening Howl
- Enforcer Emilgund no longer casts Frenzy