### PR TITLE
Correct quest completion log text for The Cudgel of Kar'desh

### DIFF
--- a/data/sql/world/base/dungeon_ssc.sql
+++ b/data/sql/world/base/dungeon_ssc.sql
@@ -10,3 +10,6 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 21212) AND (`Item` IN (34062));
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
     (21212, 34062, 34062, 100, 0, 1, 3, 2, 2, 'Lady Vashj - (ReferenceTable)');
+
+/* Correct quest log text for SSC attunement quest "The Cudgel of Kar'desh" */
+UPDATE `quest_template` SET `QuestCompletionLog` = 'Return to Skar\'this the Heretic in the heroic Slave Pens of Coilfang Reservoir.' WHERE `ID` = 10901;


### PR DESCRIPTION
The SSC attunement quest had an incorrect entry directing the player to turn in the quest in the Alterac Mountains when it should have been Heroic Slave Pens.