### PR TITLE
Update Mounts and Riding

### DIFF
--- a/data/sql/world/base/mounts_and_riding.sql
+++ b/data/sql/world/base/mounts_and_riding.sql
@@ -63,3 +63,133 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (23, 7952, 13317, 0, 0, 8, 0, 66002, 0, 0, 1, 0, 0, '', 'Zjolnir will not sell Whistle of the Ivory Raptor after the player has completed PROGRESSION_ONYXIA'),
 (23, 7955, 13326, 0, 0, 8, 0, 66002, 0, 0, 1, 0, 0, '', 'Milli Featherwhistle will not sell White Mechanostrider Mod A after the player has completed PROGRESSION_ONYXIA'),
 (23, 7955, 13327, 0, 0, 8, 0, 66002, 0, 0, 1, 0, 0, '', 'Milli Featherwhistle will not sell Icy Blue Mechanostrider Mod A after the player has completed PROGRESSION_ONYXIA');
+
+
+-- Alliance 60% speed mounts
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Black Stallion Bridle'          WHERE `entry` = 2411;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Pinto Bridle'                   WHERE `entry` = 2414;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Chestnut Mare Bridle'           WHERE `entry` = 5655;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Brown Horse Bridle'             WHERE `entry` = 5656;
+
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Gray Ram'                       WHERE `entry` = 5864;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Brown Ram'                      WHERE `entry` = 5872;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'White Ram'                      WHERE `entry` = 5873;
+
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Red Mechanostrider'             WHERE `entry` = 8563; 
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Blue Mechanostrider'            WHERE `entry` = 8595; 
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Green Mechanostrider'           WHERE `entry` = 13321;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Unpainted Mechanostrider'       WHERE `entry` = 13322;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Purple Mechanostrider'          WHERE `entry` = 13323;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Red and Blue Mechanostrider'    WHERE `entry` = 13324;
+
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Striped Nightsaber'             WHERE `entry` = 8629;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Striped Frostsaber'             WHERE `entry` = 8631;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Spotted Frostsaber'             WHERE `entry` = 8632;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Striped Dawnsaber'              WHERE `entry` = 47100;
+
+-- Horde 60% speed mounts
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Timber Wolf'                    WHERE `entry` = 1132;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Dire Wolf'                      WHERE `entry` = 5665;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Brown Wolf'                     WHERE `entry` = 5668;
+
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Emerald Raptor'                 WHERE `entry` = 8588;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Turquoise Raptor'               WHERE `entry` = 8591;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Violet Raptor'                  WHERE `entry` = 8592;
+
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Red Skeletal Horse'             WHERE `entry` = 13331;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Blue Skeletal Horse'            WHERE `entry` = 13332;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Brown Skeletal Horse'           WHERE `entry` = 13333;
+
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Gray Kodo'                      WHERE `entry` = 15277;
+UPDATE `item_template` SET `BuyPrice` = 100000,  `RequiredLevel` = 40, `Name` = 'Brown Kodo'                     WHERE `entry` = 15290;
+
+-- Alliance 100% speed mounts
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Frostsaber'                     WHERE `entry` = 12302;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Nightsaber'                     WHERE `entry` = 12303;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Frostsaber'               WHERE `entry` = 18766;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Mistsaber'                WHERE `entry` = 18767;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Dawnsaber'                WHERE `entry` = 18768;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Stormsaber'               WHERE `entry` = 18902;
+
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'White Mechanostrider Mod A'     WHERE `entry` = 13326; 
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Icy Blue Mechanostrider Mod A'  WHERE `entry` = 13327;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Green Mechanostrider'     WHERE `entry` = 18772;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift White Mechanostrider'     WHERE `entry` = 18773;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Yellow Mechanostrider'    WHERE `entry` = 18774;
+
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'White Stallion Bridle'          WHERE `entry` = 12353;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Palomino Bridle'                WHERE `entry` = 12354;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Palomino'                 WHERE `entry` = 18776;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Brown Steed'              WHERE `entry` = 18777;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift White Steed'              WHERE `entry` = 18778;
+
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Black Ram'                      WHERE `entry` = 13328;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Frost Ram'                      WHERE `entry` = 13329;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift White Ram'                WHERE `entry` = 18785;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Brown Ram'                WHERE `entry` = 18786;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Gray Ram'                 WHERE `entry` = 18787;
+
+-- Horde 100% speed mounts
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Mottled Red Raptor'             WHERE `entry` = 8586;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Ivory Raptor'                   WHERE `entry` = 13317;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Blue Raptor'              WHERE `entry` = 18788;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Olive Raptor'             WHERE `entry` = 18789;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Orange Raptor'            WHERE `entry` = 18790;
+
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Green Skeletal Warhorse'        WHERE `entry` = 13334;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Purple Skeletal Warhorse'       WHERE `entry` = 18791;
+
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Green Kodo'                     WHERE `entry` = 15292;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Teal Kodo'                      WHERE `entry` = 15293;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Great White Kodo'               WHERE `entry` = 18793;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Great Brown Kodo'               WHERE `entry` = 18794;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Great Gray Kodo'                WHERE `entry` = 18795;
+
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Red Wolf'                       WHERE `entry` = 12330;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Arctic Wolf'                    WHERE `entry` = 12351;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Brown Wolf'               WHERE `entry` = 18796;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Timber Wolf'              WHERE `entry` = 18797;
+UPDATE `item_template` SET `BuyPrice` = 1000000, `RequiredLevel` = 60, `Name` = 'Swift Gray Wolf'                WHERE `entry` = 18798;
+
+-- special mounts
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 10000000, `RequiredLevel` = 60, `Name` = 'Winterspring Frostsaber'          WHERE `entry` = 13086;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 10000000, `RequiredLevel` = 60, `Name` = 'Deathcharger'                     WHERE `entry` = 13335;
+
+UPDATE `item_template` SET `Quality` = 4, `BuyPrice` = 100000,   `RequiredLevel` = 60, `Name` = 'Frostwolf Howler'                 WHERE `entry` = 19029;
+UPDATE `item_template` SET `Quality` = 4, `BuyPrice` = 100000,   `RequiredLevel` = 60, `Name` = 'Stormpike Battle Charger'         WHERE `entry` = 19030;
+
+UPDATE `item_template` SET `Quality` = 4, `BuyPrice` = 10000000, `RequiredLevel` = 60, `Name` = 'Swift Razzashi Raptor'            WHERE `entry` = 19872;
+UPDATE `item_template` SET `Quality` = 4, `BuyPrice` = 10000000, `RequiredLevel` = 60, `Name` = 'Swift Zulian Tiger'               WHERE `entry` = 19902;
+
+UPDATE `item_template` SET `Quality` = 5, `BuyPrice` = 10000000, `RequiredLevel` = 60, `Name` = 'Black Qiraji Resonating Crystal'  WHERE `entry` = 21176;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 1000000,  `RequiredLevel` = 60, `Name` = 'Blue Qiraji Resonating Crystal'   WHERE `entry` = 21218;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 1000000,  `RequiredLevel` = 60, `Name` = 'Red Qiraji Resonating Crystal'    WHERE `entry` = 21321;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 1000000,  `RequiredLevel` = 60, `Name` = 'Green Qiraji Resonating Crystal'  WHERE `entry` = 21323;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 1000000,  `RequiredLevel` = 60, `Name` = 'Yellow Qiraji Resonating Crystal' WHERE `entry` = 21324;
+
+-- unavailable mounts
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Winter Wolf'                      WHERE `entry` = 1133;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Gray Wolf'                        WHERE `entry` = 1134;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Red Wolf'                         WHERE `entry` = 5663;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Skeletal Mount'                   WHERE `entry` = 8583;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Ivory Raptor'                     WHERE `entry` = 8589;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Obsidian Raptor'                  WHERE `entry` = 8590;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Spotted Nightsaber'               WHERE `entry` = 8628;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Bengal Tiger'                     WHERE `entry` = 8630;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Leopard'                          WHERE `entry` = 8633;
+
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Primal Leopard'                   WHERE `entry` = 12325;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Tawny Sabercat'                   WHERE `entry` = 12326;
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Golden Sabercat'                  WHERE `entry` = 12327;
+
+UPDATE `item_template` SET `Quality` = 3, `BuyPrice` = 100000,   `RequiredLevel` = 40, `Name` = 'Fluorescent Green Mechanostrider' WHERE `entry` = 13325;
+UPDATE `item_template` SET `Quality` = 5, `BuyPrice` = 10000000, `RequiredLevel` = 60, `Name` = 'Foror\'s Fabled Steed'            WHERE `entry` = 20221;
+
+
+UPDATE `item_template` SET `bonding` = 1, `SellPrice` = 0 WHERE `entry` IN 
+(1132, 1133, 1134, 2411, 2414, 5655, 5656, 5663, 5665, 5668, 5864, 5872, 5873, 8563, 8583, 8586, 8588, 8589, 8590, 8591, 8592, 8595, 8628, 8629, 8630, 8631, 8632, 8633, 
+12302, 12303, 12325, 12326, 12327, 12330, 12351, 12353, 12354, 13317, 13321, 13322, 13323, 13324, 13325, 13326, 13327, 13328, 13329, 13331, 13332, 13333, 13334, 15277, 15290, 15292, 15293, 
+18766, 18767, 18768, 18772, 18773, 18774, 18776, 18777, 18778, 18785, 18786, 18787, 18788, 18789, 18790, 18791, 18793, 18794, 18795, 18796, 18797, 18798, 18902, 20221, 47100);
+
+-- https://www.azerothcore.org/wiki/item_template#quality
+-- https://www.azerothcore.org/wiki/item_template#bonding

