### PR TITLE
fix SMART_ACTION_TALK worldserver errors

### DIFF
--- a/data/sql/world/base/zone_terokkar_forest.sql
+++ b/data/sql/world/base/zone_terokkar_forest.sql
@@ -48,6 +48,10 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (22441, 0, 11, 12, 11, 0, 100, 512, 0, 0, 0, 0, 0, 0, 47, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Teribus the Cursed - On Respawn - Set Visible OFF'),
 (22441, 0, 12, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 47, 1, 0, 0, 0, 0, 0, 10, 622441, 122441, 0, 0, 0, 0, 0, 0,       'Teribus the Cursed - On Respawn - Set Visible ON for patrol');
 
+-- fix SMART_ACTION_TALK worldserver errors
+UPDATE `smart_scripts` SET `target_type` = 21, `target_param1` = 40 WHERE `entryorguid` = 1410 AND `source_type` = 0 AND `id` = 3;
+UPDATE `smart_scripts` SET `target_type` = 21, `target_param1` = 40 WHERE `entryorguid` = 16769 AND `source_type` = 0 AND `id` = 17;
+
 DELETE FROM `creature` WHERE `guid` IN (247237, 622441);
 INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES


### PR DESCRIPTION
fix a few worldserver errors in Terokkar Forest

these happen when creatures try to say something that includes a class or race to the invoker 
when the invoker is a pet or summon it causes an error message.

```
SmartScript::ProcessAction: SMART_ACTION_TALK: EntryOrGuid 1410 SourceType 0 EventType 4 TargetType 7 using non-existent Text id 0 for talker 10557, ignored.
SmartScript::ProcessAction: SMART_ACTION_TALK: EntryOrGuid 16769 SourceType 0 EventType 4 TargetType 7 using non-existent Text id 1 for talker 29264, ignored.
```