### PR TITLE
Exclude RNDbots from some phased areas

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -635,7 +635,7 @@ public:
                 }
                 break;
             case AREA_BOUGH_SHADOW:
-                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_ONYXIA))
+                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_ONYXIA) || isExcludedFromProgression(player))
                 {
                     player->RemoveAura(IPP_PHASE);
                     player->RemoveAura(IPP_PHASE_II);
@@ -643,7 +643,7 @@ public:
                 }
                 break;
             case AREA_SERADANE:
-                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_ONYXIA))
+                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_ONYXIA) || isExcludedFromProgression(player))
                 {
                     player->RemoveAura(IPP_PHASE);
                     player->RemoveAura(IPP_PHASE_II);
@@ -651,7 +651,7 @@ public:
                 }
                 break;
             case AREA_DREAM_BOUGH:
-                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_ONYXIA))
+                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_ONYXIA) || isExcludedFromProgression(player))
                 {
                     player->RemoveAura(IPP_PHASE);
                     player->RemoveAura(IPP_PHASE_II);
@@ -659,7 +659,7 @@ public:
                 }
                 break;
             case AREA_JADEMIR_LAKE:
-                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_ONYXIA))
+                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_ONYXIA) || isExcludedFromProgression(player))
                 {
                     player->RemoveAura(IPP_PHASE);
                     player->RemoveAura(IPP_PHASE_II);
@@ -667,7 +667,7 @@ public:
                 }
                 break;
             case AREA_TWILIGHT_GROVE:
-                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_ONYXIA))
+                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_ONYXIA) || isExcludedFromProgression(player))
                 {
                     player->RemoveAura(IPP_PHASE);
                     player->RemoveAura(IPP_PHASE_II);
@@ -992,7 +992,7 @@ public:
             case AREA_THE_ALLIANCE_VALIANTS_RING:
             case AREA_THE_HORDE_VALIANTS_RING:
             case AREA_ARGENT_PAVILION:
-                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_WOTLK_TIER_2))
+                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_WOTLK_TIER_2) || isExcludedFromProgression(player))
                 {
                     player->RemoveAura(IPP_PHASE);
                     player->RemoveAura(IPP_PHASE_II);
@@ -1003,40 +1003,55 @@ public:
                 
                 uint32 mapid = player->GetMapId();
 
-                if (mapid == MAP_SHADOWFANG_KEEP && ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ)) && (sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40))))
+                if (mapid == MAP_SHADOWFANG_KEEP)  
                 {
-                    player->RemoveAura(IPP_PHASE);
-                    player->RemoveAura(IPP_PHASE_II);
-                    player->CastSpell(player, IPP_PHASE, false);
-                    break;
+					if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40)) || isExcludedFromProgression(player))
+                    {
+                        player->RemoveAura(IPP_PHASE);
+                        player->RemoveAura(IPP_PHASE_II);
+                        player->CastSpell(player, IPP_PHASE, false);
+                        break;
+                    }
                 }
-                if (mapid == MAP_RAZORFEN_DOWNS && ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ)) && (sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40))))
+                if (mapid == MAP_RAZORFEN_DOWNS)
                 {
-                    player->RemoveAura(IPP_PHASE);
-                    player->RemoveAura(IPP_PHASE_II);
-                    player->CastSpell(player, IPP_PHASE, false);
-                    break;
+					if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40)) || isExcludedFromProgression(player))
+                    {
+                        player->RemoveAura(IPP_PHASE);
+                        player->RemoveAura(IPP_PHASE_II);
+                        player->CastSpell(player, IPP_PHASE, false);
+                        break;
+				    }
                 }    
-                if (mapid == MAP_SCARLET_MONASTERY && ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ)) && (sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40))))
+                if (mapid == MAP_SCARLET_MONASTERY)
                 {
-                    player->RemoveAura(IPP_PHASE);
-                    player->RemoveAura(IPP_PHASE_II);
-                    player->CastSpell(player, IPP_PHASE, false);
-                    break;
+				    if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40)) || isExcludedFromProgression(player))
+                    {
+                        player->RemoveAura(IPP_PHASE);
+                        player->RemoveAura(IPP_PHASE_II);
+                        player->CastSpell(player, IPP_PHASE, false);
+                        break;
+                    }
                 }