--- a/data/sql/world/base/vanilla_item_changes.sql
+++ b/data/sql/world/base/vanilla_item_changes.sql
@@ -19850,15 +19850,6 @@ UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000 WHERE entry
 /*  Tablet of Restoration III  */
 UPDATE item_template SET BuyPrice = 1800 WHERE entry=1057;
 
-/*  Horn of the Timber Wolf  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=1132;
-
-/*  Horn of the Winter Wolf  */
-UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000 WHERE entry=1133;
-
-/*  Horn of the Gray Wolf  */
-UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000 WHERE entry=1134;
-
 /*  Scroll of Stamina  */
 UPDATE item_template SET ItemLevel = 15, RequiredLevel = 5 WHERE entry=1180;
 
@@ -19883,14 +19874,8 @@ UPDATE item_template SET ItemLevel = 30, RequiredLevel = 20 WHERE entry=2290;
 /*  Light Leather  */
 UPDATE item_template SET BuyPrice = 60 WHERE entry=2318;
 
-/*  Black Stallion Bridle  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=2411;
-
 /*  Palomino  */
 UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000, SellPrice = 0 WHERE entry=2413;
-
-/*  Pinto Bridle  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=2414;
 
 /*  White Stallion  */
 UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000, SellPrice = 0 WHERE entry=2415;
