### PR TITLE
Fix SerpentshrineCavern.RequireAllBosses

### DIFF
--- a/src/tbcScripts/serpentshrine_cavern.cpp
+++ b/src/tbcScripts/serpentshrine_cavern.cpp
@@ -12,8 +12,7 @@ enum SSCMisc
 {
     GO_LADY_VASHJ_BRIDGE_CONSOLE = 184568,
     MAP_SSC                      = 548,
-    DATA_LURKER                  = 1,
-    DATA_VASHJ                   = 6
+    DATA_VASHJ                   = 5
 };
 
 class GlobalSerpentshrineScript : public GlobalScript
@@ -27,15 +26,9 @@ public:
         {
             if (InstanceScript* instance = instanceMap->GetInstanceScript())
             {
-                uint32 bossCount = instance->GetEncounterCount() - 3;
-                for (uint8 id = 0; id <= bossCount; ++id)
+                for (uint8 id = 0; id <= 4; ++id) // check boss data id 0-4
                 {
                     if (id == bossId && newState == DONE)
-                    {
-                        continue;
-                    }
-
-                    if (id == DATA_LURKER)
                     {
                         continue;
                     }
@@ -62,16 +55,6 @@ public:
                     go->SetGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
                 }
             }
-        }
-    }
-
-    void OnLoadSpellCustomAttr(SpellInfo* spellInfo) override
-    {
-        switch (spellInfo->Id)
-        {
-            case 38236: // Tidalvess - Spawn Spitfire Totem
-                spellInfo->Effects[EFFECT_0].BasePoints = 25000;
-                break;
         }
     }
 


### PR DESCRIPTION
As discussed with Grimfeather, enabling SerpentshrineCavern.RequireAllBosses would erroneously permanently disable the console to operate the bridge leading to Lady Vashj, instead of making its operation contingent on all other SSC bosses being defeated (as indicated by the config comments). This was due to an incorrect integer being assigned to Vashj, making a required check for Vashj's existence always fail.

The existing code also appears to count the SSC bosses incorrectly, therefore excluding Morogrim Tidewalker, and further hardwires an exclusion for The Lurker Below for unknown reasons. Since all five pre-Vashj SSC bosses were required to be killed to access Vashj prior to 2.4 (and none were required thereafter), there should be no exclusions.

I've tested Grimfeather's proposed fix, which is the subject of this PR, and it works fine--now, all five bosses must be killed, and doing so does allow the console to be operated.

I also deleted the block for setting the Spitfire Totem's HP since AC already has the correct HP.