### PR TITLE
fix Onyxia40 whelp spawn

### DIFF
--- a/src/vanillaScripts/boss_onyxia.cpp
+++ b/src/vanillaScripts/boss_onyxia.cpp
@@ -284,7 +284,7 @@ public:
                         uint8 selectedCave = urand(0, 1);
 
                         // Summon a whelp at the selected cave mouth
-                        Creature* whelp = me->SummonCreature(NPC_ONYXIAN_WHELP, caveMouths[selectedCave][0], caveMouths[selectedCave][1], caveMouths[selectedCave][2], 0);
+                        Creature* whelp = me->SummonCreature(NPC_ONYXIAN_WHELP_40, caveMouths[selectedCave][0], caveMouths[selectedCave][1], caveMouths[selectedCave][2], 0);
 
                         if (whelp)
                         {


### PR DESCRIPTION
because of the previous fix changing the onyxia10 man version back to level 80
now another error revealed itself.

onyxia40 summoned the wotlk 10man version of the whelps.
which was wrongly set to 60 before so nobody noticed it.

now summoning the 40man version of the whelps.