### PR TITLE
Save Horsemen Portal Between Sessions

### DIFF
--- a/src/naxx40Scripts/instance_naxxramas.cpp
+++ b/src/naxx40Scripts/instance_naxxramas.cpp
@@ -607,10 +607,15 @@ public:
                     {
                         _events.RescheduleEvent(EVENT_AND_THEY_WOULD_ALL_GO_DOWN_TOGETHER, 15s);
 
-                        if (horsemanKilled != HorsemanCount)
-                            return false;
+                        if (horsemanKilled == 0)
+                        {
+                            ActivateWingPortal(DATA_HORSEMAN_PORTAL);
+                            break; 
+                        }
 
-                        // all horsemans are killed
+                        if (horsemanKilled != HorsemanCount)
+                            return false; 
+
                         if (Creature* cr = GetCreature(DATA_BARON_RIVENDARE_BOSS))
                             cr->CastSpell(cr, SPELL_THE_FOUR_HORSEMAN_CREDIT, true);
 


### PR DESCRIPTION
After a server restart, if a player finished the Four Horsemen encounter, the Four Horsemen stayed dead, but the instance still lost its “DONE” state. The problem was that the script checked for all four bosses being dead at the exact moment it reloaded the encounter state. Sometimes the instance state is restored before the creatures’ dead flags are fully reapplied, so the code saw fewer than four dead bosses and rejected the DONE state. That caused the Horsemen portal to go dark and blocked progression to Sapphiron.

The fix allows the DONE state to be accepted during load, even if the dead creatures haven’t finished restoring yet. It still only marks the encounter as DONE during the actual fight when all four die together. This change only affects reloading.