### PR TITLE
level 80s couldn't walk into Onyxia's Lair

### DIFF
--- a/src/vanillaScripts/instance_onyxias_lair.cpp
+++ b/src/vanillaScripts/instance_onyxias_lair.cpp
@@ -155,15 +155,19 @@ public:
             player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
             player->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);
         }
+	    else if (player->GetLevel() == IP_LEVEL_WOTLK && (player->HasItemCount(ITEM_DRAKEFIRE_AMULET) ||  isExcludedFromProgression(player)))
+        {
+            player->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);
+        }
         else if (player->GetLevel() > IP_LEVEL_TBC && player->GetLevel() < IP_LEVEL_WOTLK)
         {
             handler.PSendSysMessage("Your level is too high to enter this version of Onyxia\'s Lair.");
         }
         else if (!player->HasItemCount(ITEM_DRAKEFIRE_AMULET))
         {
-            handler.PSendSysMessage("You must have the Drakefire Amulet in your inventory to enter this version of Onyxia\'s Lair.");
+            handler.PSendSysMessage("You must have the Drakefire Amulet in your inventory to enter Onyxia\'s Lair.");
         }	
-        else if (progressionLevel > PROGRESSION_TBC_TIER_4)
+        else if (player->GetLevel() <= IP_LEVEL_TBC && progressionLevel > PROGRESSION_TBC_TIER_4)
         {
             handler.PSendSysMessage("Your progression level is too high to enter this version of Onyxia\'s Lair.");
         }	


### PR DESCRIPTION
still issues remain

I noticed someone having issues walking into the WotLK version of Onyxia at level 80.
The entrance did not teleport you inside.

You could still do the raid if you teleported inside with the `.tele onyxia` command.
but of course it should also be possible to simply walk in.