### PR TITLE
isAllowedToCastSpell Wishmaster Adjustments

### DIFF
--- a/src/naxx40Scripts/custom_spells_40.cpp
+++ b/src/naxx40Scripts/custom_spells_40.cpp
@@ -452,7 +452,7 @@ class spell_loatheb_corrupted_mind_40 : public SpellScript
                 {
                     case CLASS_PRIEST:
                         spell_id = 29194; // priests should be getting 29185, but it triggers on dmg effects as well
-                        break;			
+                        break;
                     case CLASS_DRUID:
                         spell_id = 29194;
                         break;


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/pull/851

taking Wishmaster's advice
this makes the code more consistent

I've also noticed that AzerothCore has the same issue as VMangos
the priest's version of Corrupted Mind also triggers on damage spells. it shouldn't.
so using the druid's version of Corrupted Mind instead for priests.

a `thank you` to Wishmaster for helping me out.