### PR TITLE
chore: code cleanup of naxx40 scripts

### DIFF
--- a/src/naxx40Scripts/boss_four_horsemen_40.cpp
+++ b/src/naxx40Scripts/boss_four_horsemen_40.cpp
@@ -16,6 +16,8 @@
  */
 
 #include "Player.h"
+#include "ScriptMgr.h"
+#include "ScriptedCreature.h"
 #include "SpellScript.h"
 #include "naxxramas.h"
 #include "IndividualProgression.h"
@@ -253,12 +255,10 @@ public:
                     }
                     else if (horsemanId == HORSEMAN_BLAUMEUX)
                     {
-                    {
                         if (!sIndividualProgression->doableNaxx40Bosses)
                         {
                             me->CastSpell(me->GetVictim(), SPELL_BLAUMEUX_VOID_ZONE, false);
                         }
-                    }
                     }
                     else if (horsemanId == HORSEMAN_MOGRAINE)
                     {
@@ -347,7 +347,6 @@ class spell_four_horsemen_mark_aura : public AuraScript
                         break;
                 }
             }
-
 
             if (damage)
             {

--- a/src/naxx40Scripts/boss_gluth_40.cpp
+++ b/src/naxx40Scripts/boss_gluth_40.cpp
@@ -189,6 +189,7 @@ public:
                         uint32 reduceHp = uint32(zombie->GetMaxHealth() * 0.05f);
                         if (zombie->GetHealth() > reduceHp)
                             zombie->SetHealth(reduceHp); // Reduce HP to ~5%
+
                         zombie->SetWalk(true);                 // Set to walk
                         zombie->GetMotionMaster()->MoveFollow(me,
                             0.0f,
@@ -245,7 +246,7 @@ public:
 
                     if (sIndividualProgression->doableNaxx40Bosses)
                         events.Repeat(9s);
-					else
+                    else
                         events.Repeat(3s);
                     break;
                 }

--- a/src/naxx40Scripts/boss_gothik_40.cpp
+++ b/src/naxx40Scripts/boss_gothik_40.cpp
@@ -440,7 +440,7 @@ public:
                             go->SetGoState(GO_STATE_ACTIVE);
 
                         gateOpened = true;
-						
+
                         summons.DoForAllSummons([&](WorldObject* summon)
                         {
                             if (Creature* gothikMinion = summon->ToCreature())
@@ -454,7 +454,7 @@ public:
                                     }
                                 }
                         });
-						
+
                         Talk(EMOTE_GATE_OPENED);
                     }
                     break;

--- a/src/naxx40Scripts/boss_grobbulus_40.cpp
+++ b/src/naxx40Scripts/boss_grobbulus_40.cpp
@@ -122,6 +122,12 @@ public:
             summons.DespawnAll();
         }
 
