### PR TITLE
Corrections to tbc_item_changes

### DIFF
--- a/data/sql/world/base/tbc_item_changes.sql
+++ b/data/sql/world/base/tbc_item_changes.sql
@@ -839,7 +839,7 @@ UPDATE `item_template` SET `stat_type3` = 21 WHERE entry=28030;
 UPDATE `item_template` SET `dmg_min1` = 100.28, `dmg_max1` = 187.28 WHERE entry=28033;
 
 /*  Hourglass of the Unraveller  */
-UPDATE `item_template` SET `spellid_1` = 33648 WHERE entry=28034;
+UPDATE `item_template` SET `spellid_1` = 60066 WHERE entry=28034;
 
 /*  Vengeance of the Illidari  */
 UPDATE `item_template` SET `stat_type1` = 21 WHERE entry=28040;
@@ -878,7 +878,7 @@ UPDATE `item_template` SET `stat_type3` = 18 WHERE entry=28187;
 UPDATE `item_template` SET `dmg_min1` = 106.28, `dmg_max1` = 196.28, `stat_type3` = 21 WHERE entry=28188;
 
 /*  Scarab of the Infinite Cycle  */
-UPDATE `item_template` SET `spellid_2` = 33953 WHERE entry=28190;
+UPDATE `item_template` SET `spellid_2` = 60061 WHERE entry=28190;
 
 /*  Mana-Etched Vestments  */
 UPDATE `item_template` SET `stat_type3` = 21 WHERE entry=28191;
@@ -5465,6 +5465,9 @@ UPDATE item_template SET bonding = 3 WHERE entry=29958;
 
 /*  Captured Firefly  */
 UPDATE item_template SET bonding = 3 WHERE entry=29960;
+
+/*  Nether Vortex  */
+UPDATE item_template SET bonding = 1 WHERE entry=30183;
 
 /*  Fiery Warhorse's Reins  */
 UPDATE item_template SET RequiredLevel = 70 WHERE entry=30480;


### PR DESCRIPTION
Changes:

1. tbc_item_changes originally modified the proc spells for Hourglass of the Unraveller and Scarab of the Infinite Cycle to use the same spell ID as their original TBC proc spells. That makes sense at face value, but the problem is that the original spell IDs are used for different spells in WotLK. The original spells themselves were given new spell IDs, which are the ones in the AC database. Reverting to the original spell IDs makes both trinkets insanely powerful because they now are triggering WotLK epic trinket procs. I've reverted to using the WotLK spell IDs for both trinkets. Technically, the trinkets can be removed entirely from the file, but that would not fix the issue for anybody who has been using the module.

2. tbc_item_changes also makes Primal Nethers bind on pickup, which they were in TBC until Patch 2.4. It did not do the same thing for Nether Vortexes (essentially the leveled-up version of Primal Nethers), which were also unbound starting in Patch 2.4. There is a broader philosophical discussion to be had regarding approach as I think in general, IP considers patch 2.4 changes to be post-TBC even though they technically aren't (but I get the point, as 2.4 was a significant overhaul to many TBC mechanics and practically like a pre-patch to WotLK). However, in any case, the most nonsensical approach is to have these two items treated differently. I've added Nether Vortexes and made them BoP as well to match Primal Nethers (I am totally fine with unbinding both, and in fact that's what I have on my own build, but I just stuck with what is the existing approach for the PR).