### PR TITLE
set Badlands patrol to active

### DIFF
--- a/data/sql/world/base/zone_badlands.sql
+++ b/data/sql/world/base/zone_badlands.sql
@@ -49,6 +49,19 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (2907, 0, 1, 0, 0, 0, 100, 0, 0, 0, 3000, 4000, 0, 0, 11, 9532, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Dustbelcher Mystic - In Combat - Cast Lightning Bolt'),
 (2907, 0, 2, 0, 0, 0, 100, 0, 0, 15000, 30000, 30000, 0, 0, 11, 13281, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,      'Dustbelcher Mystic - In Combat - Cast Earth Shock');
 
+-- set members escort Tho'Grun to active, so the patrol stays together
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (2716, 2717, 2718, 2907);
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (-6973, -6974, -6975, -6989, -7210);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
+`event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+--
+(-6973, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Dustbelcher Wyrmhunter - On Respawn - Set Active'),
+(-6974, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Dustbelcher Shaman - On Respawn - Set Active'),
+(-6975, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Dustbelcher Wyrmhunter - On Respawn - Set Active'),
+(-6989, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Dustbelcher Mauler - On Respawn - Set Active'),
+(-7210, 0, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Dustbelcher Mystic - On Respawn - Set Active');
 
 -- fix drop rate Small Stone Shard, quest 710
 UPDATE `creature_loot_template` SET `Chance` = 20 WHERE `Item` = 4626;


### PR DESCRIPTION
set members escort Tho'Grun to active, so the patrol stays together

by default only the group leader is active.
if no players are nearby the leader will move ahead while the members stand still.
this can result in the members "catching up" when a player does get near.