### PR TITLE
Group Invite Restrictions

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -323,7 +323,7 @@ public:
 				
         if (sIndividualProgression->enforceGroupRules) // enforceGroupRules enabled
         {
-            if (!isExcludedFromProgression(player)) // player is a normal account
+            if (!isExcludedFromProgression(player)) // player has a normal account
             {
                 if (isExcludedFromProgression(otherPlayer)) // RNDbot
                 {
@@ -369,7 +369,7 @@ public:
                     return (currentState == otherPlayerState);
                 }
             }
-            else // player is on an excluded account
+            else // player has an excluded account
             {
                 if (isExcludedFromProgression(otherPlayer)) // RNDbot
                 {


### PR DESCRIPTION
super confusing
don't even want to explain it.

what it comes down to is:
- with enforceGroupRules set to 1 you can only invite bots and players within your expansion's level range.
- with enforceGroupRules set to 0 you can invite anyone and everyone.

reason for doing all of this:
it was required before to set enforceGroupRules  to 0 to be able to invite RNDbots.
now that's no longer required.