### PR TITLE
Warlock and Paladin summon mount spells

### DIFF
--- a/data/sql/world/base/mounts_and_riding.sql
+++ b/data/sql/world/base/mounts_and_riding.sql
@@ -1,5 +1,16 @@
 -- Re-enable Summon Felsteed (Warlock)
-DELETE FROM `disables` WHERE `sourceType`=1 AND `entry` IN (3631, 4487, 4488, 4489, 4490);
+DELETE FROM `disables` WHERE `sourceType` = 1 AND `entry` IN (3631, 4487, 4488, 4489, 4490);
+
+DELETE FROM `creature_queststarter` WHERE `id` = 3326 AND `quest` = 3631;
+DELETE FROM `creature_queststarter` WHERE `id` = 5172 AND `quest` = 4487;
+DELETE FROM `creature_queststarter` WHERE `id` = 461  AND `quest` = 4488;
+DELETE FROM `creature_queststarter` WHERE `id` = 4563 AND `quest` = 4489;
+DELETE FROM `creature_queststarter` WHERE `id` = 6251 AND `quest` = 4490;
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 3631), (5172, 4487), (461, 4488), (4563, 4489), (6251, 4490);
+
+DELETE FROM `creature_questender` WHERE `id` = 6251 AND `quest` IN (3631, 4487, 4488, 4489, 4490);
+INSERT INTO `creature_questender` (`id`, `quest`) VALUES (6251, 3631), (6251, 4487), (6251, 4488), (6251, 4489), (6251, 4490);
+
 
 -- Remove incorrect mail about riding which doesn't match Vanilla levels
 DELETE FROM `mail_level_reward` WHERE `level` <= 60;

--- a/data/sql/world/base/mounts_and_riding.sql
+++ b/data/sql/world/base/mounts_and_riding.sql
@@ -1,15 +1,23 @@
 -- Re-enable Summon Felsteed (Warlock)
 DELETE FROM `disables` WHERE `sourceType` = 1 AND `entry` IN (3631, 4487, 4488, 4489, 4490);
 
-DELETE FROM `creature_queststarter` WHERE `id` = 3326 AND `quest` = 3631;
-DELETE FROM `creature_queststarter` WHERE `id` = 5172 AND `quest` = 4487;
-DELETE FROM `creature_queststarter` WHERE `id` = 461  AND `quest` = 4488;
-DELETE FROM `creature_queststarter` WHERE `id` = 4563 AND `quest` = 4489;
-DELETE FROM `creature_queststarter` WHERE `id` = 6251 AND `quest` = 4490;
+DELETE FROM `creature_queststarter` WHERE `id` = 3326 AND `quest` = 3631; -- Orgrimmar
+DELETE FROM `creature_queststarter` WHERE `id` = 5172 AND `quest` = 4487; -- Ironforge
+DELETE FROM `creature_queststarter` WHERE `id` = 461  AND `quest` = 4488; -- Stormwind
+DELETE FROM `creature_queststarter` WHERE `id` = 4563 AND `quest` = 4489; -- Undercity
+DELETE FROM `creature_queststarter` WHERE `id` = 6251 AND `quest` = 4490; -- Ratchet
 INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 3631), (5172, 4487), (461, 4488), (4563, 4489), (6251, 4490);
 
 DELETE FROM `creature_questender` WHERE `id` = 6251 AND `quest` IN (3631, 4487, 4488, 4489, 4490);
 INSERT INTO `creature_questender` (`id`, `quest`) VALUES (6251, 3631), (6251, 4487), (6251, 4488), (6251, 4489), (6251, 4490);
+
+
+-- Summon Warhorse - Tome of Nobility (Paladin)
+DELETE FROM `creature_queststarter` WHERE `id` = 6171 AND `quest` = 1661; -- Stormwind, but what aobut Ironforge?
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (6171, 1661);
+
+DELETE FROM `creature_questender` WHERE `id` = 6171 AND `quest` = 1661;
+INSERT INTO `creature_questender` (`id`, `quest`) VALUES (6171, 1661);
 
 
 -- Remove incorrect mail about riding which doesn't match Vanilla levels

