### PR TITLE
Intermittent auras fix

### DIFF
--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -90,10 +90,10 @@ void IndividualProgression::AdjustStats(Player* player, float computedPowerAdjus
 	auto bp2 = static_cast<int32>(computedHealthAdjustment);
 
     player->RemoveAura(ABSORB_SPELL);
-    player->CastCustomSpell(player, ABSORB_SPELL, &bp1, nullptr, nullptr, false);
+    player->CastCustomSpell(player, ABSORB_SPELL, &bp1, nullptr, nullptr, true);
 
 	player->RemoveAura(HP_AURA_SPELL);
-    player->CastCustomSpell(player, HP_AURA_SPELL, &bp2, nullptr, nullptr, false);
+    player->CastCustomSpell(player, HP_AURA_SPELL, &bp2, nullptr, nullptr, true);
 }
 
 float IndividualProgression::ComputeVanillaAdjustment(uint8 playerLevel, float configAdjustmentValue)


### PR DESCRIPTION
Set spell triggered flag to true - bypassed server-client handshake and forces the aura to be applied. This avoids situations where the HP and POWER reduction auras would sometimes fail to apply when equipping gear (potentially resulting in suddenly having significantly more health than intended).

Solves issue #910 