### PR TITLE
Improve EVENT_SLIME_SPRAY logic for raid difficulties

### DIFF
--- a/src/naxx40Scripts/boss_grobbulus_40.cpp
+++ b/src/naxx40Scripts/boss_grobbulus_40.cpp
@@ -171,7 +171,7 @@ public:
                     Talk(EMOTE_SLIME);
                     if (Unit* target = me->GetVictim())
                     {
-                        uint16 bp0 = urand(3200, 4800);
+                        int32 bp0 = urand(3200, 4800);
                         me->CastCustomSpell(target, SPELL_SLIME_SPRAY_10, &bp0, nullptr, nullptr, false);
                     }                    
                     events.Repeat(20s);


### PR DESCRIPTION
Refactor slime spray event handling for 40m for vanilla damage.

Sources:
https://vanilla-twinhead.twinstar.cz/?spell=28157
https://www.wowhead.com/classic/spell=28157/slime-spray

This source says 3600 to 4800 though. But I've found wowpedia tends to inflate numbers. Depending on when the article was (re)written, it could be reflecting Season of Mastery or Season of Discovery numbers instead: https://wowpedia.fandom.com/wiki/Grobbulus_(Classic)