### PR TITLE
block Quel Danas instances until IPP 12

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -587,21 +587,18 @@ public:
 
         if (mapid && mapid == MAP_OUTLAND) // prevent entering Sun's Reach Harbor in Quel'Danas without proper progression
         {
-            if (sIndividualProgression->enabled && !player->IsGameMaster() && !sIndividualProgression->isExcludedFromProgression(player))
+            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_4) && newArea == 4087) // Sun's Reach Harbor
             {
-                if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_4) && newArea == 4087) // Sun's Reach Harbor
-                {
-                    ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_4);
+                ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_4);
 
-                    TeamId teamId = player->GetTeamId(true);
-                    if (teamId == TEAM_ALLIANCE)
-                    {
-                        player->TeleportTo(0, 2270.32f, -5341.56f, 87, 1.34946f); // Light's Hope Chapel
-                    }
-                    else // Horde
-                    {
-                        player->TeleportTo(530, 9373.69f, -7168.46f, 9.17572f, 1.04876f); // Eversong Woods
-                    }
+                TeamId teamId = player->GetTeamId(true);
+                if (teamId == TEAM_ALLIANCE)
+                {
+                    player->TeleportTo(0, 2270.32f, -5341.56f, 87, 1.34946f); // Light's Hope Chapel
+                }
+                else // Horde
+                {
+                    player->TeleportTo(530, 9373.69f, -7168.46f, 9.17572f, 1.04876f); // Eversong Woods
                 }
             }
         }


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/945

it was possible to go the the isle of Quel Danas with a flight master and then enter the instances before IPP 12.

I'm now also blocking access to the instances. so you can't go there with a summon or by using the flight master and walking.

still looking into blocking access to the island completely