--- a/data/sql/world/base/mounts_and_riding.sql
+++ b/data/sql/world/base/mounts_and_riding.sql
@@ -1,11 +1,7 @@
 -- Re-enable Summon Felsteed (Warlock)
 DELETE FROM `disables` WHERE `sourceType` = 1 AND `entry` IN (3631, 4487, 4488, 4489, 4490);
 
-DELETE FROM `creature_queststarter` WHERE `id` = 3326 AND `quest` = 3631; -- Orgrimmar
-DELETE FROM `creature_queststarter` WHERE `id` = 5172 AND `quest` = 4487; -- Ironforge
-DELETE FROM `creature_queststarter` WHERE `id` = 461  AND `quest` = 4488; -- Stormwind
-DELETE FROM `creature_queststarter` WHERE `id` = 4563 AND `quest` = 4489; -- Undercity
-DELETE FROM `creature_queststarter` WHERE `id` = 6251 AND `quest` = 4490; -- Ratchet
+DELETE FROM `creature_queststarter` WHERE `quest` IN (3631, 4487, 4488, 4489, 4490); 
 INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 3631), (5172, 4487), (461, 4488), (4563, 4489), (6251, 4490);
 
 DELETE FROM `creature_questender` WHERE `id` = 6251 AND `quest` IN (3631, 4487, 4488, 4489, 4490);