+        /* void KilledUnit(Unit* who) override
+        {
+            if (who->IsPlayer())
+                instance->StorePersistentData(PERSISTENT_DATA_IMMORTAL_FAIL, 1);
+        } */
+
         void UpdateAI(uint32 diff) override
         {
             dropSludgeTimer += diff;

--- a/src/naxx40Scripts/boss_heigan_40.cpp
+++ b/src/naxx40Scripts/boss_heigan_40.cpp
@@ -156,15 +156,15 @@ public:
                 me->CastStop();
                 me->SetReactState(REACT_AGGRESSIVE);
                 DoZoneInCombat();
-				
+
                 ScheduleTimedEvent(12s, 15s, [&] {
-                    // DoCastSelf(SPELL_SPELL_DISRUPTION);				
+                    // DoCastSelf(SPELL_SPELL_DISRUPTION);
                     me->CastCustomSpell(SPELL_DISRUPTION_40, SPELLVALUE_RADIUS_MOD, 2500, me, false); // 25yd
                 }, 10s);
                 ScheduleTimedEvent(17s, [&] {
                     // DoCastSelf(SPELL_DECREPIT_FEVER);
                     int32 bp1 = 499;
-                    me->CastCustomSpell(me, SPELL_DECREPIT_FEVER, 0, &bp1, 0, false, nullptr, nullptr, ObjectGuid::Empty);				
+                    me->CastCustomSpell(me, SPELL_DECREPIT_FEVER, 0, &bp1, 0, false, nullptr, nullptr, ObjectGuid::Empty);
                 }, 22s, 25s);
                 ScheduleTimedEvent(40s, [&] {
                     DoEventTeleportPlayer(); // this currently kills the players that get teleported and was not set to repeat, so setting repeat timer really high.

--- a/src/naxx40Scripts/boss_kelthuzad_40.cpp
+++ b/src/naxx40Scripts/boss_kelthuzad_40.cpp
@@ -516,6 +516,12 @@ public:
             ScriptedAI::MoveInLineOfSight(who);
         }
 
+        // void JustDied(Unit* /*killer*/) override
+        // {
+        //     if (me->GetEntry() == NPC_UNSTOPPABLE_ABOMINATION)
+        //         me->GetInstanceScript()->SetData(DATA_ABOMINATION_KILLED, 0);
+        // }
+
         void AttackStart(Unit* who) override
         {
             ScriptedAI::AttackStart(who);

--- a/src/naxx40Scripts/boss_loatheb_40.cpp
+++ b/src/naxx40Scripts/boss_loatheb_40.cpp
@@ -87,6 +87,12 @@ public:
             instance->SetData(DATA_SPORE_KILLED, 0);
         }
 
+        /* void KilledUnit(Unit* who) override
+        {
+            if (who->IsPlayer())
+                instance->StorePersistentData(PERSISTENT_DATA_IMMORTAL_FAIL, 1);
+        } */
+
         void JustEngagedWith(Unit* who) override
         {
             BossAI::JustEngagedWith(who);

--- a/src/naxx40Scripts/boss_maexxna_40.cpp
+++ b/src/naxx40Scripts/boss_maexxna_40.cpp
@@ -144,6 +144,12 @@ public:
             summons.Summon(cr);
         }
 
+        /* void KilledUnit(Unit* who) override
+        {
+            if (who->IsPlayer())
+                instance->StorePersistentData(PERSISTENT_DATA_IMMORTAL_FAIL, 1);
+        } */
+
         void JustDied(Unit*  killer) override
         {
             BossAI::JustDied(killer);

--- a/src/naxx40Scripts/boss_razuvious_40.cpp
+++ b/src/naxx40Scripts/boss_razuvious_40.cpp
@@ -200,10 +200,13 @@ public:
             });
         }
 
-        void KilledUnit(Unit*) override
+        void KilledUnit(Unit* /*who*/) override
         {
             if (roll_chance_i(30))
                 Talk(SAY_SLAY);
+
+            /* if (who->IsPlayer())
+                instance->StorePersistentData(PERSISTENT_DATA_IMMORTAL_FAIL, 1); */
         }
 
         void DamageTaken(Unit* who, uint32& damage, DamageEffectType, SpellSchoolMask) override
@@ -346,6 +349,12 @@ public:
                     break;
             }
         }
+
+        /* void KilledUnit(Unit* who) override
+        {
+            if (who->IsPlayer())
+                me->GetInstanceScript()->StorePersistentData(PERSISTENT_DATA_IMMORTAL_FAIL, 1);
+        } */
 
         void JustEngagedWith(Unit* who) override
         {

--- a/src/naxx40Scripts/boss_sapphiron_40.cpp
+++ b/src/naxx40Scripts/boss_sapphiron_40.cpp
@@ -71,7 +71,8 @@ enum Events
     EVENT_FLIGHT_SPELL_EXPLOSION    = 10,
     EVENT_FLIGHT_START_LAND         = 11,
     EVENT_LAND                      = 12,
-    EVENT_GROUND                    = 13
+    EVENT_GROUND                    = 13,
+    EVENT_HUNDRED_CLUB              = 14
 };
 
 // Unlike other Naxx 40 scripts, this overwrites all versions of the UI
@@ -172,6 +173,7 @@ public:
             events.ScheduleEvent(EVENT_LIFE_DRAIN, 17s);
             events.ScheduleEvent(EVENT_BLIZZARD, 17s);
             events.ScheduleEvent(EVENT_FLIGHT_START, 45s);
+            // events.ScheduleEvent(EVENT_HUNDRED_CLUB, 5s);
         }
 
         void JustDied(Unit*  killer) override
@@ -219,6 +221,12 @@ public:
             }
             return true;
         }
