### PR TITLE
TBC - Shattrath phasing

### DIFF
--- a/data/sql/world/base/ipp_aware_npcs.sql
+++ b/data/sql/world/base/ipp_aware_npcs.sql
@@ -63,8 +63,9 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc_t4' WHERE `entry` IN 
 -- Phasing TBC vendors and trainers - Copies are added to replace them until TBC T4.
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc_t4' WHERE `entry` IN (18754, 18771, 19187, 21087);
 
--- TBC, Terrace of Light, phasing Shattered Sun offensive NPCs
-UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `id1` IN (24932, 25115, 25142, 25153, 25155);
+-- TBC, phasing Shattered Sun offensive NPCs in Shattrath
+UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `id1` IN (17076, 19475, 24932, 24938, 25115, 25134, 25135, 25136, 25137, 25138, 25141, 25142, 25143, 25153, 25155);
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc_t5' WHERE `entry` IN (18594, 25167, 27666, 27667); 
 
 -- TBC, Terrace of Light, phasing T5 game objects
 UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_tbc_t4' WHERE `entry` IN 
@@ -72,10 +73,6 @@ UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_tbc_t4' WHERE `entr
  187345,  -- Sunwell Plateau model
  187356,  -- Shattered Sun Banner
  187357); -- Shattered Sun Banner
-
--- Phasing for General Tiras'alan and Dathris Sunstriker - prevent early access to Isle of Quel'Danas
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc_t5' WHERE `entry` IN (18594, 25167, 27666, 27667);
-UPDATE `creature` SET `ScriptName` = 'npc_ipp_tbc_t5' WHERE `guid` IN (3413); -- Lady Liadrin (entry 17076)
 
 -- Dragons of Nightmare
 UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `id1` IN (14887, 14888, 14889, 14890);


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/859

phasing all the Shattered Sun npcs in Shattrath until TBC tier 5.

still looking into if something should be there to fill the now empty spaces.

edit:
most videos on YT are from late TBC or private servers I can't trust.
but I found this: https://www.youtube.com/watch?v=PsG4-fkrBkU
it shows it's all empty. nothing was there before the Shattered Sun npcs.