### PR TITLE
Give RNDbots access to TBC dungeons

### DIFF
--- a/data/sql/world/base/00_cleanup.sql
+++ b/data/sql/world/base/00_cleanup.sql
@@ -29,6 +29,9 @@ DELETE FROM `creature` WHERE `guid` = 88156 AND `id1` IN (20278); -- Vixton Pinc
 
 /* the following edits are temporary */
 
+-- remove access requirements from database, this is now done with cpp
+DELETE FROM `dungeon_access_requirements` WHERE `dungeon_access_id` IN (15, 16, 32, 46, 47, 64);
+
 -- Make Spice Bread learnable for completion's sake, but only after reaching a level when it will no longer allow skipping early cooking
 -- no longer needed. you can't get Simple Flour during vanilla.
 UPDATE `trainer_spell` SET `ReqSkillRank` = 1 WHERE `SpellID` = 37836;

--- a/data/sql/world/base/dungeon_attunements.sql
+++ b/data/sql/world/base/dungeon_attunements.sql
@@ -1,19 +1,3 @@
-REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (15, 2, 16309, NULL, 2, NULL, 0, NULL);
-REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (16, 2, 16309, NULL, 2, NULL, 0, NULL);
-REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (32, 1, 10445, 'You must complete the quest "The Vials of Eternity" and be level 70 before entering The Battle of Mount Hyjal.', 2, NULL, 0, NULL);
-REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (46, 1, 10901, 'You must complete the quest "The Cudgel of Kar\'desh" and be level 70 before entering Serpentshrine Reservoir.', 2, NULL, 0, NULL);
-REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (47, 2, 31704, 'You must possess The Tempest Key to enter The Eye.', 2, NULL, 0, NULL);
-REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (47, 1, 10888, 'You must complete "The Trial of the Naaru: Magtheridon" to enter The Eye.', 2, NULL, 0, NULL);
-REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (62, 1, 10277, 'You must complete the quest "The Caverns of Time" to enter Old Hillsbrad.', 2, NULL, 0, NULL);
-REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (63, 1, 10277, 'You must complete the quest "The Caverns of Time" to enter Old Hillsbrad.', 2, NULL, 0, NULL);
-
-/* Because you should also be able to enter with the blessed Medallion of Karabor, the quest is checked instead of the item. It's not possible to do a check for item 1 or 2. 
-   This way the requirement_note is still correct, you just don't need the item on you anymore. */
-
-DELETE FROM `dungeon_access_requirements` WHERE `dungeon_access_id` = 64;
-INSERT INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES 
-(64, 1, 10985, 'You must possess the Medallion of Karabor to enter the Black Temple.', 2, NULL, 0, NULL);
-
 /* Maraudon Portal Requirement Script */
 UPDATE `gameobject_template` SET `ScriptName` = 'go_mara_portal' WHERE `entry` = 178404;
 

--- a/data/sql/world/base/dungeon_attunements.sql
+++ b/data/sql/world/base/dungeon_attunements.sql
@@ -2,31 +2,27 @@
 UPDATE `gameobject_template` SET `ScriptName` = 'go_mara_portal' WHERE `entry` = 178404;
 
 /* TBC Attunement Quests - Restore pre-3.0 version */
-DELETE FROM `creature_questender` WHERE `id`=22421 AND `quest`=13431;
-DELETE FROM `creature_questender` WHERE `id`=22421 AND `quest`=10901;
-INSERT INTO `creature_questender` (`id`, `quest`) VALUES (22421, 10901);
 
--- Adds The Mark of Vashj spell to The Cudgel of Kar'desh (cosmetic)
-UPDATE `quest_template` SET `RewardSpell` = 39145 WHERE (`ID` = 10901);
-
-DELETE FROM `creature_queststarter` WHERE `id`=22421 AND `quest`=13431;
-DELETE FROM `creature_queststarter` WHERE `id`=22421 AND `quest`=10901;
+-- The Cudgel of Kar'desh
+DELETE FROM `creature_queststarter` WHERE `id` = 22421 AND `quest` IN (10901, 13431); -- 
 INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (22421, 10901);
 
-DELETE FROM `creature_questender` WHERE `id`=18481 AND `quest`=13430;
+DELETE FROM `creature_questender` WHERE `id` = 22421 AND `quest` IN (10901, 13431);
+INSERT INTO `creature_questender` (`id`, `quest`) VALUES (22421, 10901);
 
-DELETE FROM `creature_queststarter` WHERE `id`=18481 AND `quest`=13430;
-DELETE FROM `creature_queststarter` WHERE `id`=18481 AND `quest`=10888;
+UPDATE `quest_template` SET `RewardSpell` = 39145 WHERE (`ID` = 10901); -- Adds The Mark of Vashj spell to The Cudgel of Kar'desh (cosmetic)
+
+-- Trial of the Naaru: Magtheridon
+DELETE FROM `creature_queststarter` WHERE `id` = 18481 AND `quest` IN (10888, 13430); 
 INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (18481, 10888);
 
