### PR TITLE
WotLK emblems update

### DIFF
--- a/data/sql/world/base/wotlk_emblems.sql
+++ b/data/sql/world/base/wotlk_emblems.sql
@@ -8,17 +8,13 @@
 */
 
 -- heroic dungeons
-DELETE FROM `creature_loot_template` WHERE `Item` IN (40752, 40753, 45624, 47241) AND `entry` IN (28860, 29932, 30397, 30398, 30510, 30529, 30530, 30532, 
-30540, 30748, 30774, 30788, 30807, 30810, 31125, 31211, 31212, 31215, 31349, 31350, 31360, 31362, 31367, 31368, 31370, 31381, 31384, 31386, 31456, 31463,
-31464, 31465, 31469, 31506, 31507, 31508, 31509, 31510, 31511, 31512, 31533, 31536, 31537, 31538, 31558, 31559, 31560, 31610, 31611, 31612, 31656,
-31673, 31679, 31722, 32313, 35490, 36476, 36494, 36497, 36498, 36502, 36538, 36658, 36938, 37613, 37627, 37677, 38112, 38113, 38599, 38603);
+DELETE FROM `creature_loot_template` WHERE `Item` IN (40752, 40753, 45624, 47241) AND `Entry` IN 
+(29932, 30397, 30398, 30510, 30529, 30530, 30532, 30540, 30748, 30774, 30788, 30807, 30810, 31125, 31211, 31212, 31215, 31349, 31350, 31360, 31362, 31367, 31368, 
+31370, 31381, 31384, 31386, 31456, 31463, 31464, 31465, 31469, 31506, 31507, 31508, 31509, 31510, 31511, 31512, 31533, 31536, 31537, 31538, 31558, 31559, 31560, 31610, 
+31611, 31612, 31656, 31673, 31679, 31722, 32313, 35490, 36476, 36494, 36497, 36498, 36502, 36538, 36658, 36938, 37613, 37627, 37677, 38112, 38113, 38599, 38603);
 
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
 --
-(28860, 40752, 0, 100, 0, 1, 0, 3, 3, 'Sartharion - Emblem of Heroism'),
-(28860, 40753, 0, 100, 0, 1, 0, 3, 3, 'Sartharion - Emblem of Valor'),
-(28860, 45624, 0, 100, 0, 1, 0, 3, 3, 'Sartharion - Emblem of Conquest'),
-(28860, 47241, 0, 100, 0, 1, 0, 3, 3, 'Sartharion - Emblem of Triump'),
 (29932, 40752, 0, 100, 0, 1, 0, 1, 1, 'Eck the Ferocious - Emblem of Heroism'), 
 (29932, 40753, 0, 100, 0, 1, 0, 1, 1, 'Eck the Ferocious - Emblem of Valor'),
 (29932, 45624, 0, 100, 0, 1, 0, 1, 1, 'Eck the Ferocious - Emblem of Conquest'),
@@ -300,7 +296,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (38603, 45624, 0, 100, 0, 1, 0, 2, 2, 'Marwyn (1) - Emblem of Conquest'),
 (38603, 47241, 0, 100, 0, 1, 0, 2, 2, 'Marwyn (1) - Emblem of Triumph');
 
-DELETE FROM `gameobject_loot_template` WHERE `Item` IN (40752, 40753, 45624, 47241) AND `entry` IN (24524, 24589, 26260, 27416, 27417);
+DELETE FROM `gameobject_loot_template` WHERE `Item` IN (40752, 40753, 45624, 47241) AND `Entry` IN (24524, 24589, 26260, 27416, 27417);
 INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
 (24524, 40752, 0, 100, 0, 1, 0, 1, 1, 'Cache of Eregos'),
 (24524, 40753, 0, 100, 0, 1, 0, 1, 1, 'Cache of Eregos'),
