### PR TITLE
Modify OnPeriodic for 10-man heroic difficulty

### DIFF
--- a/src/naxx40Scripts/boss_maexxna_40.cpp
+++ b/src/naxx40Scripts/boss_maexxna_40.cpp
@@ -347,7 +347,7 @@ public:
 
     void OnPeriodic(AuraEffect const* aurEff)
     {
-        if (GetCaster() && GetCaster()->GetMap() && GetCaster()->GetMap()->GetDifficulty() == RAID_DIFFICULTY_10MAN_HEROIC)
+        if (GetCaster()->GetMap()->GetDifficulty() == RAID_DIFFICULTY_10MAN_HEROIC)
         {
             AuraEffect* eff = const_cast<AuraEffect*>(aurEff);
             eff->SetAmount(static_cast<int32>(urand(657, 843)));


### PR DESCRIPTION
Adjust the OnPeriodic method to set a blizzlike amount for the aura effect based on the raid difficulty (40 man).

Source:
https://www.wowhead.com/classic/spell=28622/web-wrap