@@ -20018,41 +20003,17 @@ UPDATE item_template SET bonding = 1 WHERE entry=5462;
 /*  Cowardly Flight Potion  */
 UPDATE item_template SET BuyPrice = 340 WHERE entry=5632;
 
-/*  Chestnut Mare Bridle  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=5655;
-
-/*  Brown Horse Bridle  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=5656;
-
 /*  Recipe: Instant Toxin  */
 UPDATE item_template SET BuyPrice = 1000 WHERE entry=5657;
 
 /*  Libram: Seal of Righteousness  */
 UPDATE item_template SET BuyPrice = 1300 WHERE entry=5660;
 
-/*  Horn of the Red Wolf  */
-UPDATE item_template SET Quality = 4, bonding = 1, BuyPrice = 1000000 WHERE entry=5663;
-
-/*  Horn of the Dire Wolf  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=5665;
-
-/*  Horn of the Brown Wolf  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=5668;
-
 /*  Henrig Lonebrow's Journal  */
 UPDATE item_template SET ItemLevel = 29, RequiredLevel = 29 WHERE entry=5791;
 
 /*  Kravel's Scheme  */
 UPDATE item_template SET bonding = 0 WHERE entry=5826;
-
-/*  Gray Ram  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=5864;
-
-/*  Brown Ram  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=5872;
-
-/*  White Ram  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=5873;
 
 /*  Harness: Black Ram  */
 UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000 WHERE entry=5874;