@@ -323,12 +319,19 @@ INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, 
 (27417, 45624, 0, 100, 0, 1, 0, 1, 1, 'Confessor\'s Cache'),
 (27417, 47241, 0, 100, 0, 1, 0, 1, 1, 'Confessor\'s Cache');
 
+DELETE FROM `item_loot_template` WHERE `Item` IN (40752, 40753, 45624, 47241) AND `Entry` = 52676;
+INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(52676, 40752, 0, 100, 0, 1, 0, 2, 2, 'Cache of the Ley-Guardian'),
+(52676, 40753, 0, 100, 0, 1, 0, 2, 2, 'Cache of the Ley-Guardian'),
+(52676, 45624, 0, 100, 0, 1, 0, 2, 2, 'Cache of the Ley-Guardian'),
+(52676, 47241, 0, 100, 0, 1, 0, 2, 2, 'Cache of the Ley-Guardian');
 
-DELETE FROM `conditions` WHERE `SourceEntry` IN (40752, 40753, 45624, 47241) AND `SourceGroup` IN (28860, 29932, 30397, 30398, 30510, 30529, 30530, 30532, 
-30540, 30748, 30774, 30788, 30807, 30810, 31125, 31211, 31212, 31215, 31349, 31350, 31360, 31362, 31367, 31368, 31370, 31381, 31384, 31386, 31456, 31463,
-31464, 31465, 31469, 31506, 31507, 31508, 31509, 31510, 31511, 31512, 31533, 31536, 31537, 31538, 31558, 31559, 31560, 31610, 31611, 31612, 31656,
-31673, 31679, 31722, 32313, 35490, 36476, 36494, 36497, 36498, 36502, 36538, 36658, 36938, 37613, 37627, 37677, 38112, 38113, 38599, 38603);
-DELETE FROM `conditions` WHERE `SourceEntry` IN (40752, 40753, 45624, 47241) AND `SourceGroup` IN (24524, 24589, 26260, 27416, 27417);
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceEntry` IN (40752, 40753, 45624, 47241) AND `SourceGroup` IN 
+(28860, 29932, 30397, 30398, 30510, 30529, 30530, 30532, 30540, 30748, 30774, 30788, 30807, 30810, 31125, 31211, 31212, 31215, 31349, 31350, 31360, 31362, 31367, 31368, 
+31370, 31381, 31384, 31386, 31456, 31463, 31464, 31465, 31469, 31506, 31507, 31508, 31509, 31510, 31511, 31512, 31533, 31536, 31537, 31538, 31558, 31559, 31560, 31610, 
+31611, 31612, 31656, 31673, 31679, 31722, 32313, 35490, 36476, 36494, 36497, 36498, 36502, 36538, 36658, 36938, 37613, 37627, 37677, 38112, 38113, 38599, 38603);
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 4 AND `SourceEntry` IN (40752, 40753, 45624, 47241) AND `SourceGroup` IN (24524, 24589, 26260, 27416, 27417);
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 5 AND `SourceEntry` IN (40752, 40753, 45624, 47241) AND `SourceGroup` IN (52676);
 
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
 `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
