### PR TITLE
update respawn time footlockers

### DIFF
--- a/data/sql/world/base/professions.sql
+++ b/data/sql/world/base/professions.sql
@@ -35,7 +35,10 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES
 (19184, -350000), -- Mildred Fletcher, Shattrath
 (19478, -350000), -- Fera Palerunner, Blades Edge Mountains
 (22477, -350000); -- Anchorite Ensham, Terokkar Forest
-   
+
+-- lockpicking
+UPDATE `gameobject` SET `spawntimesecs` = 900 WHERE `id` IN (179488, 179486); -- change respawn time of footlockers from 2 hours to 15 minutes
+
 -- Make Brilliant Glass craft only available once WotLK is reached, to avoid early access to epic TBC gems
 UPDATE `npc_trainer` SET `ReqLevel` = 71 WHERE `SpellID` = 47280;
 


### PR DESCRIPTION
related to: https://github.com/chromiecraft/chromiecraft/issues/8020

respawn time was set to 2 hours
it's not 100% clear what the respawn should be

vMangos uses 5 minutes.
people in the related PR linked above say it should be 15 minutes

I'll set it to 15 minutes for now.
If someone can provide proof without a doubt that it should be something else,
then I'll simply change it again later.