### PR TITLE
fix Son of Hakkar - Poisonous Cloud

### DIFF
--- a/data/sql/world/base/dungeon_zulgurub.sql
+++ b/data/sql/world/base/dungeon_zulgurub.sql
@@ -55,7 +55,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 --
 (11357, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 12787, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Son of Hakkar - On Respawn - Cast Thrash Proc'),
 (11357, 0, 1, 0, 0, 0, 100, 0, 4000, 10000, 4000, 10000, 0, 0, 11, 16790, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Son of Hakkar - In Combat - Cast Knockdown'),
-(11357, 0, 2, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 24320, 2, 7, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Son of Hakkar - On Just Died - Cast Poisonous Blood'), -- doesn't work!
+(11357, 0, 2, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 14989, 3, 10000, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Son of Hakkar - On Just Died - Summon Poisonous Cloud'),
 (11359, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Soulflayer - On Respawn - Cast Thrash Proc'),
 (11359, 0, 1, 0, 0, 0, 100, 0, 7000, 7000, 7000, 8000, 0, 0, 11, 22678, 0, 0, 0, 0, 0, 5, 20, 0, 0, 0, 0, 0, 0, 0,      'Soulflayer - Within 0-10 Range - Cast Fear'),
 (11359, 0, 2, 0, 0, 0, 100, 0, 0, 0, 2000, 3000, 0, 0, 11, 24619, 256, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Soulflayer - In Combat - Cast Soul Tap'),


### PR DESCRIPTION
I found a creature in AQ20 that leaves a disease cloud on death.
I compared this to the smart_script for Poisonous Blood.
```
(11357, 0, 0, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 24320, 2, 7, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Son of Hakkar - On Just Died - Cast Poisonous Blood'); -- doesn't work
(15333, 0, 0, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 17742, 2, 7, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Silicate Feeder - On Just Died - Cast Cloud of Disease'); -- works
```
They look the same to me.
But looking at the spells, 24320 and 17742, I found out 24320 is supposed to trigger a server side script. Which is missing.


After searching some more, I found this:
https://github.com/azerothcore/azerothcore-wotlk/blob/74195db21b12263417fad888a3d1dee9ab9ce8d3/data/sql/old/db_world/7.x/2022_06_16_07.sql#L6

At some point instead of casting a spell, the Son of Hakkar summoned a creature called `Poisonous Cloud`.
This does work. So I'm switching back to this.