@@ -20185,54 +20146,6 @@ UPDATE item_template SET BuyPrice = 1600, SellPrice = 400 WHERE entry=8544;
 
 /*  Heavy Mageweave Bandage  */
 UPDATE item_template SET BuyPrice = 2400, SellPrice = 600 WHERE entry=8545;
-
-/*  Red Mechanostrider  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=8563;
-
-/*  Horn of the Skeletal Mount  */
-UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000 WHERE entry=8583;
-
-/*  Whistle of the Mottled Red Raptor  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=8586;
-
-/*  Whistle of the Emerald Raptor  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=8588;
-
-/*  Old Whistle of the Ivory Raptor  */
-UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000 WHERE entry=8589;
-
-/*  Old Whistle of the Obsidian Raptor  */
-UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000 WHERE entry=8590;
-
-/*  Whistle of the Turquoise Raptor  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=8591;
-
-/*  Whistle of the Violet Raptor  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=8592;
-
-/*  Blue Mechanostrider  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=8595;
-
-/*  Reins of the Spotted Nightsaber  */
-UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000 WHERE entry=8628;
-
-/*  Reins of the Striped Nightsaber  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=8629;
-
-/*  Reins of the Striped Dawnsaber  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=47100;
-
-/*  Reins of the Bengal Tiger  */
-UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000, SellPrice = 0 WHERE entry=8630;
-
-/*  Reins of the Striped Frostsaber  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=8631;
-
-/*  Reins of the Spotted Frostsaber  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=8632;
-
-/*  Reins of the Leopard  */
-UPDATE item_template SET Quality = 3, bonding = 1, BuyPrice = 100000, SellPrice = 0 WHERE entry=8633;
 
 /*  Mithril Insignia  */
 UPDATE item_template SET bonding = 4 WHERE entry=8663;
@@ -20399,86 +20312,11 @@ UPDATE item_template SET bonding = 3 WHERE entry=11903;
 /*  Worg Carrier  */
 UPDATE item_template SET BuyPrice = 6000, SellPrice = 1500 WHERE entry=12264;
 
-/*  Reins of the Ancient Frostsaber  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=12302;
-
-/*  Reins of the Nightsaber  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=12303;
-
-/*  Reins of the Primal Leopard  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=12325;
-
-/*  Reins of the Tawny Sabercat  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=12326;
-
-/*  Reins of the Golden Sabercat  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=12327;
-
-/*  Horn of the Red Wolf  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=12330;
-
-/*  Horn of the Arctic Wolf  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=12351;
-
-/*  White Stallion Bridle  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=12353;
-
-/*  Palomino Bridle  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=12354;
-
 /*  Smolderweb Carrier  */
 UPDATE item_template SET BuyPrice = 6000, SellPrice = 1500 WHERE entry=12529;
 
 /*  Attuned Dampener  */
 UPDATE item_template SET description = 'This object has been attuned to work against a specific being.' WHERE entry=12650;
