### PR TITLE
Remove Previous Gear Tuning

### DIFF
--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -103,18 +103,6 @@ IndividualProgression.TBCHealthAdjustment = 1
 #
 IndividualProgression.QuestXPFix = 1
 
-# IndividualProgression.PreviousGearTuning
-#
-#        Description: Reduces the power of previous expansion end-game gear when entering the next expansion for leveling.
-#                     This resolves a balancing problem where players would not get any useful gear until near the end of the leveling experience,
-#                     as well as overpowering the leveling content. This is particularly true in TBC leveling due to the strength of Naxx 40 gear.
-#                     Set to 0 (0% adjustment) to disable
-#
-#        Default:     0 - Disabled
-#                  0.01 - 1% reduced health and damage per previous expansion epic
-#
-IndividualProgression.PreviousGearTuning = 0
-
 # IndividualProgression.RequireNaxxStrathEntrance
 #
 #        Description: If enabled, this will require players to first enter Naxx 40 through the original beta entrance in the back of Stratholme,

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -14,7 +14,10 @@ IndividualProgression* IndividualProgression::instance()
 bool IndividualProgression::hasPassedProgression(Player* player, ProgressionState state) const
 {
     if (progressionLimit && state >= progressionLimit)
+	{
         return false;
+	}
+	
     return player->GetPlayerSetting("mod-individual-progression", SETTING_PROGRESSION_STATE).value >= state;
 }
 
