### PR TITLE
correct HP adjustment on player login

### DIFF
--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -73,16 +73,7 @@ void IndividualProgression::CheckHPAdjustments(Player* player) const
         return;
     }
 
-    // Player is still in Vanilla content - give Vanilla health adjustment
-    if (!hasPassedProgression(player, PROGRESSION_PRE_TBC) || (!hasPassedProgression(player, PROGRESSION_PRE_TBC) && (player->GetLevel() <= IP_LEVEL_VANILLA)))
-    {
-        player->SetMaxHealth(player->GetMaxHealth() * vanillaHealthAdjustment);
-    }
-    // Player is in TBC content - give TBC health adjustment
-    else if (!hasPassedProgression(player, PROGRESSION_TBC_TIER_5) || (!hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (player->GetLevel() <= IP_LEVEL_TBC)))
-    {
-        player->SetMaxHealth(player->GetMaxHealth() * tbcHealthAdjustment);
-    }
+    player->SetMaxHealth(player->GetMaxHealth()); // just to trigger OnPlayerAfterUpdateMaxHealth
 }
 
 void IndividualProgression::ApplyGearStatsTuning(Player* player, float& computedAdjustment, ItemTemplate const* item) const


### PR DESCRIPTION
this update is just so hp adjustment on login is the same as after un-equiping gear with stamina.

the HP adjustment config setting is very confusing and totally not what you would expect.

you would expect the difference between
IndividualProgression.VanillaHealthAdjustment = 1
and 
IndividualProgression.VanillaHealthAdjustment = 0.5
to be 50% health reduction.

but it's not. not even close.
it's closer to a 10% health reduction.

but tbh I don't really care
the health adjustment is much less important than the power and healing reduction.
so it's whatever to me.

I don't even know what the adjustment is based on
I have no proof for it needing any adjustment.
that's also why the default config setting is now 1. no adjustment.