### PR TITLE
fix Cadaverous Worm - Dire Maul West

### DIFF
--- a/data/sql/world/base/dungeon_dire_maul.sql
+++ b/data/sql/world/base/dungeon_dire_maul.sql
@@ -391,6 +391,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 -- Cadaverous Worm
 DELETE FROM `creature_loot_template` WHERE `entry` = 14370;
+UPDATE `creature_template` SET `lootid` = 0 WHERE `entry` = 14370;
 UPDATE `creature_template_model` SET `DisplayScale` = 0.25  WHERE `CreatureID` = 14370;
 
 -- fix waypoints


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/853

I checked VMangos
creature should have no loot and display scale should be 0.25