-DELETE FROM `disables` WHERE `sourceType` = 1 AND `entry` = 10888;
-DELETE FROM `disables` WHERE `sourceType` = 1 AND `entry` = 10901;
-UPDATE `quest_template` SET `QuestType` = 2 WHERE `ID` = 10901;
-UPDATE `quest_template_addon` SET `NextQuestID` = 10888 WHERE `ID` = 10884;
-UPDATE `quest_template_addon` SET `NextQuestID` = 10888 WHERE `ID` = 10885;
-UPDATE `quest_template_addon` SET `NextQuestID` = 10888 WHERE `ID` = 10886;
+DELETE FROM `creature_questender` WHERE `id` = 18481 AND `quest` = 13430;
 
-/* The Vials of Eternity */
+DELETE FROM `disables` WHERE `sourceType` = 1 AND `entry` IN (10888, 10901);
+UPDATE `quest_template` SET `QuestType` = 2 WHERE `ID` = 10901;
+UPDATE `quest_template_addon` SET `NextQuestID` = 10888 WHERE `ID` IN (10884, 10885, 10886);
+
+-- The Vials of Eternity
 DELETE FROM `creature_questender` WHERE `id` = 19935 AND `quest` = 13432;
 DELETE FROM `creature_queststarter` WHERE `id` = 19935 AND `quest` = 13432;
 REPLACE INTO `creature_queststarter` (`id`, `quest`) VALUES (19935, 10445);
@@ -44,4 +40,3 @@ DELETE FROM `achievement_reward_locale` WHERE `ID` = 432 AND `Locale` = 'frFR';
 
 /* Reward Title Hand of A'dal */
 REPLACE INTO `achievement_reward` (`ID`, `TitleA`, `TitleH`, `ItemID`, `Sender`, `Subject`, `Body`, `MailTemplateID`) VALUES (431, 64, 64, 0, 0, NULL, NULL, 0);
-