+
+        /* void KilledUnit(Unit* who) override
+        {
+            if (who->IsPlayer())
+                instance->StorePersistentData(PERSISTENT_DATA_IMMORTAL_FAIL, 1);
+        } */
 
         void UpdateAI(uint32 diff) override
         {
@@ -397,6 +405,20 @@ public:
                     me->SetReactState(REACT_AGGRESSIVE);
                     me->SetInCombatWithZone();
                     return;
+                case EVENT_HUNDRED_CLUB:
+                    {
+                        Map::PlayerList const& pList = me->GetMap()->GetPlayers();
+                        for (auto const& itr : pList)
+                        {
+                            if (itr.GetSource()->GetResistance(SPELL_SCHOOL_FROST) > 100)
+                            {
+                                instance->SetData(DATA_HUNDRED_CLUB, 0);
+                                return;
+                            }
+                        }
+                        events.Repeat(5s);
+                        return;
+                    }
             }
             DoMeleeAttackIfReady();
         }

--- a/src/naxx40Scripts/custom_spells_40.cpp
+++ b/src/naxx40Scripts/custom_spells_40.cpp
@@ -248,7 +248,6 @@ class spell_sapphiron_chill_40 : public AuraScript
     }
 };
 
-
 // 28522 - Icebolt
 class spell_sapphiron_icebolt_40 : public SpellScript
 {
@@ -355,7 +354,7 @@ class spell_razuvious_disrupting_shout_40 : public SpellScript
 {
     PrepareSpellScript(spell_razuvious_disrupting_shout_40);
 
-    void CalculateDamage(SpellEffIndex)
+    void CalculateDamage(SpellEffIndex /*effIndex*/)
     {
         Unit* caster = GetCaster();
         if (!caster || (caster->GetMap()->GetDifficulty() != RAID_DIFFICULTY_10MAN_HEROIC))
@@ -453,7 +452,7 @@ class spell_loatheb_corrupted_mind_40 : public SpellScript
 {
     PrepareSpellScript(spell_loatheb_corrupted_mind_40);
 
-    void HandleEffect(SpellEffIndex)
+    void HandleEffect(SpellEffIndex /*effIndex*/)
     {
         if (Unit* caster = GetCaster())
         {

--- a/src/naxx40Scripts/instance_naxxramas.cpp
+++ b/src/naxx40Scripts/instance_naxxramas.cpp
@@ -186,8 +186,8 @@ public:
         _events.Reset();
         _currentWingTaunt = SAY_FIRST_WING_TAUNT;
         _horsemanLoaded = 0;
-		_thaddiusScreams = false;
-        
+        _thaddiusScreams = false;
+
         // Achievements
         _abominationsKilled = 0;
         _faerlinaAchievement = true;
@@ -262,9 +262,9 @@ public:
     {
         InstanceScript::OnPlayerEnter(player);
         if (_thaddiusScreams == false)
-		{
+        {
             _events.ScheduleEvent(EVENT_THADDIUS_SCREAMS, 2min, 2min + 30s);
-		}
+        }
 
         SetData(DATA_THADDIUS_SCREAMS, 0);
     }
@@ -462,9 +462,9 @@ public:
             case DATA_ABOMINATION_KILLED:
                 ++_abominationsKilled;
                 return;
-			case DATA_THADDIUS_SCREAMS:
-			    _thaddiusScreams = true;
-			    return;
+            case DATA_THADDIUS_SCREAMS:
+                _thaddiusScreams = true;
+                return;
             case DATA_FRENZY_REMOVED:
                 _faerlinaAchievement = false;
                 return;
@@ -610,11 +610,11 @@ public:
                         if (horsemanKilled == 0)
                         {
                             ActivateWingPortal(DATA_HORSEMAN_PORTAL);
-                            break; 
+                            break;
                         }
 
                         if (horsemanKilled != HorsemanCount)
-                            return false; 
+                            return false;
 
                         if (Creature* cr = GetCreature(DATA_BARON_RIVENDARE_BOSS))
                             cr->CastSpell(cr, SPELL_THE_FOUR_HORSEMAN_CREDIT, true);
@@ -743,7 +743,7 @@ private:
     EventMap _events;
     uint8 _currentWingTaunt;
     uint8 _horsemanLoaded;
-	bool _thaddiusScreams;
+    bool _thaddiusScreams;
 
     // GameObjects
     std::set<GameObject*> _heiganEruption[HeiganEruptSectionCount];


### PR DESCRIPTION
- Code cleanup, minor formatting and whitespace
- Re-add removed headers `ScriptMgr.h` and `ScriptedCreature.h` in `boss_four_horsemen_40.cpp`. I encountered a compile error on `class boss_four_horsemen_40 : public CreatureScript`
- Re-add, but commented out, deleted achievement-related logic for consistency.

Built and tested locally with AC 9a9d26533420 (non-playerbots)




