### PR TITLE
fix SendZoneText compile error

### DIFF
--- a/src/vanillaScripts/aq_scripts.cpp
+++ b/src/vanillaScripts/aq_scripts.cpp
@@ -173,7 +173,7 @@ public:
                 return;
 
             if (announce)
-                sWorldSessionMgr->SendZoneText(GLOBAL_TEXT_CHAMPION, player->GetName().c_str());
+                player->GetMap()->SendZoneText(GLOBAL_TEXT_CHAMPION, player->GetName().c_str());
 
             eventTimer += 1000;
             eventStage = STAGE_OPEN_GATES;


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/774

AC decided to move SendZoneText from WorldSessionMgr.cpp to Map.cpp
this produced an error for IP.

this should fix it.