@@ -26,7 +29,10 @@ bool IndividualProgression::isBeforeProgression(Player* player, ProgressionState
 void IndividualProgression::UpdateProgressionState(Player* player, ProgressionState newState) const
 {
     if (progressionLimit && newState > progressionLimit)
+	{
         return;
+	}
+	
     uint8 currentState = player->GetPlayerSetting("mod-individual-progression", SETTING_PROGRESSION_STATE).value;
     if (newState > currentState)
     {
@@ -42,9 +48,10 @@ void IndividualProgression::ForceUpdateProgressionState(Player* player, Progress
 void IndividualProgression::CheckAdjustments(Player* player) const
 {
     if (!enabled)
-    {
+	{
         return;
-    }
+	}
+ 
     if (!hasPassedProgression(player, PROGRESSION_NAXX40) || (!hasPassedProgression(player, PROGRESSION_NAXX40) && (player->GetLevel() <= IP_LEVEL_VANILLA)))
     {
         AdjustVanillaStats(player);
@@ -53,14 +60,10 @@ void IndividualProgression::CheckAdjustments(Player* player) const
     {
         AdjustTBCStats(player);
     }
-    else
-    {
-        AdjustWotLKStats(player);
-    }
+	
     if (player->getClass() == CLASS_HUNTER)
     {
-        // Remove the 15% built-in ranged haste that was added to hunters in WotLK
-        // This lets us add haste spells back to quivers
+        // Remove the 15% built-in ranged haste that was added to hunters in WotLK - This lets us add haste spells back to quivers
         player->RemoveAura(RANGED_HASTE_SPELL);
         player->CastSpell(player, RANGED_HASTE_SPELL, false);
     }	
@@ -68,35 +71,14 @@ void IndividualProgression::CheckAdjustments(Player* player) const
 
 void IndividualProgression::CheckHPAdjustments(Player* player) const
 {
-    if (!enabled)
-    {
+    if (vanillaHealthAdjustment == 1)
+	{
         return;
-    }
+	}
 
     player->SetMaxHealth(player->GetMaxHealth()); // just to trigger OnPlayerAfterUpdateMaxHealth
 }
 
-void IndividualProgression::ApplyGearStatsTuning(Player* player, float& computedAdjustment, ItemTemplate const* item) const
-{
-    if (item->Quality != ITEM_QUALITY_EPIC) // Non-endgame gear is okay
-        return;
-    if ((hasPassedProgression(player, PROGRESSION_NAXX40) && (item->RequiredLevel <= IP_LEVEL_VANILLA)) ||
-        (hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (item->RequiredLevel <= IP_LEVEL_TBC)))
-    {
-        computedAdjustment -= (100.0f * previousGearTuning);
-    }
-}
-
-void IndividualProgression::ComputeGearTuning(Player* player, float& computedAdjustment, ItemTemplate const* item) const
-{
-    if (item->Quality != ITEM_QUALITY_EPIC) // Non-endgame gear is okay
-        return;
-    if ((hasPassedProgression(player, PROGRESSION_NAXX40) && (item->RequiredLevel <= IP_LEVEL_VANILLA)) ||
-        (hasPassedProgression(player, PROGRESSION_TBC_TIER_5) && (item->RequiredLevel <= IP_LEVEL_TBC)))
-    {
-        computedAdjustment += previousGearTuning;
-    }
-}
 
 void IndividualProgression::AdjustVanillaStats(Player* player) const
 {
@@ -104,50 +86,20 @@ void IndividualProgression::AdjustVanillaStats(Player* player) const
     float adjustmentApplyPercent = (player->GetLevel() - 10.0f) / 50.0f;
     float computedAdjustment = player->GetLevel() > 10 ? (adjustmentValue * adjustmentApplyPercent) : 0;
 
-    float adjustmentHealingValue = -100.0f * (1.0f - vanillaHealingAdjustment);
-    float adjustmentHealingApplyPercent = (player->GetLevel() - 10.0f) / 50.0f;
-    float computedHealingAdjustment = player->GetLevel() > 10 ? (adjustmentHealingValue * adjustmentHealingApplyPercent) : 0;
-
-    AdjustStats(player, computedAdjustment, computedHealingAdjustment);
+	AdjustStats(player, computedAdjustment);
 }
 
 void IndividualProgression::AdjustTBCStats(Player* player) const
 {
-    float adjustmentValue = -100.0f * (1.0f - tbcPowerAdjustment);
-    float adjustmentApplyPercent = 1;
-    float computedAdjustment = player->GetLevel() > 10 ? (adjustmentValue * adjustmentApplyPercent) : 0;
+    float computedAdjustment = -100.0f * (1.0f - tbcPowerAdjustment);
 
-    float adjustmentHealingValue = -100.0f * (1.0f - tbcHealingAdjustment);
-    float adjustmentHealingApplyPercent = 1;
-    float computedHealingAdjustment = player->GetLevel() > 10 ? (adjustmentHealingValue * adjustmentHealingApplyPercent) : 0;
-
-    for (uint8 i = EQUIPMENT_SLOT_START; i < EQUIPMENT_SLOT_END; ++i)
-    {
-        if (Item *item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
-        {
-            ApplyGearStatsTuning(player, computedAdjustment, item->GetTemplate());
-            ApplyGearStatsTuning(player, computedHealingAdjustment, item->GetTemplate());
-        }
-    }
-    AdjustStats(player, computedAdjustment, computedHealingAdjustment);
+	AdjustStats(player, computedAdjustment);
 }
 
-void IndividualProgression::AdjustWotLKStats(Player* player) const
-{
-    float computedAdjustment = 0;
-    for (uint8 i = EQUIPMENT_SLOT_START; i < EQUIPMENT_SLOT_END; ++i)
-    {
-        if (Item* item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
-            ApplyGearStatsTuning(player, computedAdjustment, item->GetTemplate());
-    }
-    AdjustStats(player, computedAdjustment, computedAdjustment);
-}
-
-void IndividualProgression::AdjustStats(Player* player, float computedAdjustment, float /*computedHealingAdjustment*/)
+void IndividualProgression::AdjustStats(Player* player, float computedAdjustment)
 {
     // int32 bp0 = 0; // This would be the damage taken adjustment value, but we are already adjusting health
     auto bp1 = static_cast<int32>(computedAdjustment);
-    // auto bp1Healing = static_cast<int32>(computedHealingAdjustment);
 
     player->RemoveAura(ABSORB_SPELL);
     player->CastCustomSpell(player, ABSORB_SPELL, &bp1, nullptr, nullptr, false);
@@ -170,8 +122,7 @@ uint8 IndividualProgression::GetAccountProgression(uint32 accountId)
     uint8 progressionLevel = 0;
     if (!sWorld->getBoolConfig(CONFIG_PLAYER_SETTINGS_ENABLED))
     {
-        // Prevent crash if player settings are not enabled
-        return 0;
+        return 0; // Prevent crash if player settings are not enabled
     }
     QueryResult result = CharacterDatabase.Query("SELECT `data` FROM `character_settings` WHERE `source` = 'mod-individual-progression' AND `guid` IN (SELECT `guid` FROM `characters` WHERE `account` = {});", accountId);
     if (result)
@@ -423,7 +374,6 @@ private:
         sIndividualProgression->enforceGroupRules = sConfigMgr->GetOption<bool>("IndividualProgression.EnforceGroupRules", true);
         sIndividualProgression->fishingFix = sConfigMgr->GetOption<bool>("IndividualProgression.FishingFix", true);
         sIndividualProgression->simpleConfigOverride = sConfigMgr->GetOption<bool>("IndividualProgression.SimpleConfigOverride", true);
-        sIndividualProgression->previousGearTuning = sConfigMgr->GetOption<float>("IndividualProgression.PreviousGearTuning", 0);
         sIndividualProgression->progressionLimit = sConfigMgr->GetOption<uint8>("IndividualProgression.ProgressionLimit", 0);
         sIndividualProgression->startingProgression = sConfigMgr->GetOption<uint8>("IndividualProgression.StartingProgression", 0);
         sIndividualProgression->questMoneyAtLevelCap = sConfigMgr->GetOption<bool>("IndividualProgression.QuestMoneyAtLevelCap", true);

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -250,7 +250,7 @@ public:
 
     std::map<uint32, uint8> customProgressionMap;
     questXpMapType questXpMap;
-    float vanillaPowerAdjustment, vanillaHealthAdjustment, tbcPowerAdjustment, tbcHealthAdjustment, vanillaHealingAdjustment, tbcHealingAdjustment, previousGearTuning;
+    float vanillaPowerAdjustment, vanillaHealthAdjustment, tbcPowerAdjustment, tbcHealthAdjustment, vanillaHealingAdjustment, tbcHealingAdjustment;
     bool enabled, questXpFix, hunterPetLevelFix, enforceGroupRules, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, requireNaxxStrath, pvpGearRequirements, DisableRDF, excludeAccounts;
     int progressionLimit, startingProgression, tbcRacesProgressionLevel, deathKnightProgressionLevel, deathKnightStartingProgression;
     std::string excludedAccountsRegex;
@@ -262,7 +262,6 @@ public:
     void CheckAdjustments(Player* player) const;
     void CheckHPAdjustments(Player* player) const;
     void ApplyGearStatsTuning(Player* player, float& computedAdjustment, ItemTemplate const* item) const;
-    void ComputeGearTuning(Player* player, float& computedAdjustment, ItemTemplate const* item) const;
     void AdjustVanillaStats(Player* player) const;
     void AdjustTBCStats(Player* player) const;
     void AdjustWotLKStats(Player* player) const;
@@ -271,7 +270,7 @@ public:
     void UpdateProgressionQuests(Player* player);
     void checkKillProgression(Player* player, Creature* killed);
     static void LoadCustomProgressionEntries(const std::string& customProgressionString);
-    static void AdjustStats(Player* player, float computedAdjustment, float computedHealingAdjustment);
+	static void AdjustStats(Player* player, float computedAdjustment);
     static float ComputeVanillaAdjustment(uint8 playerLevel, float configAdjustmentValue);
     static uint8 GetAccountProgression(uint32 accountId);
 };


### PR DESCRIPTION
- removed the custom setting PreviousGearTuning that made very little sense.
let players enjoy their hard earned Naxx40 gear. Nobody wants to replace it with TBC greens.