@@ -789,12 +792,102 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (4, 27417, 40753, 0, 1, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
 (4, 27417, 45624, 0, 2, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
 (4, 27417, 45624, 0, 2, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
-(4, 27417, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3');
+(4, 27417, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3'),
+--
+(5, 52676, 40752, 0, 0, 8, 0, 66014, 0, 0, 1, 0, 0, '', 'Emblem of Heroism will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_1'),
+(5, 52676, 40753, 0, 1, 8, 0, 66014, 0, 0, 0, 0, 0, '', 'Emblem of Valor will only drop if the player has completed PROGRESSION_WOTLK_TIER_1'),
+(5, 52676, 40753, 0, 1, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
+(5, 52676, 45624, 0, 2, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
+(5, 52676, 45624, 0, 2, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
+(5, 52676, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3');
+
+-- Obsidian Sanctum
+DELETE FROM `creature_loot_template` WHERE `Item` IN (40752, 40753, 45624, 47241) AND `entry` IN (28860, 30449, 30451, 30452, 31311, 31520, 31534, 31535);
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+--
+(28860, 40752, 0, 100, 0, 1, 0, 1, 1, 'Sartharion - Emblem of Heroism'),
+(28860, 40753, 0, 100, 0, 1, 0, 1, 1, 'Sartharion - Emblem of Valor'),
+(28860, 45624, 0, 100, 0, 1, 0, 1, 1, 'Sartharion - Emblem of Conquest'),
+(28860, 47241, 0, 100, 0, 1, 0, 1, 1, 'Sartharion - Emblem of Triump'),
+(30449, 40752, 0, 100, 0, 1, 0, 1, 1, 'Vesperon - Emblem of Heroism'),
+(30449, 40753, 0, 100, 0, 1, 0, 1, 1, 'Vesperon - Emblem of Valor'),
+(30449, 45624, 0, 100, 0, 1, 0, 1, 1, 'Vesperon - Emblem of Conquest'),
+(30449, 47241, 0, 100, 0, 1, 0, 1, 1, 'Vesperon - Emblem of Triump'),
+(30451, 40752, 0, 100, 0, 1, 0, 1, 1, 'Shadron - Emblem of Heroism'),
+(30451, 40753, 0, 100, 0, 1, 0, 1, 1, 'Shadron - Emblem of Valor'),
+(30451, 45624, 0, 100, 0, 1, 0, 1, 1, 'Shadron - Emblem of Conquest'),
+(30451, 47241, 0, 100, 0, 1, 0, 1, 1, 'Shadron - Emblem of Triump'),
+(30452, 40752, 0, 100, 0, 1, 0, 1, 1, 'Tenebron - Emblem of Heroism'),
+(30452, 40753, 0, 100, 0, 1, 0, 1, 1, 'Tenebron - Emblem of Valor'),
+(30452, 45624, 0, 100, 0, 1, 0, 1, 1, 'Tenebron - Emblem of Conquest'),
+(30452, 47241, 0, 100, 0, 1, 0, 1, 1, 'Tenebron - Emblem of Triump'),
+--
+(31311, 40753, 0, 100, 0, 1, 0, 1, 1, 'Sartharion (1) - Emblem of Valor'),
+(31311, 45624, 0, 100, 0, 1, 0, 1, 1, 'Sartharion (1) - Emblem of Conquest'),
+(31311, 47241, 0, 100, 0, 1, 0, 1, 1, 'Sartharion (1) - Emblem of Triumph'),
+(31520, 40753, 0, 100, 0, 1, 0, 1, 1, 'Shadron (1) - Emblem of Valor'),
+(31520, 45624, 0, 100, 0, 1, 0, 1, 1, 'Shadron (1) - Emblem of Conquest'),
+(31520, 47241, 0, 100, 0, 1, 0, 1, 1, 'Shadron (1) - Emblem of Triump'),
+(31534, 40753, 0, 100, 0, 1, 0, 1, 1, 'Tenebron (1) - Emblem of Valor'),
+(31534, 45624, 0, 100, 0, 1, 0, 1, 1, 'Tenebron (1) - Emblem of Conquest'),
+(31534, 47241, 0, 100, 0, 1, 0, 1, 1, 'Tenebron (1) - Emblem of Triump'),
+(31535, 40753, 0, 100, 0, 1, 0, 1, 1, 'Vesperon (1) - Emblem of Valor'),
+(31535, 45624, 0, 100, 0, 1, 0, 1, 1, 'Vesperon (1) - Emblem of Conquest'),
+(31535, 47241, 0, 100, 0, 1, 0, 1, 1, 'Vesperon (1) - Emblem of Triump');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceEntry` IN (40752, 40753, 45624, 47241) AND `SourceGroup` IN (28860, 30449, 30451, 30452, 31311, 31520, 31534, 31535);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
+`ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
+--
+(1, 28860, 40752, 0, 0, 8, 0, 66014, 0, 0, 1, 0, 0, '', 'Emblem of Heroism will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_1'),
+(1, 28860, 40753, 0, 1, 8, 0, 66014, 0, 0, 0, 0, 0, '', 'Emblem of Valor will only drop if the player has completed PROGRESSION_WOTLK_TIER_1'),
+(1, 28860, 40753, 0, 1, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
+(1, 28860, 45624, 0, 2, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
+(1, 28860, 45624, 0, 2, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
+(1, 28860, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3'),
+(1, 30449, 40752, 0, 0, 8, 0, 66014, 0, 0, 1, 0, 0, '', 'Emblem of Heroism will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_1'),
+(1, 30449, 40753, 0, 1, 8, 0, 66014, 0, 0, 0, 0, 0, '', 'Emblem of Valor will only drop if the player has completed PROGRESSION_WOTLK_TIER_1'),
+(1, 30449, 40753, 0, 1, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
+(1, 30449, 45624, 0, 2, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
+(1, 30449, 45624, 0, 2, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
+(1, 30449, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3'),
+(1, 30451, 40752, 0, 0, 8, 0, 66014, 0, 0, 1, 0, 0, '', 'Emblem of Heroism will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_1'),
+(1, 30451, 40753, 0, 1, 8, 0, 66014, 0, 0, 0, 0, 0, '', 'Emblem of Valor will only drop if the player has completed PROGRESSION_WOTLK_TIER_1'),
+(1, 30451, 40753, 0, 1, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
+(1, 30451, 45624, 0, 2, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
+(1, 30451, 45624, 0, 2, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
+(1, 30451, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3'),
+(1, 30452, 40752, 0, 0, 8, 0, 66014, 0, 0, 1, 0, 0, '', 'Emblem of Heroism will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_1'),
+(1, 30452, 40753, 0, 1, 8, 0, 66014, 0, 0, 0, 0, 0, '', 'Emblem of Valor will only drop if the player has completed PROGRESSION_WOTLK_TIER_1'),
+(1, 30452, 40753, 0, 1, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
+(1, 30452, 45624, 0, 2, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
+(1, 30452, 45624, 0, 2, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
+(1, 30452, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3'),
+--
+(1, 31311, 40753, 0, 0, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
+(1, 31311, 45624, 0, 1, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
+(1, 31311, 45624, 0, 1, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
+(1, 31311, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3'),
+(1, 31520, 40753, 0, 0, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
+(1, 31520, 45624, 0, 1, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
+(1, 31520, 45624, 0, 1, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
+(1, 31520, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3'),
+(1, 31534, 40753, 0, 0, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
+(1, 31534, 45624, 0, 1, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
+(1, 31534, 45624, 0, 1, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
+(1, 31534, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3'),
+(1, 31535, 40753, 0, 0, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
+(1, 31535, 45624, 0, 1, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
+(1, 31535, 45624, 0, 1, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
+(1, 31535, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3');
+
+DELETE FROM `creature_loot_template`  WHERE `Reference` IN (34349, 60001) AND `entry` = 31311;
+DELETE FROM `reference_loot_template` WHERE `Entry` = 60001; -- 00_cleanup
 
 
 -- tier 7 raid bosses, Naxxramas
-DELETE FROM `creature_loot_template` WHERE `Item` IN (40753, 45624, 47241) AND `entry` IN (15928, 15931, 15932, 15936, 15952, 15953, 15954, 15956, 
-15989, 15990, 16011, 16028, 16060, 16061, 29249, 29268, 29278, 29324, 29373, 29417, 29448, 29615, 29701, 29718, 29940, 29955, 29991, 30061, 31311);
+DELETE FROM `creature_loot_template` WHERE `Item` IN (40753, 45624, 47241) AND `entry` IN 
+(15928, 15931, 15932, 15936, 15952, 15953, 15954, 15956, 15989, 15990, 16011, 16028, 16060, 16061, 29249, 29268, 29278, 29324, 29373, 29417, 29448, 29615, 29701, 29718, 29940, 29955, 29991, 30061);
 
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
 --
@@ -881,10 +974,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (29991, 47241, 0, 100, 0, 1, 0, 1, 1, 'Sapphiron (1) - Emblem of Triumph'),
 (30061, 40753, 0, 100, 0, 1, 0, 2, 2, 'Kel\'Thuzad (1) - Emblem of Valor'),
 (30061, 45624, 0, 100, 0, 1, 0, 2, 2, 'Kel\'Thuzad (1) - Emblem of Conquest'),
-(30061, 47241, 0, 100, 0, 1, 0, 2, 2, 'Kel\'Thuzad (1) - Emblem of Triumph'),
-(31311, 40753, 0, 100, 0, 1, 0, 1, 1, 'Sartharion (1) - Emblem of Valor'),
-(31311, 45624, 0, 100, 0, 1, 0, 1, 1, 'Sartharion (1) - Emblem of Conquest'),
-(31311, 47241, 0, 100, 0, 1, 0, 1, 1, 'Sartharion (1) - Emblem of Triumph');
+(30061, 47241, 0, 100, 0, 1, 0, 2, 2, 'Kel\'Thuzad (1) - Emblem of Triumph');
 
 DELETE FROM `gameobject_loot_template` WHERE `Item` IN (40753, 45624, 47241) AND `entry` IN (25192, 25193, 26094, 26097);
 INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
@@ -901,16 +991,8 @@ INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, 
 (26097, 45624, 0, 100, 0, 1, 0, 2, 2, 'Alexstrasza\'s Gift'),
 (26097, 47241, 0, 100, 0, 1, 0, 2, 2, 'Alexstrasza\'s Gift');
 
-UPDATE `creature_loot_template` SET `Reference` = 60001 WHERE `Reference` = 34349 AND `entry` = 31311;
-
-DELETE FROM `reference_loot_template` WHERE `Entry` = 60001;
-INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
-(60001, 40753, 0, 100, 0, 1, 0, 1, 1, 'Emblem of Valor'),
-(60001, 45624, 0, 100, 0, 1, 0, 1, 1, 'Emblem of Conquest'),
-(60001, 47241, 0, 100, 0, 1, 0, 1, 1, 'Emblem of Triumph');
-
-DELETE FROM `conditions` WHERE `SourceEntry` IN (40753, 45624, 47241) AND `SourceGroup` IN (15928, 15931, 15932, 15936, 15952, 15953, 15954, 15956, 
-15989, 15990, 16011, 16028, 16060, 16061, 29249, 29268, 29278, 29324, 29373, 29417, 29448, 29615, 29701, 29718, 29940, 29955, 29991, 30061, 31311);
+DELETE FROM `conditions` WHERE `SourceEntry` IN (40753, 45624, 47241) AND `SourceGroup` IN 
+(15928, 15931, 15932, 15936, 15952, 15953, 15954, 15956, 15989, 15990, 16011, 16028, 16060, 16061, 29249, 29268, 29278, 29324, 29373, 29417, 29448, 29615, 29701, 29718, 29940, 29955, 29991, 30061);
 DELETE FROM `conditions` WHERE `SourceEntry` IN (40753, 45624, 47241) AND `SourceGroup` IN (25192, 25193, 26094, 26097);
 DELETE FROM `conditions` WHERE `SourceEntry` IN (40753, 45624, 47241) AND `SourceGroup` IN (60001);
 
@@ -1029,10 +1111,6 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (1, 30061, 45624, 0, 1, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
 (1, 30061, 45624, 0, 1, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
 (1, 30061, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3'),
-(1, 31311, 40753, 0, 0, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
-(1, 31311, 45624, 0, 1, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
-(1, 31311, 45624, 0, 1, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
-(1, 31311, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3'),
 --
 (4, 25192, 40753, 0, 0, 8, 0, 66015, 0, 0, 1, 0, 0, '', 'Emblem of Valor will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_2'),
 (4, 25192, 45624, 0, 1, 8, 0, 66015, 0, 0, 0, 0, 0, '', 'Emblem of Conquest will only drop if the player has completed PROGRESSION_WOTLK_TIER_2'),
@@ -1106,6 +1184,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 
 DELETE FROM `gameobject_loot_template` WHERE `Item` IN (45624, 47241) AND `entry` IN 
 (26929, 26946, 26955, 26956, 26959, 26960, 26961, 26962, 26963, 26967, 26974, 27030, 27061, 27068, 27073, 27074, 27078, 27079, 27080, 27081, 27085, 27086);
+
 INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
 (26929, 45624, 0, 100, 0, 1, 0, 1, 2, 'Cache of Living Stone'),
 (26929, 47241, 0, 100, 0, 1, 0, 1, 2, 'Cache of Living Stone'),
@@ -1157,11 +1236,11 @@ INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `
 (34349, 45624, 0, 100, 0, 1, 0, 1, 1, 'Emblem of Conquest'),
 (34349, 47241, 0, 100, 0, 1, 0, 1, 1, 'Emblem of Triumph');
 
-DELETE FROM `conditions` WHERE `SourceEntry` IN (45624, 47241) AND `SourceGroup` IN
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1  AND `SourceEntry` IN (45624, 47241) AND `SourceGroup` IN
 (32857, 32867, 32927, 33118, 33186, 33190, 33271, 33288, 33293, 33449, 33515, 33692, 33693, 33694, 33724, 33885, 33955, 33993, 33994, 34175);
-DELETE FROM `conditions` WHERE `SourceEntry` IN (45624, 47241) AND `SourceGroup` IN
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 4  AND `SourceEntry` IN (45624, 47241) AND `SourceGroup` IN
 (26929, 26946, 26955, 26956, 26959, 26960, 26961, 26962, 26963, 26967, 26974, 27030, 27061, 27068, 27073, 27074, 27078, 27079, 27080, 27081, 27085, 27086);
-DELETE FROM `conditions` WHERE `SourceEntry` IN (45624, 47241) AND `SourceGroup` IN (34349);
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 10 AND `SourceEntry` IN (45624, 47241) AND `SourceGroup` IN (34349);
 
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
 `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
@@ -1256,11 +1335,6 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (10, 34349, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3');
 
 
-/* Conquest vendors */
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_ulduar' WHERE `entry` IN (33963, 33964);
-
-/* Triumph vendors */
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_totc' WHERE `entry` IN (35494, 35495, 35573, 35574);
-
-/* Frost vendors */
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_icc' WHERE `entry` IN (37941, 37942, 38858);
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_ulduar' WHERE `entry` IN (33963, 33964);             -- Conquest vendors
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_totc' WHERE `entry` IN (35494, 35495, 35573, 35574); -- Triumph vendors
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_icc' WHERE `entry` IN (37941, 37942, 38858);         -- Frost vendors

--- a/data/sql/world/base/wotlk_emblems.sql
+++ b/data/sql/world/base/wotlk_emblems.sql
@@ -802,7 +802,7 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (5, 52676, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3');
 
 -- Obsidian Sanctum
-DELETE FROM `creature_loot_template` WHERE `Item` IN (40752, 40753, 45624, 47241) AND `entry` IN (28860, 30449, 30451, 30452, 31311, 31520, 31534, 31535);
+DELETE FROM `creature_loot_template` WHERE `Item` IN (40752, 40753, 45624, 47241) AND `Entry` IN (28860, 30449, 30451, 30452, 31311, 31520, 31534, 31535);
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
 --
 (28860, 40752, 0, 100, 0, 1, 0, 1, 1, 'Sartharion - Emblem of Heroism'),
@@ -881,12 +881,12 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (1, 31535, 45624, 0, 1, 8, 0, 66016, 0, 0, 1, 0, 0, '', 'Emblem of Conquest will only drop if the player has NOT completed PROGRESSION_WOTLK_TIER_3'),
 (1, 31535, 47241, 0, 0, 8, 0, 66016, 0, 0, 0, 0, 0, '', 'Emblem of Triumph will only drop if the player has completed PROGRESSION_WOTLK_TIER_3');
 
-DELETE FROM `creature_loot_template`  WHERE `Reference` IN (34349, 60001) AND `entry` = 31311;
+DELETE FROM `creature_loot_template`  WHERE `Reference` IN (34349, 60001) AND `Entry` = 31311;
 DELETE FROM `reference_loot_template` WHERE `Entry` = 60001; -- 00_cleanup
 
 
 -- tier 7 raid bosses, Naxxramas
-DELETE FROM `creature_loot_template` WHERE `Item` IN (40753, 45624, 47241) AND `entry` IN 
+DELETE FROM `creature_loot_template` WHERE `Item` IN (40753, 45624, 47241) AND `Entry` IN 
 (15928, 15931, 15932, 15936, 15952, 15953, 15954, 15956, 15989, 15990, 16011, 16028, 16060, 16061, 29249, 29268, 29278, 29324, 29373, 29417, 29448, 29615, 29701, 29718, 29940, 29955, 29991, 30061);
 
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
@@ -976,7 +976,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (30061, 45624, 0, 100, 0, 1, 0, 2, 2, 'Kel\'Thuzad (1) - Emblem of Conquest'),
 (30061, 47241, 0, 100, 0, 1, 0, 2, 2, 'Kel\'Thuzad (1) - Emblem of Triumph');
 
-DELETE FROM `gameobject_loot_template` WHERE `Item` IN (40753, 45624, 47241) AND `entry` IN (25192, 25193, 26094, 26097);
+DELETE FROM `gameobject_loot_template` WHERE `Item` IN (40753, 45624, 47241) AND `Entry` IN (25192, 25193, 26094, 26097);
 INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
 (25192, 40753, 0, 100, 0, 1, 0, 1, 1, 'Four Horsemen Chest'),
 (25192, 45624, 0, 100, 0, 1, 0, 1, 1, 'Four Horsemen Chest'),
@@ -1136,7 +1136,7 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 
 
 -- tier 8 raid bosses, Ulduar
-DELETE FROM `creature_loot_template` WHERE `Item` IN (45624, 47241) AND `entry` IN 
+DELETE FROM `creature_loot_template` WHERE `Item` IN (45624, 47241) AND `Entry` IN 
 (32857, 32867, 32927, 33118, 33186, 33190, 33271, 33288, 33293, 33449, 33515, 33692, 33693, 33694, 33724, 33885, 33955, 33993, 33994, 34175);
 
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
@@ -1182,7 +1182,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (34175, 45624, 0, 100, 0, 1, 0, 1, 1, 'Auriaya (1) - Emblem of Conquest'),
 (34175, 47241, 0, 100, 0, 1, 0, 1, 1, 'Auriaya (1) - Emblem of Triumph');
 
-DELETE FROM `gameobject_loot_template` WHERE `Item` IN (45624, 47241) AND `entry` IN 
+DELETE FROM `gameobject_loot_template` WHERE `Item` IN (45624, 47241) AND `Entry` IN 
 (26929, 26946, 26955, 26956, 26959, 26960, 26961, 26962, 26963, 26967, 26974, 27030, 27061, 27068, 27073, 27074, 27078, 27079, 27080, 27081, 27085, 27086);
 
 INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 


### PR DESCRIPTION
AC added emblem drops for 3 more dragons in the Obsidian Sanctum
this update will phase these drops

also fixed double emblem drops from Sartharion
they were dropped both directly in `creature_loot_template` and in `reference_loot_template` as well.
now only in `creature_loot_template`