### PR TITLE
a few more fixes in Desolace

### DIFF
--- a/data/sql/world/base/zone_desolace.sql
+++ b/data/sql/world/base/zone_desolace.sql
@@ -1,25 +1,28 @@
--- smart scripts
+/* smart scripts */
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN 
-(4632, 4634, 4635, 4636, 4637, 4654, 4655, 4656, 4657, 4663, 4664, 4665, 4670, 4671, 4672, 4673, 4674, 4675, 4676, 4677, 4681, 4682, 4692, 4695, 4696, 4705, 4726, 4728, 5402, 5600, 5602, 5760, 5771, 10182, 13019, 14225);
+(4632, 4634, 4635, 4636, 4637, 4654, 4655, 4656, 4657, 4663, 4664, 4665, 4670, 4671, 4672, 4673, 4674, 4675, 4676, 4677, 
+4681, 4682, 4692, 4695, 4696, 4705, 4726, 4728, 5402, 5600, 5602, 5760, 5771, 10182, 10204, 13019, 14225);
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN 
-(4632, 4634, 4635, 4636, 4637, 4654, 4655, 4656, 4657, 4663, 4664, 4665, 4670, 4671, 4672, 4673, 4674, 4675, 4676, 4677, 4681, 4682, 4692, 4695, 4696, 4705, 4726, 4728, 5402, 5600, 5602, 5760, 5771, 10182, 13019, 14225);
+(4632, 4634, 4635, 4636, 4637, 4654, 4655, 4656, 4657, 4663, 4664, 4665, 4670, 4671, 4672, 4673, 4674, 4675, 4676, 4677, 
+4681, 4682, 4692, 4695, 4696, 4705, 4726, 4728, 5402, 5600, 5602, 5760, 5771, 10182, 10204, 13019, 14225, -610204);
+
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
 `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
 `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
 `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
 --
-(4632, 0, 0, 0, 9, 0, 100, 0, 2100, 2400, 10100, 10400, 0, 5, 11, 25710, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,    'Kolkar Centaur - Within 0-5 Range - Cast Heroic Strike'),
+(4632, 0, 0, 0, 9, 0, 100, 0, 0, 0, 10100, 10400, 0, 5, 11, 25710, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Kolkar Centaur - Within 0-5 Range - Cast Heroic Strike'),
 (4632, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Kolkar Centaur - Between 0-15% Health - Flee For Assist (No Repeat)'),
-(4634, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 12787, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Kolkar Mauler - On Reset - Cast Thrash'),
+(4634, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 12787, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Kolkar Mauler - On Respawn - Cast Thrash'),
 (4634, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Kolkar Mauler - Between 0-15% Health - Flee For Assist (No Repeat)'),
-(4635, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2100, 2300, 0, 0, 11, 9532, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Kolkar Windchaser - In Combat - Cast Lightning Bolt'),
+(4635, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2000, 2000, 0, 0, 11, 9532, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Kolkar Windchaser - In Combat - Cast Lightning Bolt'),
 (4635, 0, 1, 0, 0, 0, 100, 0, 7000, 11000, 15000, 18000, 0, 0, 11, 6728, 64, 0, 0, 0, 0, 21, 30, 0, 0, 0, 0, 0, 0, 0, 'Kolkar Windchaser - Within 0-30 Range - Cast Enveloping Winds'),
 (4635, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Kolkar Windchaser - Between 0-15% Health - Flee For Assist (No Repeat)'),
-(4636, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 7165, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Kolkar Battle Lord - On Reset - Cast Battle Stance'),
+(4636, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 7165, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Kolkar Battle Lord - On Respawn - Cast Battle Stance'),
 (4636, 0, 1, 0, 0, 0, 100, 0, 1000, 3000, 30000, 45000, 0, 0, 11, 8258, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Kolkar Battle Lord - In Combat - Cast Devotion Aura'),
-(4636, 0, 2, 0, 9, 0, 100, 0, 2100, 3000, 9800, 10400, 0, 5, 11, 25710, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Kolkar Battle Lord - Within 0-5 Range - Cast Heroic Strike'),
+(4636, 0, 2, 0, 9, 0, 100, 0, 0, 0, 9800, 10400, 0, 5, 11, 25710, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Kolkar Battle Lord - Within 0-5 Range - Cast Heroic Strike'),
 (4636, 0, 3, 0, 2, 0, 100, 1, 0, 20, 0, 0, 0, 0, 39, 20, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Kolkar Battle Lord - Between 0-20% Health - Call for Help (No Repeat)'),
-(4637, 0, 0, 0, 9, 0, 100, 0, 1500, 3000, 9000, 14000, 0, 20, 11, 11824, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,    'Kolkar Destroyer - Within 0-20 Range - Cast Shock'),
+(4637, 0, 0, 0, 9, 0, 100, 0, 0, 0, 9000, 14000, 0, 20, 11, 11824, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Kolkar Destroyer - Within 0-20 Range - Cast Shock'),
 (4637, 0, 1, 0, 12, 0, 100, 1, 0, 20, 0, 0, 0, 0, 11, 7160, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,                 'Kolkar Destroyer - Target Between 0-20% Health - Cast Execute (No Repeat)'),
 (4637, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Kolkar Destroyer - Between 0-15% Health - Flee For Assist (No Repeat)'),
 (4654, 0, 0, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 30, 60, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Maraudine Scout - Outside 30 Range - Start Combat Movement'),
@@ -27,25 +30,25 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (4654, 0, 2, 0, 9, 0, 100, 0, 0, 0, 4000, 4000, 0, 5, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Maraudine Scout - Within 0-5 Range - Start Combat Movement'),
 (4654, 0, 3, 0, 9, 0, 100, 0, 0, 0, 2000, 4000, 5, 30, 11, 6660, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Maraudine Scout - Within 5-30 Range - Cast Shoot'),
 (4654, 0, 4, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Maraudine Scout - Between 0-15% Health - Flee For Assist (No Repeat)'),
-(4655, 0, 0, 0, 9, 0, 100, 0, 0, 0, 12000, 16000, 0, 5, 11, 8379, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Maraudine Wrangler - Within 0-5 Range - Cast Disarm'),
+(4655, 0, 0, 0, 9, 0, 100, 0, 0, 0, 12000, 16000, 0, 5, 11, 8379, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Maraudine Wrangler - Within 0-5 Range - Cast Disarm'),
 (4655, 0, 1, 0, 0, 0, 100, 0, 4000, 9000, 18000, 34000, 0, 0, 11, 6533, 0, 0, 0, 0, 0, 21, 20, 0, 0, 0, 0, 0, 0, 0,   'Maraudine Wrangler - In Combat - Cast Net'),
 (4655, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Maraudine Wrangler - Between 0-15% Health - Flee For Assist (No Repeat)'),
 (4656, 0, 0, 0, 0, 0, 100, 0, 8000, 12000, 15000, 20000, 0, 0, 11, 3391, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,    'Maraudine Mauler - In Combat - Cast Thrash'),
 (4656, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Maraudine Mauler - Between 0-15% Health - Flee For Assist (No Repeat)'),
-(4657, 0, 0, 0, 0, 0, 100, 0, 1500, 1500, 4000, 4500, 0, 0, 11, 9532, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,       'Maraudine Windchaser - In Combat - Cast Lightning Bolt'),
-(4657, 0, 1, 0, 14, 0, 100, 0, 600, 40, 17000, 21000, 0, 0, 11, 959, 1, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,        'Maraudine Windchaser - Friendly missing 600 Health - Cast Healing Wave'),
+(4657, 0, 0, 0, 0, 0, 100, 0, 1500, 1500, 4000, 4500, 0, 0, 11, 9532, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,      'Maraudine Windchaser - In Combat - Cast Lightning Bolt'),
+(4657, 0, 1, 0, 14, 0, 100, 0, 600, 40, 17000, 21000, 0, 0, 11, 959, 65, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,       'Maraudine Windchaser - Friendly missing 600 Health - Cast Healing Wave'),
 (4657, 0, 2, 0, 0, 0, 100, 0, 7000, 11000, 15000, 18000, 0, 0, 11, 9532, 0, 0, 0, 0, 0, 5, 30, 0, 0, 0, 0, 0, 0, 0,   'Maraudine Windchaser - In Combat - Cast Enveloping Winds'),
 (4657, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Maraudine Windchaser - Between 0-15% Health - Flee For Assist (No Repeat)'),
 --
 (4663, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2400, 3800, 0, 0, 11, 20807, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Burning Blade Augur - In Combat - Cast Shadow Bolt'),
-(4663, 0, 1, 0, 9, 0, 100, 0, 3000, 6000, 15000, 25000, 0, 5, 11, 6909, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,    'Burning Blade Augur - Within 0-5 Range - Cast Curse of Thorns'),
+(4663, 0, 1, 0, 0, 0, 100, 0, 3000, 6000, 15000, 25000, 0, 0, 11, 6909, 32, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,   'Burning Blade Augur - Within 0-5 Range - Cast Curse of Thorns'),
 (4663, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Burning Blade Augur - Between 0-15% Health - Flee For Assist (No Repeat)'),
-(4664, 0, 0, 0, 9, 0, 100, 0, 2000, 2000, 8000, 11000, 0, 5, 11, 8374, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,      'Burning Blade Reaver - Within 0-5 Range - Cast Arcing Smash'),
+(4664, 0, 0, 0, 9, 0, 100, 0, 0, 0, 8000, 11000, 0, 5, 11, 8374, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Burning Blade Reaver - Within 0-5 Range - Cast Arcing Smash'),
 (4665, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2400, 3800, 0, 0, 11, 19816, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Burning Blade Adept - In Combat - Cast Fireball'),
 (4665, 0, 1, 0, 2, 0, 100, 1, 0, 80, 0, 0, 0, 0, 11, 6742, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Burning Blade Adept - Between 0-80% Health - Cast Bloodlust (No Repeat)'),
 (4665, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Burning Blade Adept - Between 0-15% Health - Flee For Assist (No Repeat)'),
 --
-(4670, 0, 0, 0, 1, 0, 100, 1, 0, 0, 1000, 1000, 0, 0, 11, 6920, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,             'Hatefury Rogue - Out of Combat - Cast Hide (No Repeat)'),
+(4670, 0, 0, 0, 1, 0, 100, 1, 1000, 1000, 0, 0, 0, 0, 11, 6920, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,             'Hatefury Rogue - Out of Combat - Cast Hide (No Repeat)'),
 (4670, 0, 1, 2, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 11, 8599, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Hatefury Rogue - Between 0-30% Health - Cast Enrage (No Repeat)'),
 (4670, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hatefury Rogue - On Enrage - Say Line 0'),
 (4671, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 3616, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Hatefury Trickster - On Respawn - Cast Poison Proc'),
@@ -59,32 +62,32 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (4674, 0, 1, 0, 9, 0, 100, 0, 0, 0, 10000, 14000, 0, 5, 11, 6595, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Hatefury Shadowstalker - Within 0-5 Range - Cast Exploit Weakness'),
 (4674, 0, 2, 3, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 11, 8599, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Hatefury Shadowstalker - Between 0-30% Health - Cast Enrage (No Repeat)'),
 (4674, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hatefury Shadowstalker - On Enrage - Say Line 0'),
-(4675, 0, 0, 0, 9, 0, 100, 0, 0, 0, 10000, 10000, 0, 30, 11, 1094, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,         'Hatefury Hellcaller - Within 0-30 Range - Cast Immolate'),
-(4675, 0, 2, 0, 9, 0, 100, 0, 2000, 2000, 20000, 20000, 0, 30, 11, 5740, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,   'Hatefury Hellcaller - Within 0-30 Range - Cast Rain of Fire'),
+(4675, 0, 0, 0, 0, 0, 100, 0, 0, 0, 10000, 10000, 0, 0, 11, 1094, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Hatefury Hellcaller - In Combat - Cast Immolate'),
+(4675, 0, 2, 0, 0, 0, 100, 0, 2000, 2000, 20000, 20000, 0, 0, 11, 5740, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,    'Hatefury Hellcaller - In Combat - Cast Rain of Fire'),
 (4675, 0, 3, 4, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 11, 8599, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Hatefury Hellcaller - Between 0-30% Health - Cast Enrage (No Repeat)'),
 (4675, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                      'Hatefury Hellcaller - On Enrage - Say Line 0'),
 (4676, 0, 0, 0, 0, 0, 100, 0, 1000, 3000, 30000, 35000, 0, 0, 11, 2601, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Lesser Infernal - In Combat - Cast Fire Shield III'),
 (4677, 0, 0, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 7165, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Doomwarder - On Aggro - Cast Battle Stance'),
 (4681, 0, 0, 0, 0, 0, 100, 0, 5000, 16000, 15000, 25000, 0, 0, 11, 3429, 288, 0, 0, 0, 0, 5, 30, 0, 0, 0, 0, 0, 0, 0, 'Mage Hunter - Within 0-30 Range - Cast Plague Mind'),
-(4682, 0, 0, 0, 9, 0, 100, 0, 2200, 2400, 12000, 15000, 0, 5, 11, 7816, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Nether Sister - Within 0-5 Range - Cast Lash of Pain'),
+(4682, 0, 0, 0, 9, 0, 100, 0, 0, 0, 12000, 15000, 0, 5, 11, 7816, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Nether Sister - Within 0-5 Range - Cast Lash of Pain'),
 --
 (4692, 0, 0, 0, 9, 0, 100, 0, 0, 0, 9000, 12000, 0, 5, 11, 5708, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Dread Swoop - Within 0-5 Range - Cast Swoop'),
-(4695, 0, 0, 0, 9, 0, 100, 0, 5000, 9000, 12000, 18000, 0, 5, 11, 3427, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,    'Carrion Horror - Within 0-5 Range - Cast Infected Wound'),
-(4696, 0, 0, 0, 9, 0, 100, 0, 3000, 7000, 14000, 17000, 0, 5, 11, 5416, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Scorpashi Snapper - Within 0-5 Range - Cast Venom Sting'),
+(4695, 0, 0, 0, 0, 0, 100, 0, 5000, 9000, 12000, 18000, 0, 0, 11, 3427, 32, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,   'Carrion Horror - Within 0-5 Range - Cast Infected Wound'),
+(4696, 0, 0, 0, 0, 0, 100, 0, 3000, 7000, 14000, 17000, 0, 0, 11, 5416, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,    'Scorpashi Snapper - Within 0-5 Range - Cast Venom Sting'),
 (4705, 0, 0, 0, 0, 0, 100, 0, 9000, 15000, 16000, 21000, 0, 0, 11, 11829, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,  'Burning Blade Invoker - In Combat - Cast Flamestrike'),
 (4705, 0, 1, 0, 0, 0, 85, 0, 4000, 14000, 11000, 17000, 0, 0, 11, 9574, 64, 0, 0, 0, 0, 5, 20, 0, 0, 0, 0, 0, 0, 0,   'Burning Blade Invoker - Within 0-20 Range - Cast Flame Buffet'),
 (4726, 0, 0, 0, 9, 0, 100, 0, 0, 0, 5000, 7000, 0, 30, 11, 15611, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Raging Thunder Lizard - Within 0-30 Range - Cast Lizard Bolt'),
 (4726, 0, 1, 2, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 11, 8599, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Raging Thunder Lizard - Between 0-30% Health - Cast Enrage (No Repeat)'),
 (4726, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                      'Raging Thunder Lizard - On Enrage - Say Line 0'),
-(4728, 0, 0, 0, 9, 0, 100, 0, 8000, 14000, 25000, 35000, 0, 5, 11, 3636, 64, 0, 0, 0, 0, 5, 5, 0, 0, 0, 0, 0, 0, 0,   'Gritjaw Basilisk - Within 0-5 Range - Cast Crystalline Slumber'),
+(4728, 0, 0, 0, 0, 0, 100, 0, 8000, 14000, 25000, 35000, 0, 0, 11, 3636, 64, 0, 0, 0, 0, 5, 5, 0, 0, 0, 0, 0, 0, 0,   'Gritjaw Basilisk - Within 0-5 Range - Cast Crystalline Slumber'),
 --
 (5402, 0, 0, 0, 0, 0, 100, 0, 1000, 3000, 30000, 30000, 0, 0, 11, 9128, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'Khan Hratha - In Combat - Cast Battle Shout'),
-(5402, 0, 1, 0, 9, 0, 100, 0, 7700, 11000, 7000, 11000, 0, 5, 11, 15496, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,    'Khan Hratha - Within 0-5 Range - Cast Cleave'),
-(5600, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 7165, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Khan Dez hepah - On Reset - Cast Battle Stance'),
-(5600, 0, 1, 0, 9, 0, 100, 0, 2100, 3200, 6000, 10000, 0, 5, 11, 25710, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Khan Dez hepah - Within 0-5 Range - Cast Heroic Strike'),
+(5402, 0, 1, 0, 0, 0, 100, 0, 7000, 11000, 7000, 11000, 0, 0, 11, 15496, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,   'Khan Hratha - Within 0-5 Range - Cast Cleave'),
+(5600, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 7165, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Khan Dez hepah - On Respawn - Cast Battle Stance'),
+(5600, 0, 1, 0, 9, 0, 100, 0, 0, 0, 6000, 10000, 0, 5, 11, 25710, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Khan Dez hepah - Within 0-5 Range - Cast Heroic Strike'),
 (5600, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Khan Dez hepah - Between 0-15% Health - Flee For Assist (No Repeat)'),
-(5602, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 7165, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Khan Shaka - On Reset - Cast Battle Stance'),
-(5602, 0, 1, 0, 9, 0, 100, 0, 3000, 4000, 17000, 23000, 0, 5, 11, 9080, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Khan Shaka - Within 0-5 Range - Cast Hamstring'),
+(5602, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 7165, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Khan Shaka - On Respawn - Cast Battle Stance'),
+(5602, 0, 1, 0, 0, 0, 100, 0, 3000, 4000, 17000, 23000, 0, 0, 11, 9080, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,    'Khan Shaka - Within 0-5 Range - Cast Hamstring'),
 (5602, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Khan Shaka - Between 0-15% Health - Flee For Assist (No Repeat)'),
 (5760, 0, 0, 0, 9, 0, 100, 0, 0, 0, 9000, 14000, 0, 5, 11, 13737, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Lord Azrethoc - Within 0-5 Range - Cast Mortal Strike'),
 (5760, 0, 1, 0, 2, 0, 100, 1, 20, 40, 0, 0, 0, 0, 11, 7961, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Lord Azrethoc - Between 20-40% Health - Cast Azrethocs Stomp (No Repeat)'),
@@ -93,16 +96,17 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (5771, 0, 2, 0, 0, 0, 100, 0, 2100, 3100, 2100, 3100, 0, 0, 11, 12471, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Jugkar Grim\'rod - In Combat - Cast Shadow Bolt'),
 (5771, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Jugkar Grim\'rod - Between 0-15% Health - Flee For Assist (No Repeat)'),
 --
-(10182, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Rexxar - On Reset - Cast Thrash'),
-(10182, 0, 1, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 21911, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Rexxar - On Reset - Cast Puncture'),
+(10182, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Rexxar - On Respawn - Cast Thrash'),
+(10182, 0, 1, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 21911, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Rexxar - On Respawn - Cast Puncture'),
 (10182, 0, 2, 0, 0, 0, 100, 0, 7000, 9000, 12000, 16000, 0, 0, 11, 18813, 0, 0, 0, 0, 0, 5, 10, 0, 0, 0, 0, 0, 0, 0,  'Rexxar - Within 0-10 Range - Cast Knock Away'),
-(10182, 0, 3, 0, 9, 0, 100, 0, 4850, 18250, 4850, 18250, 0, 5, 11, 40504, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,   'Rexxar - Within 0-5 Range - Cast Cleave'),
-(10182, 0, 4, 0, 9, 0, 100, 0, 3000, 5000, 8000, 12000, 0, 5, 11, 17963, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,    'Rexxar - Within 0-5 Range - Cast Sundering Cleave'),
+(10182, 0, 3, 0, 0, 0, 100, 0, 4850, 18250, 4850, 18250, 0, 0, 11, 40504, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,  'Rexxar - Within 0-5 Range - Cast Cleave'),
+(10182, 0, 4, 0, 0, 0, 100, 0, 3000, 5000, 8000, 12000, 0, 0, 11, 17963, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,   'Rexxar - Within 0-5 Range - Cast Sundering Cleave'),
 (10182, 0, 5, 6, 2, 0, 100, 1, 0, 25, 0, 0, 0, 0, 11, 30485, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Rexxar - Between 0-25% Health - Cast Enrage (No Repeat)'),
 (10182, 0, 6, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                     'Rexxar - On Enrage - Say Line 0'),
 (10182, 0, 7, 0, 74, 0, 100, 1, 0, 0, 0, 0, 20, 0, 11, 8602, 0, 0, 0, 0, 0, 9, 10204, 0, 0, 0, 0, 0, 0, 0,            'Rexxar - On Misha Between 0-20% Health - Cast Vengeance (No Repeat)'),
 (10182, 0, 8, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 54, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                     'Rexxar - On Agrro - Waypoint Pause'),
 (10182, 0, 9, 0, 1, 0, 100, 0, 0, 0, 0, 0, 0, 0, 65, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                     'Rexxar - OOC - Waypoint Resume'),
+(-610204, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Misha - On Respawn - Set Active'),
 --
 (13019, 0, 0, 0, 0, 0, 100, 0, 9000, 15000, 16000, 21000, 0, 0, 11, 11829, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Burning Blade Seer - In Combat - Cast Flamestrike'),
 (13019, 0, 1, 0, 0, 0, 85, 0, 4000, 14000, 11000, 17000, 0, 0, 11, 9658, 64, 0, 0, 0, 0, 5, 20, 0, 0, 0, 0, 0, 0, 0,  'Burning Blade Seer - Within 0-20 Range - Cast Flame Buffet'),
@@ -722,8 +726,8 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 (282820, 26, -1439.9, 1799.24, 50.1445, NULL, 10000, 0, 0, 100, 0);
 
 /* smart scripts */
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (4700);
-DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (-28272, -28278, -28282);
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (4700, 4701);
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (-28272, -28273, -28274, -28278, -28279, -28280, -28282, -28283, -28284, -28295, -28298, -28299);
 
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
 `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