-                if (mapid == MAP_STRATHOLME && ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ)) && (sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40))))
+                if (mapid == MAP_STRATHOLME)
                 {
-                    player->RemoveAura(IPP_PHASE);
-                    player->RemoveAura(IPP_PHASE_II);
-                    player->CastSpell(player, IPP_PHASE, false);
-                    break;
+                    if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40)) || isExcludedFromProgression(player))
+                    {
+                        player->RemoveAura(IPP_PHASE);
+                        player->RemoveAura(IPP_PHASE_II);
+                        player->CastSpell(player, IPP_PHASE, false);
+                        break;
+                    }
                 }
-                if (mapid == MAP_DIRE_MAUL && ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ)) && (sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40))))
+                if (mapid == MAP_DIRE_MAUL)
                 {
-                    player->RemoveAura(IPP_PHASE);
-                    player->RemoveAura(IPP_PHASE_II);
-                    player->CastSpell(player, IPP_PHASE, false);
-                    break;
+                    if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40)) || isExcludedFromProgression(player))
+                    {
+                        player->RemoveAura(IPP_PHASE);
+                        player->RemoveAura(IPP_PHASE_II);
+                        player->CastSpell(player, IPP_PHASE, false);
+                        break;
+                    }
                 }
 
                 player->RemoveAura(IPP_PHASE);

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -1005,7 +1005,7 @@ public:
 
                 if (mapid == MAP_SHADOWFANG_KEEP)  
                 {
-					if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40)) || isExcludedFromProgression(player))
+					if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40))
                     {
                         player->RemoveAura(IPP_PHASE);
                         player->RemoveAura(IPP_PHASE_II);
@@ -1015,7 +1015,7 @@ public:
                 }
                 if (mapid == MAP_RAZORFEN_DOWNS)
                 {
-					if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40)) || isExcludedFromProgression(player))
+					if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40))
                     {
                         player->RemoveAura(IPP_PHASE);
                         player->RemoveAura(IPP_PHASE_II);
@@ -1025,7 +1025,7 @@ public:
                 }    
                 if (mapid == MAP_SCARLET_MONASTERY)
                 {
-				    if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40)) || isExcludedFromProgression(player))
+				    if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40))
                     {
                         player->RemoveAura(IPP_PHASE);
                         player->RemoveAura(IPP_PHASE_II);
@@ -1035,7 +1035,7 @@ public:
                 }
                 if (mapid == MAP_STRATHOLME)
                 {
-                    if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40)) || isExcludedFromProgression(player))
+                    if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40))
                     {
                         player->RemoveAura(IPP_PHASE);
                         player->RemoveAura(IPP_PHASE_II);
@@ -1045,7 +1045,7 @@ public:
                 }
                 if (mapid == MAP_DIRE_MAUL)
                 {
-                    if ((sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40)) || isExcludedFromProgression(player))
+                    if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_AQ) && sIndividualProgression->isBeforeProgression(player, PROGRESSION_NAXX40))
                     {
                         player->RemoveAura(IPP_PHASE);
                         player->RemoveAura(IPP_PHASE_II);


### PR DESCRIPTION
RNDbots are now excluded from the following phased areas:

- BOUGH_SHADOW
- SERADANE
- DREAM_BOUGH
- JADEMIR_LAKE
- TWILIGHT_GROVE
- ARGENT_PAVILION

dungeons:
- ~~SHADOWFANG_KEEP~~
- ~~RAZORFEN_DOWNS~~
- ~~SCARLET_MONASTERY~~
- ~~STRATHOLME~~
- ~~DIRE_MAUL~~

I'm still thinking about not doing it for the dungeons.
It effects special bosses in those dungeons during the scourge invasion.
Excluding the RNDbots means they will see those bosses ALWAYS.
So as a real player you'll see them engage something you can't see yourself if you're not in the Naxx40 phase yourself.
So not exactly ideal. I changed my mind, I'll undo this for now.

Right now this will only effect the vanilla world dragons and the Argent Pavilion


Currently RNDbots do not see the AQ war bosses either.
Same goes for all the scourge invasion encounters.
RNDbots don't have the progression level for it.
Excluding them from this requirement would mean they see the bosses and all the invasion encounters all the time.
I can't do that.

Alt bots don't have these issues. Alt bots get progression levels
