### PR TITLE
fixes in Hillsbrad Foothills

### DIFF
--- a/data/sql/world/base/zone_hillsbrad_foothills.sql
+++ b/data/sql/world/base/zone_hillsbrad_foothills.sql
@@ -1,3 +1,159 @@
+/* smart scripts */
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` IN (2351, 2354, 2356, 2385, 14280);
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN 
+(2240, 2241, 2244, 2249, 2260, 2261, 2264, 2265, 2266, 2267, 2268, 2269, 2270, 2304, 2305, 2319, 2335, 2344, 2345, 2346, 2348, 2349, 2350, 
+2360, 2368, 2369, 2370, 2371, 2372, 2373, 2374, 2375, 2376, 2377, 2387, 2403, 2404, 2427, 2428, 2448, 2449, 2450, 2451, 2503, 14278);
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN 
+(2240, 2241, 2244, 2249, 2260, 2261, 2264, 2265, 2266, 2267, 2268, 2269, 2270, 2304, 2305, 2319, 2335, 2344, 2345, 2346, 2348, 2349, 2350, 2351, 2354, 2356, 
+2360, 2368, 2369, 2370, 2371, 2372, 2373, 2374, 2375, 2376, 2377, 2385, 2387, 2403, 2404, 2427, 2428, 2448, 2449, 2450, 2451, 2503, 14278, 14280);
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
+`event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+--
+(2240, 0, 0, 0, 67, 0, 100, 0, 0, 0, 2000, 10000, 0, 5, 11, 7159, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Syndicate Footpad - Behind Target - Cast Backstab'),
+(2240, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Syndicate Footpad - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2241, 0, 0, 0, 0, 0, 100, 0, 2000, 12000, 36000, 46000, 0, 0, 11, 6713, 0, 0, 0, 0, 0, 5, 5, 0, 0, 0, 0, 0, 0, 0,     'Syndicate Thief - Within 0-5 Range - Cast Disarm'),
+(2241, 0, 1, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 3616, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Syndicate Thief - On Respawn - Cast Poison Proc'),
+(2241, 0, 2, 0, 67, 0, 100, 0, 0, 0, 2000, 10000, 0, 5, 11, 7159, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Syndicate Thief - Behind Target - Cast Backstab'),
+(2241, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Syndicate Thief - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2244, 0, 0, 0, 1, 0, 100, 0, 1000, 1000, 900000, 900000, 0, 0, 11, 13787, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Syndicate Shadow Mage - Out of Cobmat - Cast Demon Armor'),
+(2244, 0, 1, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 20791, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Syndicate Shadow Mage - In Combat - Cast Shadow Bolt'),
+(2244, 0, 2, 0, 0, 0, 100, 0, 2000, 2000, 30000, 30000, 0, 0, 11, 16247, 96, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,    'Syndicate Shadow Mage - In Combat - Cast Curse of Thorns'),
+(2244, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Syndicate Shadow Mage - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2249, 0, 0, 1, 2, 0, 100, 0, 0, 20, 0, 0, 0, 0, 11, 8599, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Ferocious Yeti - Between 0-20% Health - Cast Enrage'),
+(2249, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'Ferocious Yeti - On Enrage - Say Line 0'),
+(2260, 0, 0, 0, 67, 0, 100, 0, 0, 0, 8000, 12000, 0, 5, 11, 37685, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Syndicate Rogue - Behind Target - Cast Backstab'),
+(2260, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Syndicate Rogue - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2261, 0, 0, 0, 9, 0, 100, 0, 0, 0, 20000, 30000, 0, 5, 11, 3602, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Syndicate Watchman - Within 0-5 Range - Cast Torch Burst'),
+(2261, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Syndicate Watchman - Between 0-15% Health - Flee For Assist (No Repeat)'),
+--
+(2264, 0, 0, 0, 67, 0, 100, 0, 0, 0, 7000, 9000, 0, 5, 11, 2590, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Hillsbrad Tailor - Behind Target - Cast Backstab'),
+(2264, 0, 1, 0, 9, 0, 100, 0, 0, 0, 7000, 11000, 0, 5, 11, 101, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,              'Hillsbrad Tailor - Within 0-5 Range - Cast Trip'),
+(2264, 0, 2, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hillsbrad Tailor - Between 0-30% Health - Flee For Assist'),
+(2265, 0, 0, 0, 9, 0, 100, 0, 0, 0, 25000, 30000, 0, 5, 11, 3148, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Hillsbrad Apprentice Blacksmith - Within 0-5 Range - Cast Head Crack'),
+(2265, 0, 1, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hillsbrad Apprentice Blacksmith - Between 0-30% Health - Flee For Assist (No Repeat)'),
+(2266, 0, 0, 0, 0, 0, 100, 0, 8000, 18000, 20000, 40000, 0, 0, 11, 6713, 0, 0, 0, 0, 0, 5, 5, 0, 0, 0, 0, 0, 0, 0,     'Hillsbrad Farmer - Within 0-5 Range - Cast Disarm'),
+(2266, 0, 1, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hillsbrad Farmer - Between 0-30% Health - Flee For Assist (No Repeat)'),
+(2267, 0, 0, 0, 9, 0, 100, 0, 0, 0, 45000, 45000, 0, 5, 11, 6016, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Hillsbrad Peasant - Within 0-5 Range - Cast Pierce Armor'),
+(2267, 0, 1, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hillsbrad Peasant - Between 0-30% Health - Flee For Assist (No Repeat)'),
+(2268, 0, 0, 0, 0, 0, 100, 0, 1000, 1000, 180000, 180000, 0, 0, 11, 7164, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,    'Hillsbrad Footman - In Combat - Cast Defensive Stance'),
+(2268, 0, 1, 0, 105, 0, 100, 0, 0, 0, 12000, 15000, 0, 5, 11, 1671, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,          'Hillsbrad Footman - Target Casting - Cast Shield Bash'),
+(2268, 0, 2, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hillsbrad Footman - Between 0-30% Health - Flee For Assist (No Repeat)'),
+(2269, 0, 0, 0, 0, 0, 100, 0, 1000, 1000, 180000, 180000, 0, 0, 11, 7164, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,    'Hillsbrad Miner - In Combat - Cast Defensive Stance'),
+(2269, 0, 1, 0, 9, 0, 100, 0, 0, 0, 5000, 9000, 0, 5, 11, 7405, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,              'Hillsbrad Miner - Within 0-5 Range - Cast Sunder Armor'),
+(2269, 0, 2, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hillsbrad Miner - Between 0-30% Health - Flee For Assist (No Repeat)'),
+(2270, 0, 0, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hillsbrad Sentry - Between 0-30% Health - Flee For Assist (No Repeat)'),
+--
+(2304, 0, 0, 0, 0, 0, 100, 0, 1000, 3000, 23000, 30000, 0, 0, 11, 7020, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,      'Captain Ironhill - In Combat - Cast Stoneform'),
+(2304, 0, 1, 0, 105, 0, 100, 0, 0, 0, 10000, 14000, 0, 5, 11, 12555, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,         'Captain Ironhill - Target Casting - Cast Pummel'),
+(2304, 0, 2, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Captain Ironhill - Between 0-30% Health - Flee For Assist (No Repeat)'),
+(2305, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 643, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Foreman Bonds - On Respawn - Cast Devotion Aura'),
+(2305, 0, 1, 0, 9, 0, 100, 0, 0, 0, 60000, 60000, 0, 5, 11, 5588, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Foreman Bonds - Within 0-5 Range - Cast Hammer of Justice'),
+(2305, 0, 2, 3, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 12, 7360, 1, 300000, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,              'Foreman Bonds - Between 0-30% Health - Summon Creature \'Dun Garok Soldier\' (No Repeat)'),
+(2305, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 7360, 1, 300000, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,              'Foreman Bonds - Between 0-30% Health - Summon Creature \'Dun Garok Soldier\' (No Repeat)'),
+(2319, 0, 0, 0, 1, 0, 100, 0, 1000, 1000, 900000, 900000, 0, 0, 11, 12544, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Syndicate Wizard - Out of Combat - Cast Frost Armor'),
+(2319, 0, 1, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 20815, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Syndicate Wizard - In Combat - Cast Fireball'),
+(2319, 0, 2, 0, 0, 0, 100, 0, 5000, 9000, 25000, 35000, 0, 0, 11, 12824, 1, 0, 0, 0, 0, 6, 30, 0, 0, 0, 0, 0, 0, 0,    'Syndicate Wizard - Within 0-30 Range - Cast Polymorph'),
+(2335, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 20811, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Magistrate Burnside - In Combat - Cast Fireball'),
+(2335, 0, 1, 0, 106, 0, 100, 0, 0, 0, 12000, 15000, 0, 8, 11, 11969, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,         'Magistrate Burnside - Within 0-8 Range - Cast Fire Nova'),
+(2335, 0, 2, 0, 0, 0, 100, 0, 5000, 7000, 16000, 20000, 0, 0, 11, 7739, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,      'Magistrate Burnside - In Combat - Cast Inferno Shell'),
+(2335, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Magistrate Burnside - Between 0-15% Health - Flee For Assist (No Repeat)'),
+--
+(2344, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 643, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Dun Garok Mountaineer - On Respawn - Cast Devotion Aura'),
+(2344, 0, 1, 0, 9, 0, 100, 0, 0, 0, 9000, 15000, 0, 5, 11, 13953, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Dun Garok Mountaineer - Within 0-5 Range - Cast Holy Strike'),
+(2344, 0, 2, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Dun Garok Mountaineer - Between 0-30% Health - Flee For Assist (No Repeat)'),
+(2345, 0, 0, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 30, 60, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Dun Garok Rifleman - Outside 30 Range - Start Combat Movement'),
+(2345, 0, 1, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 5, 30, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Dun Garok Rifleman - Within 5-30 Range - Stop Combat Movement'),
+(2345, 0, 2, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 0, 5, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Dun Garok Rifleman - Within 0-5 Range - Start Combat Movement'),
+(2345, 0, 3, 0, 9, 0, 100, 0, 0, 0, 2000, 4000, 5, 30, 11, 6660, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Dun Garok Rifleman - Within 5-30 Range - Cast Shoot'),
+(2345, 0, 4, 0, 0, 0, 100, 0, 12000, 18000, 30000, 30000, 0, 0, 11, 6685, 1, 0, 0, 0, 0, 5, 30, 0, 0, 0, 0, 0, 0, 0,   'Dun Garok Rifleman - Within 0-30 Range - Cast Piercing Shot'),
+(2345, 0, 5, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Dun Garok Rifleman - Between 0-30% Health - Flee For Assist (No Repeat)'),
+(2346, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 3000, 0, 0, 11, 9734, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Dun Garok Priest - In Combat - Cast Holy Smite'),
+(2346, 0, 1, 0, 74, 0, 100, 0, 0, 0, 15000, 25000, 40, 40, 11, 11642, 65, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,       'Dun Garok Priest - Friendly Between 0-40% Health - Cast Heal'),
+(2346, 0, 2, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Dun Garok Priest - Between 0-30% Health - Flee For Assist (No Repeat)'),
+--
+(2348, 0, 0, 0, 0, 0, 100, 0, 3000, 5000, 31000, 36000, 0, 0, 11, 3396, 96, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Elder Moss Creeper - In Combat - Cast Corrosive Poison'),
+(2349, 0, 0, 0, 0, 0, 100, 0, 5000, 16000, 30000, 36000, 0, 0, 11, 3396, 96, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,    'Giant Moss Creeper - In Combat - Cast Corrosive Poison'),
+(2350, 0, 0, 0, 0, 0, 100, 0, 3000, 5000, 31000, 36000, 0, 0, 11, 3396, 96, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Forest Moss Creeper - In Combat - Cast Corrosive Poison'),
+(2360, 0, 0, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hillsbrad Farmhand - Between 0-30% Health - Flee For Assist (No Repeat)'),
+--
+(2368, 0, 0, 0, 0, 0, 100, 0, 1000, 1000, 180000, 180000, 0, 0, 11, 7164, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,    'Daggerspine Shorestalker - In Combat - Cast Defensive Stance'),
+(2368, 0, 1, 0, 105, 0, 100, 0, 0, 0, 9000, 13000, 0, 5, 11, 12555, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,          'Daggerspine Shorestalker - Target Casting - Cast Pummel'),
+(2368, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Daggerspine Shorestalker - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2369, 0, 0, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 30, 60, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Daggerspine Shorehunter - Outside 30 Range - Start Combat Movement'),
+(2369, 0, 1, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 5, 30, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Daggerspine Shorehunter - Within 5-30 Range - Stop Combat Movement'),
+(2369, 0, 2, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 0, 5, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Daggerspine Shorehunter - Within 0-5 Range - Start Combat Movement'),
+(2369, 0, 3, 0, 9, 0, 100, 0, 0, 0, 2000, 4000, 5, 30, 11, 10277, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Daggerspine Shorehunter - Within 5-30 Range - Cast Throw'),
+(2369, 0, 4, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Daggerspine Shorehunter - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2370, 0, 0, 0, 0, 0, 100, 0, 5000, 9000, 12000, 16000, 0, 0, 11, 3589, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,     'Daggerspine Screamer - Within 0-5 Range - Cast Deafening Screech'),
+(2370, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Daggerspine Screamer - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2371, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 9532, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Daggerspine Siren - In Combat - Cast Lightning Bolt'),
+(2371, 0, 1, 0, 0, 0, 100, 0, 6000, 8000, 19000, 24000, 0, 0, 11, 992, 33, 0, 0, 0, 0, 5, 30, 0, 0, 0, 0, 0, 0, 0,     'Daggerspine Siren - In Combat - Cast Shadow Word: Pain'),
+(2371, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Daggerspine Siren - Between 0-15% Health - Flee For Assist (No Repeat)'),
+--
+(2372, 0, 0, 0, 9, 0, 100, 0, 0, 0, 30000, 30000, 0, 5, 11, 3650, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Mudsnout Gnoll - Within 0-5 Range - Cast Sling Mud'),
+(2372, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Mudsnout Gnoll - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2373, 0, 0, 0, 0, 0, 100, 0, 0, 0, 3400, 4800, 0, 0, 11, 20805, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Mudsnout Shaman - In Combat CMC - Cast \'Lightning Bolt\''),
+(2373, 0, 1, 0, 74, 0, 100, 0, 0, 0, 15000, 20000, 40, 40, 11, 939, 65, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,         'Mudsnout Shaman - Friendly Between 0-40% Health - Cast Healing Wave'),
+(2373, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Mudsnout Shaman - Between 0-15% Health - Flee For Assist (No Repeat)'),
+--
+(2374, 0, 0, 0, 9, 0, 100, 0, 0, 0, 8000, 12000, 0, 5, 11, 3427, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Torn Fin Muckdweller - Within 0-5 Range - Cast Infected Wound'),
+(2374, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Torn Fin Muckdweller - Between 0-15% Health - Flee For Assist'),
+(2375, 0, 0, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 30, 60, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Torn Fin Coastrunner - Outside 30 Range - Start Combat Movement'),
+(2375, 0, 1, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 5, 30, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Torn Fin Coastrunner - Within 5-30 Range - Stop Combat Movement'),
+(2375, 0, 2, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 0, 5, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Torn Fin Coastrunner - Within 0-5 Range - Start Combat Movement'),
+(2375, 0, 3, 0, 9, 0, 100, 0, 0, 0, 2000, 4000, 5, 30, 11, 10277, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Torn Fin Coastrunner - Within 5-30 Range - Cast Throw'),
+(2375, 0, 4, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Torn Fin Coastrunner - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2376, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 9532, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,             'Torn Fin Oracle - In Combat - Cast Lightning Bolt'),
+(2376, 0, 1, 0, 2, 0, 100, 0, 0, 25, 25000, 35000, 0, 0, 11, 939, 65, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,           'Torn Fin Oracle - Between 0-25% Health - Cast Healing Wave'),
+(2376, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Torn Fin Oracle - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2377, 0, 0, 0, 106, 0, 100, 0, 0, 0, 12000, 15000, 0, 8, 11, 865, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,           'Torn Fin Tidehunter - Within 0-8 Range - Cast Frost Nova'),
+(2377, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Torn Fin Tidehunter - Between 0-15% Health - Flee For Assist (No Repeat)'),
+--
+(2387, 0, 0, 0, 1, 0, 100, 0, 1000, 1000, 900000, 900000, 0, 0, 11, 12544, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,   'Hillsbrad Councilman - Out of Combat - Cast Frost Armor'),
+(2387, 0, 1, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 20806, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Hillsbrad Councilman - In Combat - Cast Frostbolt'),
+(2387, 0, 2, 0, 106, 0, 100, 0, 0, 0, 25000, 25000, 0, 8, 11, 122, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,           'Hillsbrad Councilman - Within 0-8 Range - Cast Frost Nova'),
+(2387, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hillsbrad Councilman - Between 0-15% Health - Flee For Assist (No Repeat)'),
+--
+(2403, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Farmer Getz - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2404, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Blacksmith Verringtan - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2427, 0, 0, 0, 0, 0, 100, 0, 7000, 11000, 21000, 25000, 0, 0, 11, 3442, 0, 0, 0, 0, 0, 6, 15, 0, 0, 0, 0, 0, 0, 0,    'Jailor Eston - Within 0-15 Range - Cast Enslave'),
+(2427, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Jailor Eston - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2428, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                         'Jailor Marlgen - On Aggro - Say Line 0'),
+(2428, 0, 1, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 30, 60, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Jailor Marlgen - Outside 30 Range - Start Combat Movement'),
+(2428, 0, 2, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 5, 30, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Jailor Marlgen - Within 5-30 Range - Stop Combat Movement'),
+(2428, 0, 3, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 0, 5, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Jailor Marlgen - Within 0-5 Range - Start Combat Movement'),
+(2428, 0, 4, 0, 9, 0, 100, 0, 0, 0, 2000, 4000, 5, 30, 11, 6660, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Jailor Marlgen - Within 5-30 Range - Cast Shoot'),
+(2428, 0, 5, 0, 9, 0, 100, 0, 0, 0, 5000, 15000, 0, 20, 11, 6533, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Jailor Marlgen - Within 0-20 Range - Cast Net'),
+(2428, 0, 6, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Jailor Marlgen - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2448, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Clerk Horrace Whitesteed - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2449, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Citizen Wilkes - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2450, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Miner Hackett - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2451, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Farmer Kalaba - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(2503, 0, 0, 0, 0, 0, 100, 0, 1000, 3000, 11000, 15000, 0, 0, 11, 5115, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,      'Hillsbrad Foreman - In Combat - Cast Battle Command'),
+(2503, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hillsbrad Foreman - Between 0-15% Health - Flee For Assist (No Repeat)'),
+(14278, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Ro\'Bark - Between 0-15% Health - Flee For Assist (No Repeat)');
+
+
+-- Drop chance for Humbert's Sword was incorrectly set to 100 - updated to 25 - value copied from VMangos
+UPDATE `creature_loot_template` SET `Chance` = 25 WHERE `Item` = 3693;
+
+-- Drop chance for Mountain Lion Blood was incorrectly set to 100%
+DELETE FROM `creature_loot_template` WHERE `Item` = 3496;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+(2384, 3496, 0, 40, 1, 1, 0, 1, 1, 'Starving Mountain Lion - Mountain Lion Blood'),
+(2385, 3496, 0, 80, 1, 1, 0, 1, 1, 'Feral Mountain Lion - Mountain Lion Blood'),
+(2406, 3496, 0, 80, 1, 1, 0, 1, 1, 'Mountain Lion - Mountain Lion Blood'),
+(2407, 3496, 0, 80, 1, 1, 0, 1, 1, 'Hulking Mountain Lion - Mountain Lion Blood');
+
+-- Souvenirs of Death - this quests was missing a pre quest
+UPDATE `quest_template_addon` SET `PrevQuestID` = 527 WHERE `ID` = 546;
+
+
+/* ---- Purgation Isle (896) ---- */
+
 -- smart scripts
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (7073, 607069, 607071, 607072, 607075);
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (7073, 607069, 607071, 607072, 607075);
@@ -14,23 +170,6 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (607072, 0, 0, 0, 9, 0, 100, 0, 5000, 8000, 7000, 10000, 0, 5, 11, 11976, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,      'Cursed Justicar - Within 0-5 Range - Cast Strike'),
 (607075, 0, 0, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Writhing Mage   - Between 0-15% Health - Flee For Assist (No Repeat)');
 
-
--- Drop chance for Humbert's Sword was incorrectly set to 100 - updated to 25 - value copied from VMangos
-UPDATE `creature_loot_template` SET `Chance` = 25 WHERE `Item` = 3693;
-
--- Drop chance for Mountain Lion Blood was incorrectly set to 100 
-DELETE FROM `creature_loot_template` WHERE `Item` = 3496;
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
-(2384, 3496, 0, 40, 1, 1, 0, 1, 1, 'Starving Mountain Lion - Mountain Lion Blood'),
-(2385, 3496, 0, 80, 1, 1, 0, 1, 1, 'Feral Mountain Lion - Mountain Lion Blood'),
-(2406, 3496, 0, 80, 1, 1, 0, 1, 1, 'Mountain Lion - Mountain Lion Blood'),
-(2407, 3496, 0, 80, 1, 1, 0, 1, 1, 'Hulking Mountain Lion - Mountain Lion Blood');
-
--- Souvenirs of Death - this quests was missing a pre quest
-UPDATE `quest_template_addon` SET `PrevQuestID` = 527 WHERE `ID` = 546;
-
-
--- Purgation Isle (896)
 DELETE FROM `creature_template` WHERE `entry` IN (607068, 607069, 607070, 607071, 607072, 607075);
 INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`, `KillCredit1`, `KillCredit2`, `name`, `subname`, `IconName`, `gossip_menu_id`, 
 `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `speed_swim`, `speed_flight`, `detection_range`, `scale`, `rank`, `dmgschool`, `DamageModifier`, 


### PR DESCRIPTION
WIP

some of the changes:
- Syndicate Shadow Mage now casts Demon Armor and Curse of Thorns
- Syndicate Rogue and Watchman now flee at 15% health
- Captain Ironhill, fix Pummel
- Dun Garok Rifleman, fix ranged combat
- Dun Garok Priest, fix Heal
- Gray Bear, Vicious Gray Bear and Elder Gray Bear no longer cast Swipe
- Daggerspine Shorestalker, fix Pummel and now flees at 15% health
- Daggerspine Shorehunter, fix ranged combat
- Daggerspine Screamer now flees at 15% health
- Daggerspine Siren no longer casts Enveloping Winds https://www.youtube.com/watch?v=S7C0RsqQ9RA
- Mudsnout Gnoll now flees at 15% health
- Mudsnout Shaman, fix Healing Wave
- Torn Fin Coastrunner, fix ranged combat
- Feral Mountain Lion no longer casts Claw
- Jailor Eston now flees at 15% health
- Jailor Marlgen, fix ranged combat
- Ro'Bark no longer casts Mace Smash and now flees at 15% health
- Big Samras no longer casts Swipe