-
-/*  Reins of the Winterspring Frostsaber  */
-UPDATE item_template SET SellPrice = 0, RequiredLevel = 60 WHERE entry=13086;
-
-/*  Whistle of the Ivory Raptor  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=13317;
-
-/*  Green Mechanostrider  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=13321;
-
-/*  Unpainted Mechanostrider  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=13322;
-
-/*  Purple Mechanostrider  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=13323;
-
-/*  Red and Blue Mechanostrider  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=13324;
-
-/*  Fluorescent Green Mechanostrider  */
-UPDATE item_template SET BuyPrice = 100000, RequiredLevel = 40 WHERE entry=13325;
-
-/*  White Mechanostrider Mod A  */
-UPDATE item_template SET Name = 'White Mechanostrider Mod A', BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=13326;
-
-/*  Icy Blue Mechanostrider Mod A  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=13327;
-
-/*  Black Ram  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=13328;
-
-/*  Frost Ram  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=13329;
-
-/*  Red Skeletal Horse  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=13331;
-
-/*  Blue Skeletal Horse  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=13332;
-
-/*  Brown Skeletal Horse  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=13333;
-
-/*  Green Skeletal Warhorse  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=13334;
-
-/*  Deathcharger's Reins  */
-UPDATE item_template SET Quality = 3, BuyPrice = 1000000, SellPrice = 250000, RequiredLevel = 60 WHERE entry=13335;
 
 /*  Crystal of Zin-Malor  */
 UPDATE item_template SET Quality = 2 WHERE entry=13347;
@@ -20515,18 +20353,6 @@ UPDATE item_template SET bonding = 4 WHERE entry=13704;
 
 /*  Runecloth Bandage  */
 UPDATE item_template SET BuyPrice = 2000, SellPrice = 500 WHERE entry=14529;
-
-/*  Gray Kodo  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=15277;
-
-/*  Brown Kodo  */
-UPDATE item_template SET BuyPrice = 100000, SellPrice = 0, RequiredLevel = 40 WHERE entry=15290;
-
-/*  Green Kodo  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=15292;
-
-/*  Teal Kodo  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=15293;
 
 /*  Ironfeather  */
 UPDATE item_template SET Quality = 1, class = 7 WHERE entry=15420;
@@ -20651,89 +20477,14 @@ UPDATE item_template SET BuyPrice = 50000, SellPrice = 12500 WHERE entry=18607;
 /*  Mature Black Dragon Sinew  */
 UPDATE item_template SET bonding = 1 WHERE entry=18705;
 
-/*  Reins of the Swift Frostsaber  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18766;
-
-/*  Reins of the Swift Mistsaber  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18767;
-
-/*  Reins of the Swift Dawnsaber  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18768;
-
-/*  Swift Green Mechanostrider  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18772;
-
-/*  Swift White Mechanostrider  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18773;
-
-/*  Swift Yellow Mechanostrider  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18774;
-
-/*  Swift Palomino  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18776;
-
-/*  Swift Brown Steed  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18777;
-
-/*  Swift White Steed  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18778;
-
-/*  Swift White Ram  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18785;
-
-/*  Swift Brown Ram  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18786;
-
-/*  Swift Gray Ram  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18787;
-
-/*  Swift Blue Raptor  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18788;
-
-/*  Swift Olive Raptor  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18789;
-
-/*  Swift Orange Raptor  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18790;
-
-/*  Purple Skeletal Warhorse  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18791;
-
-/*  Great White Kodo  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18793;
-
-/*  Great Brown Kodo  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18794;
-
-/*  Great Gray Kodo  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18795;
-
-/*  Horn of the Swift Brown Wolf  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18796;
-
-/*  Horn of the Swift Timber Wolf  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18797;
-
-/*  Horn of the Swift Gray Wolf  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18798;
-
 /*  Combat Mana Potion  */
 UPDATE item_template SET BuyPrice = 1100, SellPrice = 275 WHERE entry=18841;