@@ -743,14 +747,24 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (-28282, 0, 0, 1, 108, 0, 100, 512, 26, 282820, 0, 0, 0, 0, 41, 3000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,  'Aged Kodo - On Waypoint Path Ended - Despawn After 3 Seconds'),
 (-28282, 0, 1, 2, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 41, 3000, 0, 0, 0, 0, 0, 10, 28283, 0, 0, 0, 0, 0, 0, 0,    'Aged Kodo - On Waypoint Path Ended - Despawn After 3 Seconds'),
 (-28282, 0, 2, 3, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 41, 3000, 0, 0, 0, 0, 0, 10, 28284, 0, 0, 0, 0, 0, 0, 0,    'Aged Kodo - On Waypoint Path Ended - Despawn After 3 Seconds'),
-(-28282, 0, 3, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 41, 3000, 0, 0, 0, 0, 0, 10, 28299, 0, 0, 0, 0, 0, 0, 0,    'Dying Kodo - On Waypoint Path Ended - Despawn After 3 Seconds');
+(-28282, 0, 3, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 41, 3000, 0, 0, 0, 0, 0, 10, 28299, 0, 0, 0, 0, 0, 0, 0,    'Dying Kodo - On Waypoint Path Ended - Despawn After 3 Seconds'),
+--
+(-28273, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Aged Kodo - On Respawn - Set Active'),
+(-28274, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Aged Kodo - On Respawn - Set Active'),
+(-28279, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Aged Kodo - On Respawn - Set Active'),
+(-28280, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Aged Kodo - On Respawn - Set Active'),
+(-28283, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Aged Kodo - On Respawn - Set Active'),
+(-28284, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Aged Kodo - On Respawn - Set Active'),
+(-28295, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Dying Kodo - On Respawn - Set Active'),
+(-28298, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Dying Kodo - On Respawn - Set Active'),
+(-28299, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Dying Kodo - On Respawn - Set Active');
 
 /* Aged kodos have scripts that overrule smartAI
-I'm removing this script from the leading kodos so I can use smartAI to despawn the patrol when it reaches it's last waypoint
-this does mean that the leading kodo in the patrol can't be used for the Kodo Roundup quest */
-UPDATE `creature_template` SET `ScriptName` = '' WHERE `entry` IN (4700);
-UPDATE `creature` SET `ScriptName` = 'npc_aged_dying_ancient_kodo' WHERE `id1` IN (4700);
-UPDATE `creature` SET `ScriptName` = '' WHERE `guid` IN (28272, 28278, 28282);
+I'm removing this script from the kodo patrols so I can use smartAI to despawn the patrol when it reaches it's last waypoint and to keep them active so the formation stays intact
+this does mean that the kodos in the patrol can't be used for the Kodo Roundup quest, but the alternative is teleporting kodos catching up to the leader */
+UPDATE `creature_template` SET `ScriptName` = '' WHERE `entry` IN (4700, 4701);
+UPDATE `creature` SET `ScriptName` = 'npc_aged_dying_ancient_kodo' WHERE `id1` IN (4700, 4701);
+UPDATE `creature` SET `ScriptName` = '' WHERE `guid` IN (28272, 28273, 28274, 28278, 28279, 28280, 28282, 28283, 28284, 28295, 28298, 28299);
 
 
 -- fix hyena patrols
@@ -1171,3 +1185,41 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 (279690, 56, -977.141, 2231.51, 87.6701, NULL, 0, 0, 0, 100, 0),
 (279690, 57, -1009.04, 2254.87, 86.6962, NULL, 0, 0, 0, 100, 0),
 (279690, 58, -1020.11, 2284.9, 90.6242, NULL, 0, 0, 0, 100, 0);
+
+/* smart scripts */
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (4688, 4689, 4690);
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (
+-27940, -27941, -27942, -27943, -27950, -27951, -27952, -27953, -27955, -27956, -27957, -27958,
+-27960, -27961, -27962, -27963, -27965, -27966, -27967, -27968, -27970, -27971, -27972, -27973);
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
+`event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+--
+(-27940, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bonepaw Hyena - On Respawn - Set Active'),
+(-27941, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bonepaw Hyena - On Respawn - Set Active'),
+(-27942, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bonepaw Hyena - On Respawn - Set Active'),
+(-27943, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bonepaw Hyena - On Respawn - Set Active'),
+(-27950, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bonepaw Hyena - On Respawn - Set Active'),
+(-27951, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bonepaw Hyena - On Respawn - Set Active'),
+(-27952, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bonepaw Hyena - On Respawn - Set Active'),
+(-27953, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bonepaw Hyena - On Respawn - Set Active'),
+--
+(-27955, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Starving Bonepaw - On Respawn - Set Active'),
+(-27956, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Starving Bonepaw - On Respawn - Set Active'),
+(-27957, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Starving Bonepaw - On Respawn - Set Active'),
+(-27958, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Starving Bonepaw - On Respawn - Set Active'),
+(-27960, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Starving Bonepaw - On Respawn - Set Active'),
+(-27961, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Starving Bonepaw - On Respawn - Set Active'),
+(-27962, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Starving Bonepaw - On Respawn - Set Active'),
+(-27963, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Starving Bonepaw - On Respawn - Set Active'),
+--
+(-27965, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Rapid Bonemaw - On Respawn - Set Active'),
+(-27966, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Rapid Bonemaw - On Respawn - Set Active'),
+(-27967, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Rapid Bonemaw - On Respawn - Set Active'),
+(-27968, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Rapid Bonemaw - On Respawn - Set Active'),
+(-27970, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Rapid Bonemaw - On Respawn - Set Active'),
+(-27971, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Rapid Bonemaw - On Respawn - Set Active'),
+(-27972, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Rapid Bonemaw - On Respawn - Set Active'),
+(-27973, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Rapid Bonemaw - On Respawn - Set Active');


### PR DESCRIPTION
there is a problem with patrols that have formations.
only the leader is kept active by default.
this results in the followers teleporting across the map to catch up

the solution for this is to keep the entire patrol active
so I've done just that.

this does cause an issue with the kodo patrols.
kodos in Desolace all have scripts. they have these scripts for the Kodo Roundup quest. scripts overrule smartAI.
But I need to use smartAI to despawn the kodo patrols when they reach the kodo graveyard
and now also to keep them active so we don't see teleporting kodos
so these kodo patrols cannot be used for the Kodo Roundup quest anymore. I disabled the script to be able to use smartAI.

also updated some smartai for other creatures, because Desolace was one of the first zone I started updating
and I've learned some things later on, what works and what doesn't. so fixed that as well.