### PR TITLE
fixes in Dire Maul West

### DIFF
--- a/data/sql/world/base/dungeon_dire_maul.sql
+++ b/data/sql/world/base/dungeon_dire_maul.sql
@@ -267,11 +267,113 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 
 
 /* Dire Maul West - smart scripts */
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (11477);
-DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (11477);
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN 
+(11458, 11459, 11466, 11467, 11469, 11470, 11471, 11472, 11473, 11475, 11476, 11477, 11480, 11483, 11484, 11486, 11487, 11488, 11489, 11496, 14303, 14308, 14398, 14399, 14400);
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN 
+(11458, 11459, 11466, 11467, 11469, 11470, 11471, 11472, 11473, 11475, 11476, 11477, 11480, 11483, 11484, 11486, 11487, 11488, 11489, 11496, 14303, 14308, 14398, 14399, 14400);
+
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
 `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
 `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
 `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
 --
-(11477, 0, 0, 0, 6, 0, 100, 513, 0, 0, 0, 0, 0, 0, 11, 22825, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Rotting Highborne - On Just Died - Cast Summon Cadaverous Worm');
+(11458, 0, 0, 0, 2, 0, 100, 1, 0, 50, 0, 0, 0, 0, 11, 22693, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Petrified Treant - Between 0-50% Health - Cast Harden Skin (No Repeat)'),
+(11459, 0, 0, 0, 0, 0, 100, 0, 4000, 6000, 6000, 18000, 0, 0, 11, 5568, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,      'Ironbark Protector - In Combat - Cast Trample'),
+(11459, 0, 1, 0, 0, 0, 100, 0, 7000, 9000, 14000, 18000, 0, 0, 11, 18670, 0, 0, 0, 0, 0, 21, 10, 0, 0, 0, 0, 0, 0, 0,  'Ironbark Protector - In Combat - Cast Knock Away'),
+(11459, 0, 2, 0, 0, 0, 100, 0, 9000, 12000, 19000, 25000, 0, 0, 11, 28858, 32, 0, 0, 0, 0, 5, 30, 0, 0, 0, 0, 0, 0, 0, 'Ironbark Protector - In Combat - Cast Entangling Roots'),
+(11466, 0, 0, 0, 38, 0, 100, 0, 2, 2, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 19, 11496, 200, 0, 0, 0, 0, 0, 0,              'Highborne Summoner - On Data Set - Attack Start'),
+(11466, 0, 1, 0, 0, 0, 100, 0, 0, 2000, 3000, 5000, 0, 0, 11, 9053, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,         'Highborne Summoner - In Combat - Cast Fireball'),
+(11466, 0, 2, 0, 0, 0, 100, 0, 4000, 9000, 9000, 19000, 0, 0, 11, 13339, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Highborne Summoner - In Combat - Cast Fire Blast'),
+(11466, 0, 3, 0, 0, 0, 100, 0, 12000, 16000, 18000, 22000, 0, 0, 11, 15063, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,  'Highborne Summoner - In Combat - Cast Frost Nova'),
+(11467, 0, 0, 0, 37, 0, 85, 0, 0, 0, 0, 0, 0, 0, 41, 500, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Tsu\'zee - On AI initialize - Self: Despawn in 0.5 s'),
+(11467, 0, 1, 0, 0, 0, 100, 2, 3000, 5000, 5000, 7000, 0, 0, 11, 15581, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,     'Tsu\'zee - Within 0-5 Range - Cast Sinister Strike'),
+(11467, 0, 2, 0, 0, 0, 100, 2, 6000, 8000, 9000, 12000, 0, 0, 11, 12540, 0, 0, 0, 0, 0, 5, 5, 0, 0, 0, 0, 0, 0, 0,     'Tsu\'zee - Within 0-5 Range - Cast Gouge'),
+(11467, 0, 3, 0, 0, 0, 100, 2, 7000, 11000, 16000, 21000, 0, 0, 11, 21060, 0, 0, 0, 0, 0, 6, 10, 0, 0, 0, 0, 0, 0, 0,  'Tsu\'zee - Within 0-10 Range - Cast Blind'),
+--
+(11469, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 13376, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Eldreth Seether - On Respawn - Cast Fire Shield'),
+(11469, 0, 1, 0, 0, 0, 100, 0, 2000, 10000, 17000, 22000, 0, 0, 11, 16843, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Eldreth Seether - In Combat - Cast Crimson Fury'),
+(11469, 0, 2, 3, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 11, 8269, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Eldreth Seether - Between 0-30% Health - Cast Frenzy'),
+(11469, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                      'Eldreth Seether - On Frenzy - Say Line 0'),
+(11470, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 16006, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Eldreth Sorcerer - In Combat - Cast Chain Lightning'),
+(11470, 0, 1, 0, 0, 0, 100, 0, 9000, 15000, 16000, 21000, 0, 0, 11, 13323, 97, 0, 0, 0, 0, 6, 30, 0, 0, 0, 0, 0, 0, 0, 'Eldreth Sorcerer - In Combat - Cast Polymorph'),
+(11470, 0, 2, 0, 0, 0, 100, 0, 10000, 14000, 7000, 13000, 0, 0, 11, 22823, 0, 0, 0, 0, 0, 5, 30, 0, 0, 0, 0, 0, 0, 0,  'Eldreth Sorcerer - In Combat - Cast Starshards'),
+(11471, 0, 0, 0, 1, 0, 100, 0, 1000, 10000, 600000, 600000, 0, 0, 11, 18100, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Eldreth Apparition - Out of Combat - Cast Frost Armor'),
+(11471, 0, 1, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 16799, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Eldreth Apparition - In Combat - Cast Frostbolt'),
+(11471, 0, 2, 0, 0, 0, 100, 0, 11000, 14000, 20000, 30000, 0, 0, 11, 15244, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,  'Eldreth Apparition - In Combat - Cast Cone of Cold'), -- test!
+(11471, 0, 3, 0, 0, 0, 100, 0, 7000, 12000, 20000, 28000, 0, 0, 11, 22744, 32, 0, 0, 0, 0, 6, 30, 0, 0, 0, 0, 0, 0, 0, 'Eldreth Apparition - In Combat - Cast Chains of Ice'),
+(11472, 0, 0, 0, 9, 0, 100, 0, 0, 0, 6100, 14400, 0, 5, 11, 16838, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,           'Eldreth Spirit - Within 0-5 Range - Cast Banshee Shriek'),
+(11472, 0, 1, 0, 0, 0, 100, 0, 0, 0, 4900, 8800, 0, 0, 11, 22743, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Eldreth Spirit - In Combat - Cast Ribbon of Souls'), -- test!
+(11473, 0, 0, 0, 1, 0, 100, 0, 0, 0, 16000, 16000, 0, 0, 11, 16380, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,          'Eldreth Spectre - Out of Combat - Cast Greater Invisibility'),
+(11473, 0, 1, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 28, 16380, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Eldreth Spectre - On Aggro - Remove Greater Invisibility'),
+(11473, 0, 2, 0, 9, 0, 100, 0, 0, 0, 14000, 25000, 0, 5, 11, 17831, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Eldreth Spectre - Within 0-5 Range - Cast Call of the Graves'),
+(11473, 0, 3, 0, 14, 0, 100, 0, 2000, 40, 9000, 14000, 0, 0, 11, 7154, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,       'Eldreth Spectre - Friendly Missing Health - Cast Dark Offering'),
+(11473, 0, 4, 0, 0, 0, 100, 0, 9000, 12000, 22000, 26000, 0, 0, 11, 17201, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Eldreth Spectre - In Combat - Self Cast Dispel Magic'),
+(11475, 0, 0, 0, 9, 0, 100, 0, 0, 0, 15200, 20100, 0, 5, 11, 17831, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Eldreth Phantasm - Within 0-5 Range - Cast Call of the Graves'),
+(11475, 0, 1, 0, 0, 0, 100, 0, 6000, 9000, 16000, 29000, 0, 0, 11, 15802, 96, 0, 0, 0, 0, 5, 30, 0, 0, 0, 0, 0, 0, 0,  'Eldreth Phantasm - In Combat - Cast Shrink'),
+--
+(11476, 0, 0, 0, 9, 0, 100, 0, 0, 0, 5000, 9000, 0, 5, 11, 13444, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Skeletal Highborne - Within 0-5 Range - Cast Sunder Armor'),
+(11477, 0, 0, 0, 6, 0, 100, 512, 0, 0, 0, 0, 0, 0, 11, 22825, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Rotting Highborne - On Just Died - Cast Summon Cadaverous Worm'),
+(11480, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2400, 3800, 0, 0, 11, 15979, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Arcane Aberration - In Combat - Cast Arcane Bolt'),
+(11480, 0, 1, 0, 6, 0, 100, 512, 0, 0, 0, 0, 0, 0, 11, 22936, 258, 0, 0, 0, 0, 5, 30, 0, 1, 0, 0, 0, 0, 0,             'Arcane Aberration - On Death - Cast Mana Burn'),
+(11483, 0, 0, 0, 0, 0, 100, 0, 6000, 9000, 11000, 15000, 0, 0, 11, 15659, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,   'Mana Remnant - In Combat - Cast Chain Lightning'),
+(11483, 0, 1, 0, 0, 0, 100, 0, 5000, 25000, 15000, 25000, 0, 0, 11, 14514, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Mana Remnant - In Combat - Cast Blink'),
+(11484, 0, 0, 0, 0, 0, 100, 0, 3000, 5000, 3000, 5000, 0, 0, 11, 15230, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Residual Monstrosity - In Combat - Cast Arcane Bolt'),
+(11484, 0, 1, 0, 0, 0, 100, 0, 7000, 9000, 9000, 14000, 0, 0, 11, 22940, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Residual Monstrosity - In Combat - Cast Arcane Blast'),
+(11484, 0, 2, 0, 6, 0, 100, 512, 0, 0, 0, 0, 0, 0, 11, 22939, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Residual Monstrosity - On Death - Cast Summon Mana Bursts'),
+--
+(11486, 0, 0, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'Prince Tortheldrin - On Aggro - Say Line 0'),
+(11486, 0, 1, 0, 60, 0, 100, 257, 5000, 5000, 5000, 5000, 0, 0, 2, 14, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,       'Prince Tortheldrin - On Update - Set Faction'),
+(11486, 0, 2, 0, 25, 0, 100, 257, 0, 0, 0, 0, 0, 0, 11, 674, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Prince Tortheldrin - On Reset - Cast Dual Wield'),
+(11486, 0, 3, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Prince Tortheldrin - On Reset - Cast Thrash'),
+(11486, 0, 4, 0, 0, 0, 100, 0, 8000, 12000, 10000, 12000, 0, 0, 11, 22920, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,   'Prince Tortheldrin - In Combat - Cast Arcane Blast'),
+(11486, 0, 5, 0, 0, 0, 100, 0, 5000, 9000, 6000, 9000, 0, 0, 11, 13736, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,      'Prince Tortheldrin - In Combat - Cast Whirlwind'),
+(11486, 0, 6, 0, 105, 0, 100, 0, 0, 0, 1000, 4000, 0, 30, 11, 20537, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,         'Prince Tortheldrin - Target Casting - Cast Counterspell'),
+(11486, 0, 7, 0, 6, 0, 100, 512, 0, 0, 0, 0, 0, 0, 34, 1, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Prince Tortheldrin - On Death - Set Instance Data 1 to 2'),
+--
+(11487, 0, 0, 0, 2, 0, 100, 1, 0, 60, 0, 0, 0, 0, 11, 22917, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Magister Kalendris - Between 0-60% Health - Cast Shadowform (No Repeat)'),
+(11487, 0, 1, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 28, 22917, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Magister Kalendris - Between 0-30% Health - Remove Shadowform (No Repeat)'),
+(11487, 0, 2, 0, 0, 0, 100, 0, 1000, 3000, 6000, 8000, 0, 0, 11, 15587, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Magister Kalendris - In Combat - Cast Mind Blast'),
+(11487, 0, 3, 0, 0, 0, 100, 0, 7000, 10000, 9000, 12000, 0, 0, 11, 22919, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,   'Magister Kalendris - In Combat - Cast Mind Flay'),
+(11487, 0, 4, 0, 0, 0, 100, 0, 5000, 9000, 20000, 24000, 0, 0, 11, 15654, 0, 0, 0, 0, 0, 5, 30, 0, 0, 0, 0, 0, 0, 0,   'Magister Kalendris - In Combat - Cast Shadow Word: Pain'),
+(11487, 0, 5, 0, 0, 0, 100, 0, 8000, 12000, 15000, 20000, 0, 0, 11, 7645, 0, 0, 0, 0, 0, 6, 20, 0, 0, 0, 0, 0, 0, 0,   'Magister Kalendris - In Combat - Cast Dominate Mind'),
+(11487, 0, 6, 0, 6, 0, 100, 512, 0, 0, 0, 0, 0, 0, 99, 3, 0, 0, 0, 0, 0, 20, 185579, 150, 0, 0, 0, 0, 0, 0,            'Magister Kalendris - On Death - Set Gameobject Loot State'),
+(11487, 0, 7, 0, 1, 0, 100, 1, 10000, 10000, 0, 0, 0, 0, 11, 21157, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,          'Magister Kalendris - Out of Combat - Cast Dark Channeling'),
+--
+(11488, 0, 0, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 30, 60, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Illyanna Ravenoak - Outside 30 Range - Start Combat Movement'),
+(11488, 0, 1, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 5, 30, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Illyanna Ravenoak - Within 5-30 Range - Stop Combat Movement'),
+(11488, 0, 2, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 0, 5, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Illyanna Ravenoak - Within 0-5 Range - Start Combat Movement'),
+(11488, 0, 3, 0, 9, 0, 100, 0, 0, 0, 2000, 4000, 5, 30, 11, 16100, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Illyanna Ravenoak - Within 5-30 Range - Cast Shoot'),
+(11488, 0, 4, 0, 0, 0, 100, 0, 30000, 35000, 60000, 65000, 0, 0, 11, 22908, 0, 0, 0, 0, 0, 5, 30, 0, 0, 0, 0, 0, 0, 0, 'Illyanna Ravenoak - Within 0-30 Range - Cast Volley'),
+(11488, 0, 5, 0, 9, 0, 100, 0, 0, 0, 6000, 9000, 0, 30, 11, 20735, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Illyanna Ravenoak - Within 0-30 Range - Cast Multi-Shot'),
+(11488, 0, 6, 0, 0, 0, 100, 0, 5000, 7000, 16000, 20000, 0, 0, 11, 22914, 0, 0, 0, 0, 0, 5, 30, 0, 0, 0, 0, 0, 0, 0,   'Illyanna Ravenoak - Within 0-30 Range - Cast Concussive Shot'),
+(11488, 0, 7, 0, 0, 0, 100, 0, 7000, 10000, 10000, 15000, 0, 0, 11, 22910, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Illyanna Ravenoak - In Combat - Cast Immolation Trap'),
+--
+(11489, 0, 0, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'Tendris Warpwood - On Aggro - Say Line 0'),
+(11489, 0, 1, 0, 0, 0, 100, 0, 5000, 9000, 9000, 14000, 0, 0, 11, 5568, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,      'Tendris Warpwood - In Combat - Cast Trample'),
+(11489, 0, 2, 0, 0, 0, 100, 0, 2000, 4000, 17000, 22000, 0, 0, 11, 22924, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,    'Tendris Warpwood - In Combat - Cast Grasping Vines'),
+(11489, 0, 3, 0, 0, 0, 100, 0, 6000, 12000, 15000, 20000, 0, 0, 11, 22994, 32, 0, 0, 0, 0, 6, 40, 0, 0, 0, 0, 0, 0, 0, 'Tendris Warpwood - In Combat - Cast Entangle'),
+(11489, 0, 4, 0, 0, 0, 100, 0, 9000, 12000, 12000, 15000, 0, 0, 11, 22916, 0, 0, 0, 0, 0, 21, 10, 0, 0, 0, 0, 0, 0, 0, 'Tendris Warpwood - Within 0-10 Range - Cast Uppercut'),
+(11489, 0, 5, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 14566, 4, 120000, 0, 0, 0, 8, 0, 0, 0, 0, 63.5089, 492.417, -23.2966, 3.21228, 'Tendris Warpwood - On Death - Summon Ancient Equine Spirit'), -- test!
+--
+(11496, 0, 0, 1, 38, 0, 100, 512, 1, 1, 0, 0, 0, 0, 45, 2, 2, 0, 0, 0, 0, 11, 11466, 200, 0, 0, 0, 0, 0, 0,            'Immol\'thar - On Data Set - Set Data'),
+(11496, 0, 1, 2, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 19, 11466, 200, 0, 0, 0, 0, 0, 0,             'Immol\'thar - On Data Set - Say Line 0 Target'),
+(11496, 0, 2, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 118, 0, 0, 0, 0, 0, 0, 20, 179503, 200, 0, 0, 0, 0, 0, 0,          'Immol\'thar - On Data Set - Set Gameobject State'),
+(11496, 0, 3, 0, 0, 0, 100, 0, 5000, 9000, 9000, 14000, 0, 0, 11, 5568, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,      'Immol\'thar - In Combat - Cast Trample'),
+(11496, 0, 4, 0, 0, 0, 100, 0, 2000, 4000, 8000, 12000, 0, 0, 11, 16128, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,    'Immol\'thar - Within 0-5 Range - Cast Infected Bite'),
+(11496, 0, 5, 0, 0, 0, 100, 0, 10000, 14000, 17000, 24000, 0, 0, 11, 22950, 0, 0, 0, 0, 0, 6, 50, 1, 0, 0, 0, 0, 0, 0, 'Immol\'thar - In Combat - Cast Portal of Immol\'thar'),
+(11496, 0, 6, 0, 0, 0, 100, 0, 7000, 12000, 15000, 22000, 0, 0, 11, 22899, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Immol\'thar - In Combat - Cast Eye of Immol\'thar'),
+(11496, 0, 7, 8, 2, 0, 100, 0, 0, 30, 180000, 180000, 0, 0, 11, 8269, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,        'Immol\'thar - Between 0-30% Health - Cast Frenzy'),
+(11496, 0, 8, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                      'Immol\'thar - On Frenzy - Say Line 0'),
+(11496, 0, 9, 0, 6, 0, 100, 512, 0, 0, 0, 0, 0, 0, 34, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Immol\'thar - On Death - Set Instance Data 1 to 1'),
+--
+(14303, 0, 0, 0, 1, 0, 100, 1, 1000, 1000, 0, 0, 0, 0, 11, 22696, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,            'Petrified Guardian - Out of Combat - Cast Thorns'),
+(14303, 0, 1, 0, 2, 0, 100, 0, 0, 50, 8000, 16000, 0, 0, 11, 22373, 96, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,         'Petrified Guardian - Between 0-50% Health - Cast Regrowth'),
+(14303, 0, 2, 0, 14, 0, 100, 0, 2000, 40, 3000, 7000, 0, 0, 11, 22373, 96, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,      'Petrified Guardian - Friendly Missing Health - Cast Regrowth'),
+(14308, 0, 0, 0, 9, 0, 100, 0, 0, 0, 8000, 14000, 8, 25, 11, 22911, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Ferra - Within Rage 8-25yd - Cast Charge'),
+(14308, 0, 1, 0, 0, 0, 100, 0, 3000, 6000, 5000, 8000, 0, 0, 11, 17156, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,      'Ferra - In Combat - Cast Maul'),
+(14398, 0, 0, 0, 0, 0, 100, 0, 6000, 8000, 8000, 19000, 0, 0, 11, 22947, 320, 0, 0, 0, 0, 5, 30, 0, 1, 0, 0, 0, 0, 0,  'Eldreth Darter - In Combat - Cast Mana Burn'),
+(14398, 0, 1, 0, 0, 0, 100, 0, 3000, 9000, 18000, 34000, 0, 0, 11, 17139, 32, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Eldreth Darter - In Combat - Cast Power Word: Shield'),
+(14399, 0, 0, 0, 0, 0, 100, 0, 4000, 9000, 7000, 12000, 0, 0, 11, 22945, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,    'Arcane Torrent - In Combat - Cast Forked Lightning'),
+(14399, 0, 1, 0, 0, 0, 100, 0, 7000, 14000, 19000, 23000, 0, 0, 11, 22946, 64, 0, 0, 0, 0, 5, 20, 0, 0, 0, 0, 0, 0, 0, 'Arcane Torrent - In Combat - Cast Lightning Cloud'),
+(14400, 0, 0, 0, 1, 0, 100, 0, 1000, 1000, 300000, 300000, 0, 0, 11, 12550, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,  'Arcane Feedback - Out of Combat - Cast Lightning Shield'),
+(14400, 0, 1, 0, 0, 0, 100, 0, 0, 0, 15000, 30000, 0, 0, 11, 12550, 32, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,         'Arcane Feedback - In Combat - Cast Lightning Shield');


### PR DESCRIPTION
WIP

some of the changes:
- Eldreth Seether now casts Fire Shield
- Eldreth Apparitio, fix Cone of Cold
- Eldreth Spirit, fix Ribbon of Souls
- Eldreth Spectre now stays invisible OOC.
- Eldreth Spectre now casts Dispel Magic
- Arcane Aberration, fix Arcane Bolt
- Prince Tortheldrin, fix text on aggro
- Prince Tortheldrin, casts Whirlwind and Counter spell a lot more often, 
- Prince Tortheldrin, higher Thrash Proc chance, fewer Arcane Blasts
- Magister Kalendris, casts Mind Blast more often, Shadow Word Pain less often, Dominate Mind sooner
- Illyanna Ravenoak, fix ranged combat
- Illyanna Ravenoak casts Volley much later, Multi-Shot more often
- Tendris Warpwood now summons and Ancient Equine Spirit on Death
- Tendris Warpwood now casts Uppercut
- Immol'thar now casts Frenzy at 30% health instead of 40% and announces it.
- Petrified Guardian now casts Regrowth a lot more often
- Eldreth Darter now casts Power Word Shield more often, but only on himself