### PR TITLE
Silt Crawlers should be neutral towards players

### DIFF
--- a/data/sql/world/base/vanilla_creatures.sql
+++ b/data/sql/world/base/vanilla_creatures.sql
@@ -1475,7 +1475,7 @@ UPDATE `creature_template` SET `DamageModifier` = 1.05, `ArmorModifier` = 2.4 WH
 UPDATE `creature_template` SET `detection_range` = 18.0 WHERE `entry`=919;
 
 /*  Silt Crawler  */
-UPDATE `creature_template` SET `ArmorModifier` = 1.5 WHERE `entry`=922;
+UPDATE `creature_template` SET `faction` = 7, `ArmorModifier` = 1.5 WHERE `entry`=922;
 
 /*  [UNUSED] Lesser Arachnid  */
 UPDATE `creature_template` SET `detection_range` = 18.0 WHERE `entry`=924;


### PR DESCRIPTION
The Silt Crawlers in Swamp of Sorrows should be neutral towards players.
https://www.wowhead.com/classic/npc=922/silt-crawler

In the same vein, the Theramore Desterters in Dustwallow were friendly to Alliance players in Vanilla, they only became hostile in patch 2.3.
I'm not sure if this needs to be "fixed" though.
https://www.wowhead.com/classic/npc=5057/theramore-deserter 