### PR TITLE
update excluded account to correct progression level

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -47,7 +47,18 @@ public:
 
 		if (sIndividualProgression->isExcludedFromProgression(player))
         {
-            sIndividualProgression->UpdateProgressionState(player, static_cast<ProgressionState>(0));
+            if (player->GetLevel() <= IP_LEVEL_VANILLA)
+            {
+                sIndividualProgression->UpdateProgressionState(player, static_cast<ProgressionState>(0));
+            }
+            else if (player->GetLevel() <= IP_LEVEL_TBC)
+            {
+                sIndividualProgression->UpdateProgressionState(player, static_cast<ProgressionState>(8));
+            }
+            else // (player->GetLevel() <= IP_LEVEL_WOTLK)
+            {
+                sIndividualProgression->UpdateProgressionState(player, static_cast<ProgressionState>(13));
+            }
         }
 
         sIndividualProgression->CheckAdjustments(player);


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/901

excluded account now get a progression level based on their level when they log in.

this is important in case the VANILLA/TBC damage/healing/health modifiers are used.