@@ -13,11 +9,11 @@ INSERT INTO `creature_questender` (`id`, `quest`) VALUES (6251, 3631), (6251, 44
 
 
 -- Summon Warhorse - Tome of Nobility (Paladin)
-DELETE FROM `creature_queststarter` WHERE `id` = 6171 AND `quest` = 1661; -- Stormwind, but what aobut Ironforge?
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (6171, 1661);
+DELETE FROM `creature_queststarter` WHERE `quest` IN (1661, 4485, 4486); 
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (6171, 1661), (6179, 4485), (5149, 4486);
 
-DELETE FROM `creature_questender` WHERE `id` = 6171 AND `quest` = 1661;
-INSERT INTO `creature_questender` (`id`, `quest`) VALUES (6171, 1661);
+DELETE FROM `creature_questender` WHERE `id` = 6171 AND `quest` IN (1661, 4485, 4486);
+INSERT INTO `creature_questender` (`id`, `quest`) VALUES (6171, 1661), (6171, 4485), (6171, 4486);
 
 
 -- Remove incorrect mail about riding which doesn't match Vanilla levels
@@ -28,20 +24,23 @@ UPDATE `mail_level_reward` SET `level` = 71 WHERE `mailTemplateId` IN (285, 284)
 
 
 -- Riding Skills
-UPDATE npc_trainer SET ReqLevel=40 WHERE SpellID=33388;
-UPDATE npc_trainer SET MoneyCost=800000 WHERE SpellID=33388;
-UPDATE npc_trainer SET ReqLevel=60 WHERE SpellID=33391;
-UPDATE npc_trainer SET MoneyCost=10000000 WHERE SpellID=33391;
-UPDATE npc_trainer SET ReqLevel=70 WHERE SpellID=34090;
-UPDATE npc_trainer SET MoneyCost=6000000 WHERE SpellID=34090;
-DELETE FROM npc_trainer WHERE SpellID=13819; # Delete Summon Warhorse from trainer - it is a free reward from a quest instead
-DELETE FROM npc_trainer WHERE SpellID=13820; # Delete Summon Warhorse from more trainers
-DELETE FROM npc_trainer WHERE SpellID=23214;
-DELETE FROM npc_trainer WHERE SpellID=34767;
-DELETE FROM npc_trainer WHERE SpellID=23161;
-UPDATE npc_trainer SET ReqLevel=40 WHERE SpellID=34768;
-UPDATE npc_trainer SET ReqLevel=40 WHERE SpellID=1710;
-UPDATE npc_trainer SET ReqLevel=68 WHERE SpellID=33950;
+UPDATE npc_trainer SET ReqLevel = 40        WHERE SpellID = 33388; -- Apprentice Riding
+UPDATE npc_trainer SET MoneyCost = 800000   WHERE SpellID = 33388;
+UPDATE npc_trainer SET ReqLevel = 60        WHERE SpellID = 33391; -- Journeyman Riding
+UPDATE npc_trainer SET MoneyCost = 10000000 WHERE SpellID = 33391;
+UPDATE npc_trainer SET ReqLevel = 70        WHERE SpellID = 34090; -- Expert Riding
+UPDATE npc_trainer SET MoneyCost = 6000000  WHERE SpellID = 34090;
+
+DELETE FROM `npc_trainer` WHERE `SpellID` = 13819; -- Summon Warhorse
+DELETE FROM `npc_trainer` WHERE `SpellID` = 13820; -- Summon Warhorse
+DELETE FROM `npc_trainer` WHERE `SpellID` = 23214; -- Summon Charger (alliance)
+DELETE FROM `npc_trainer` WHERE `SpellID` = 34767; -- Summon Charger (horde)
+DELETE FROM `npc_trainer` WHERE `SpellID` = 23161; -- Dreadsteed
+DELETE FROM `npc_trainer` WHERE `SpellID` = 1710;  -- Summon Felsteed
+
+UPDATE npc_trainer SET ReqLevel = 40 WHERE SpellID = 34768; -- Summon Warhorse
+UPDATE npc_trainer SET ReqLevel = 40 WHERE SpellID = 1710;  -- Summon Felsteed
+UPDATE npc_trainer SET ReqLevel = 68 WHERE SpellID = 33950; -- Flight Form
 
 
 -- Hide pre 1.6 epic mounts ater BWL is unlocked

--- a/data/sql/world/base/zone_barrens.sql
+++ b/data/sql/world/base/zone_barrens.sql
@@ -317,20 +317,11 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (15, 4206, 0, 7, 165, 50, 'Show menu if leatherworking is 50 or higher'), -- Krulmoo Fullmoon <Expert Leatherworker>
 (15, 4350, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');      -- Mahani <Expert Tailor>
 
+
 -- Vile Familiars (Warlock)
 DELETE FROM `creature_questender` WHERE `id` = 5765 AND `quest` = 1485;
 INSERT INTO `creature_questender` (`id`, `quest`) VALUES (5765, 1485);
 
--- Summon Felsteed (Warlock)
-DELETE FROM `creature_questender` WHERE `id` = 6251 AND `quest` IN (3631, 4487, 4488, 4489, 4490);
-INSERT INTO `creature_questender` (`id`, `quest`) VALUES (6251, 3631), (6251, 4487), (6251, 4488), (6251, 4489), (6251, 4490);
-
-DELETE FROM `creature_queststarter` WHERE `id` = 6251 AND `quest` = 4490;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (6251, 4490);
-
--- Vile Familiars (Warlock)
-DELETE FROM `creature_queststarter` WHERE `id`=5765 AND `quest`=1485;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (5765, 1485);
 
 UPDATE `creature_template` SET `subname` = 'Blacksmithing Supplier'   WHERE `entry` = 3477;-- Hraq <Blacksmithing Supplier>
 UPDATE `creature_template` SET `subname` = 'Expert Blacksmith'        WHERE `entry` = 3478; -- Traugh <Expert Blacksmith>

--- a/data/sql/world/base/zone_ironforge.sql
+++ b/data/sql/world/base/zone_ironforge.sql
@@ -44,10 +44,6 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (15, 4345, 0, 7, 197, 50,  'Show menu if tailoring is 50 or higher');      -- Jormund Stonebrow <Expert Tailor>
 
 
--- Summon Felsteed (Warlock)
-DELETE FROM `creature_queststarter` WHERE `id` = 5172 AND `quest` = 4487;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (5172, 4487);
-
 -- Nissa Firestone <First Aid Trainer> 
 DELETE FROM `npc_trainer` WHERE `ID` = 5150; 
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5150, -350000); 

--- a/data/sql/world/base/zone_orgrimmar.sql
+++ b/data/sql/world/base/zone_orgrimmar.sql
@@ -88,10 +88,6 @@ INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `posit
 -- Master Pyreanor <Paladin Trainer>
 UPDATE `creature` SET `position_x`= 1940.23, `position_y`= -4135.53, `position_z`= 41.1522, `orientation`= 3.12425  WHERE `id1` = 23128;
 
--- Summon Felsteed (Warlock)
-DELETE FROM `creature_queststarter` WHERE `id` = 3326 AND `quest` = 3631;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 3631);
-
 -- Knowledge of the Orb of Orahil (Warlock)
 DELETE FROM `creature_queststarter` WHERE `id` = 3326 AND `quest` = 4967;
 INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 4967);

--- a/data/sql/world/base/zone_stormwind.sql
+++ b/data/sql/world/base/zone_stormwind.sql
@@ -67,16 +67,12 @@ UPDATE `creature` SET `equipment_id` = 1 WHERE `id1` = 12805;
 
 
 -- Tome of Nobility (Paladin)
-DELETE FROM `creature_questender` WHERE `id`=6171 AND `quest`=1661;
+DELETE FROM `creature_questender` WHERE `id` = 6171 AND `quest` = 1661;
 INSERT INTO `creature_questender` (`id`, `quest`) VALUES (6171, 1661);
 
 -- Tome of Nobility (Paladin)
-DELETE FROM `creature_queststarter` WHERE `id`=6171 AND `quest`=1661;
+DELETE FROM `creature_queststarter` WHERE `id` = 6171 AND `quest` = 1661;
 INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (6171, 1661);
-
--- Summon Felsteed (Warlock)
-DELETE FROM `creature_queststarter` WHERE `id`=461 AND `quest`=4488;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (461, 4488);
 
 
 UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55 WHERE `entry` = 68;    -- Stormwind City Guard

--- a/data/sql/world/base/zone_stormwind.sql
+++ b/data/sql/world/base/zone_stormwind.sql
@@ -63,16 +63,7 @@ INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `posit
 (614981, 14981, 0, -8454.62, 318.853, 120.969, 0.698132, 180), -- Elfarran <Warsong Gulch Battlemaster>
 (615008, 15008, 0, -8420.48, 328.711, 120.886, 3.06638, 180);  -- Lady Hoteshem <Arathi Basin Battlemaster>
 
-UPDATE `creature` SET `equipment_id` = 1 WHERE `id1` = 12805;
-
-
--- Tome of Nobility (Paladin)
-DELETE FROM `creature_questender` WHERE `id` = 6171 AND `quest` = 1661;
-INSERT INTO `creature_questender` (`id`, `quest`) VALUES (6171, 1661);
-
--- Tome of Nobility (Paladin)
-DELETE FROM `creature_queststarter` WHERE `id` = 6171 AND `quest` = 1661;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (6171, 1661);
+UPDATE `creature` SET `equipment_id` = 1 WHERE `id1` = 12805; -- Officer Areyn <Accessories Quartermaster>
 
 
 UPDATE `creature_template` SET `minlevel` = 55, `maxlevel` = 55 WHERE `entry` = 68;    -- Stormwind City Guard

--- a/data/sql/world/base/zone_undercity.sql
+++ b/data/sql/world/base/zone_undercity.sql
@@ -41,10 +41,6 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (15, 4354, 0, 7, 197, 125, 'Show menu if tailoring is 125 or higher');     -- Josef Gregorian <Artisan Tailor>
 
 
--- Summon Felsteed (Warlock)
-DELETE FROM `creature_queststarter` WHERE `id`=4563 AND `quest`=4489;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (4563, 4489);
-
 -- Mary Edras <First Aid Trainer> 
 DELETE FROM `npc_trainer` WHERE `ID`=4591; 
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4591, -350000); 


### PR DESCRIPTION
A bit of organizing.
warlock mount quests were spread over multiple SQL files.

Plus one of the dwarf paladin mount quest givers was incorrectly set to some human.
Now Tiza Battleforge in Ironforge gives quest 4485

a bit of cleaning up in mount_and_riding as well.