### PR TITLE
fix epic loot drop chances for trash in The Eye and SSC

### DIFF
--- a/data/sql/world/base/dungeon_eye_ssc.sql
+++ b/data/sql/world/base/dungeon_eye_ssc.sql
@@ -175,7 +175,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (21217, 36015, 36015, 100, 0, 1, 1, 1, 1, 'The Lurker Below - ReferenceTable - Epic Items (Group 2)'),
 (21217, 36016, 36016, 100, 0, 1, 1, 1, 1, 'The Lurker Below - ReferenceTable - Epic Items (Group 3)');
 
-
+-- hide Badge of Justice drops until TBC tier 5
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceEntry` = 29434 AND `ConditionTypeOrReference` = 8 AND `SourceGroup` IN (18805, 19516, 19622, 21212, 21213, 21214, 21215, 21216, 21217);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
 `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 


### PR DESCRIPTION
data taken from cMangos

- chance for epic loot was incorrectly set to 10%!!! for all trash mobs in The Eye
- now using a reference loot table for the epic loot drops from trash in SSC.
