### PR TITLE
fix Aldor and Scryers flight masters in Shadowmoon Valley

### DIFF
--- a/data/sql/world/base/zone_shadowmoon_valley.sql
+++ b/data/sql/world/base/zone_shadowmoon_valley.sql
@@ -1,4 +1,4 @@
--- flightmasters at Sanctum of the Stars and Altar of Sha'tar only visible if friendly with Scryers/Aldor
+-- flight masters at Sanctum of the Stars and Altar of Sha'tar only visible if at least friendly with Scryers/Aldor
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 30 AND `ConditionTypeOrReference` = 5 AND `SourceEntry` IN (19581, 21766);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
 `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/989

hiding flight master if not at least friendly with the related faction.
to prevent being able to pick up BOTH flight paths by staying neutral.