--- a/data/sql/world/base/dungeon_onyxia.sql
+++ b/data/sql/world/base/dungeon_onyxia.sql
@@ -1048,13 +1048,18 @@ INSERT INTO `gossip_menu_option` (`menuID`, `optionid`, `OptionIcon`, `OptionTex
 (60045,0,0,'Maybe... What do I do now?',0,1,3,0,0,0,0,NULL,0,0);
 
 DELETE FROM `smart_scripts` WHERE `entryorguid` = 14368 AND `source_type` = 0 AND `id` IN (1, 2);
-insert into `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) values('14368','0','1','0','62','0','100','0','60045','0','0','0','56','18513','1','0','0','0','0','7','0','0','0','0','0','0','0','Lorekeeper Lydros - Giving A Dull and Flat Elven Blade after cliking on last gossip');
-insert into `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) values('14368','0','2','0','62','0','100','0','60045','0','0','0','72','0','0','0','0','0','0','7','0','0','0','0','0','0','0','Lorekeeper Lydros - On Gossip Option 0 Selected - Close Gossip');
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
+`event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, 
+`action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(14368,0,1,0,62,0,100,0,60045,0,0,0,56,18513,1,0,0,0,0,7,0,0,0,0,0,0,0,'Lorekeeper Lydros - Giving A Dull and Flat Elven Blade after cliking on last gossip'),
+(14368,0,2,0,62,0,100,0,60045,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,'Lorekeeper Lydros - On Gossip Option 0 Selected - Close Gossip');
 
-
-
-delete from `conditions` WHERE `SourceTypeOrReferenceId` = 17 AND  `SourceEntry` = 22905;
-insert into `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) values('17','0','22905','0','0','29','0','10184','10','1','0','0','0','','Place Unfired Blade - near dead onyxia');
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 17 AND  `SourceEntry` = 22905;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
+`ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(17, 0, 22905, 0, 0, 29, 0, 10184, 10, 1, 0, 0, 0, '', 'Place Unfired Blade - near dead onyxia');
 
 DELETE FROM spell_linked_spell where spell_trigger = 22905;
 INSERT INTO spell_linked_spell (spell_trigger, spell_effect, TYPE, COMMENT) VALUES

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -74,6 +74,9 @@ enum ProgressionQuestIDs
     MIGHT_OF_KALIMDOR         = 8742,
     BANG_A_GONG               = 8743,
     INTO_THE_BREACH           = 10259,
+    VIALS_OF_ETERNITY         = 10445,
+    TRIAL_MAGTHERIDON         = 10888,
+    CUDGEL_OF_KARDESH         = 10901,
     BATTLE_UNDERCITY_HORDE    = 13267,
     BATTLE_UNDERCITY_ALLIANCE = 13377,
     SIMPLY_BANG_A_GONG        = 108743,
@@ -183,14 +186,17 @@ enum ProgressionAreas
     AREA_ARGENT_PAVILION                 = 4674
 };
 
+enum DungeonKeys
+{
+    ITEM_DRAKEFIRE_AMULET                = 16309,
+    ITEM_TEMPEST_KEY                     = 31704,
+    ITEM_MEDALLION_OF_KARABOR            = 32649,
+    ITEM_BLESSED_MEDALLION_OF_KARABOR    = 32757
+};
+
 enum ProgressionSettings
 {
     SETTING_PROGRESSION_STATE   = 0
-};
-
-enum DungeonKeys
-{
-    ITEM_DRAKEFIRE_AMULET       = 16309
 };
 
 enum ProgressionState : uint8         // Progression stands for what has been completed

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -295,7 +295,64 @@ public:
             ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_4);
             return false;
         }
-        
+        if (mapid == MAP_TEMPEST_KEEP)
+        {
+            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_1)
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_1);
+                return false;
+            }
+			else if (!player->HasItemCount(ITEM_TEMPEST_KEY))
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("You must possess the Tempest Key to enter The Eye.");
+                return false;
+            }
+			else if (player->GetQuestStatus(TRIAL_MAGTHERIDON) != QUEST_STATUS_REWARDED)
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("You must complete the quest Trial of the Naaru: Magtheridon to enter The Eye.");
+                return false;
+            }			
+        }
+        if (mapid == MAP_COILFANG_SERPENTSHRINE_CAVERN)
+        {
+            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_1)
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_1);
+                return false;
+            }
+			else if (player->GetQuestStatus(CUDGEL_OF_KARDESH) != QUEST_STATUS_REWARDED)
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("You must complete the quest The Cudgel of Kar\'desh to enter Serpentshrine Reservoir.");
+                return false;
+            }			
+        }
+        if (mapid == MAP_THE_BATTLE_FOR_MOUNT_HYJAL)
+        {
+            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_2)
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_2);
+                return false;
+            }
+			else if (player->GetQuestStatus(VIALS_OF_ETERNITY) != QUEST_STATUS_REWARDED)
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("You must complete the quest The Vials of Eternity to enter the Battle of Mount Hyjal.");
+                return false;
+            }			
+        }
+        if (mapid == MAP_BLACK_TEMPLE)
+        {
+            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_2)
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_2);
+                return false;
+            }
+			else if (!player->HasItemCount(ITEM_MEDALLION_OF_KARABOR) && !player->HasItemCount(ITEM_BLESSED_MEDALLION_OF_KARABOR)
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("You must possess the Medallion of Karabor to enter the Black Temple.");
+                return false;
+            }
+        }
+
         InstanceTemplate const* instanceTemplate = sObjectMgr->GetInstanceTemplate(mapid);
         if (instanceTemplate)
         {

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -297,7 +297,7 @@ public:
         }
         if (mapid == MAP_TEMPEST_KEEP)
         {
-            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_1)
+            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_1))
             {
                 ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_1);
                 return false;
@@ -315,7 +315,7 @@ public:
         }
         if (mapid == MAP_COILFANG_SERPENTSHRINE_CAVERN)
         {
-            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_1)
+            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_1))
             {
                 ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_1);
                 return false;
@@ -328,7 +328,7 @@ public:
         }
         if (mapid == MAP_THE_BATTLE_FOR_MOUNT_HYJAL)
         {
-            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_2)
+            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_2))
             {
                 ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_2);
                 return false;
@@ -341,12 +341,12 @@ public:
         }
         if (mapid == MAP_BLACK_TEMPLE)
         {
-            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_2)
+            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_2))
             {
                 ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_2);
                 return false;
             }
-			else if (!player->HasItemCount(ITEM_MEDALLION_OF_KARABOR) && !player->HasItemCount(ITEM_BLESSED_MEDALLION_OF_KARABOR)
+			else if (!player->HasItemCount(ITEM_MEDALLION_OF_KARABOR) && !player->HasItemCount(ITEM_BLESSED_MEDALLION_OF_KARABOR))
             {
                 ChatHandler(player->GetSession()).PSendSysMessage("You must possess the Medallion of Karabor to enter the Black Temple.");
                 return false;


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/1029

- Moved dungeon requirement checks from the database to cpp code.
This way I was able to exclude RNDbots from these requirements.

- I noticed there was a Drakefire Amulet check still in there
this most likely was the reason some people still had issues with RNDbots refusing to enter Onyxia's Lair

- now properly checking the (blessed) Medallion of Karabor.
players need one or the other in their inventory to enter the Black Temple. (RNDbots are excluded)

- a bit of code cleaning