-
-/*  Reins of the Swift Stormsaber  */
-UPDATE item_template SET BuyPrice = 1000000, SellPrice = 0, RequiredLevel = 60 WHERE entry=18902;
 
 /*  Turtle Egg (Loggerhead)  */
 UPDATE item_template SET BuyPrice = 4000 WHERE entry=18964;
 
 /*  Essence of the Firelord  */
 UPDATE item_template SET Quality = 5 WHERE entry=19017;
-
-/*  Horn of the Frostwolf Howler  */
-UPDATE item_template SET BuyPrice = 100000, RequiredLevel = 60 WHERE entry=19029;
-
-/*  Stormpike Battle Charger  */
-UPDATE item_template SET BuyPrice = 100000, RequiredLevel = 60 WHERE entry=19030;
 
 /*  Stormpike Battle Standard  */
 UPDATE item_template SET BuyPrice = 50000, SellPrice = 12500 WHERE entry=19045;
@@ -20759,12 +20510,6 @@ UPDATE item_template SET BuyPrice = 350000, SellPrice = 87500 WHERE entry=19319;
 /*  Gnoll Skin Bandolier  */
 UPDATE item_template SET BuyPrice = 350000, SellPrice = 87500 WHERE entry=19320;
 
-/*  Swift Razzashi Raptor  */
-UPDATE item_template SET RequiredLevel = 60 WHERE entry=19872;
-
-/*  Swift Zulian Tiger  */
-UPDATE item_template SET RequiredLevel = 60 WHERE entry=19902;
-
 /*  Zandalar Signet of Mojo  */
 UPDATE item_template SET RequiredLevel = 0 WHERE entry=20076;
 
@@ -20773,9 +20518,6 @@ UPDATE item_template SET RequiredLevel = 0 WHERE entry=20077;
 
 /*  Zandalar Signet of Serenity  */
 UPDATE item_template SET RequiredLevel = 0 WHERE entry=20078;
-
-/*  Foror's Fabled Steed  */
-UPDATE item_template SET BuyPrice = 10000000, RequiredLevel = 60 WHERE entry=20221;
 
 /*  Defiler's Enriched Ration  */
 UPDATE item_template SET RequiredReputationFaction = 510, RequiredReputationRank = 4 WHERE entry=20222;
@@ -20855,29 +20597,14 @@ UPDATE item_template SET ItemLevel = 60, RequiredLevel = 58 WHERE entry=21161;
 /*  Baby Shark  */
 UPDATE item_template SET bonding = 3, BuyPrice = 6000 WHERE entry=21168;
 
-/*  Black Qiraji Resonating Crystal  */
-UPDATE item_template SET RequiredLevel = 60 WHERE entry=21176;
-
 /*  Fresh Holly  */
 UPDATE item_template SET RequiredLevel = 40 WHERE entry=21212;
 
 /*  Preserved Holly  */
 UPDATE item_template SET RequiredLevel = 40 WHERE entry=21213;
 
-/*  Blue Qiraji Resonating Crystal  */
-UPDATE item_template SET RequiredLevel = 60 WHERE entry=21218;
-
 /*  Tranquil Mechanical Yeti  */
 UPDATE item_template SET bonding = 3 WHERE entry=21277;
-
-/*  Red Qiraji Resonating Crystal  */
-UPDATE item_template SET RequiredLevel = 60 WHERE entry=21321;
-
-/*  Green Qiraji Resonating Crystal  */
-UPDATE item_template SET RequiredLevel = 60 WHERE entry=21323;
-
-/*  Yellow Qiraji Resonating Crystal  */
-UPDATE item_template SET RequiredLevel = 60 WHERE entry=21324;
 
 /*  Valentine's Day Card  */
 UPDATE item_template SET bonding = 0 WHERE entry=22059;


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/pull/719

- moving the mount updates from vanilla_item_changes to mounts_and_riding
- updated several of the mount names because they are no longer items in your inventory
these items are no longer whistles, horns or reigns

the idea is that this file will be easy to edit
I also found a list of currently unavailable mounts
not sure yet what to do with those.
