### PR TITLE
chore: Added sql optional file syntax to sql folder .gitignore to simplify usage.

### DIFF
--- a/data/sql/world/base/.gitignore
+++ b/data/sql/world/base/.gitignore
@@ -1,0 +1,1 @@
+zz_optional*

--- a/data/sql/world/updates/.gitignore
+++ b/data/sql/world/updates/.gitignore
@@ -1,0 +1,1 @@
+zz_optional*


### PR DESCRIPTION
# Description

This is a very small PR that adds all files matching the pattern `zz_optional*` to allow users to put SQL optional files within the `sql/world/base` and `sql/world/update` folders and not have them being versioned in Git.