### PR TITLE
Solve ZG quest npc phasing

### DIFF
--- a/data/sql/world/base/ipp_aware_npcs.sql
+++ b/data/sql/world/base/ipp_aware_npcs.sql
@@ -31,8 +31,8 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_aqwewar' WHERE `entry` IN
 -- Phasing Cenarion Hold guards
 UPDATE `creature` SET `ScriptName` = 'npc_ipp_preaq' WHERE `id1` = 15184 AND `guid` IN (42782, 42783, 42768);
 
--- Phasing ZG quest NPCs on YoJamba Isle
-UPDATE `creature` SET `ScriptName` = 'npc_ipp_preaq' WHERE `id1` IN (14902, 14903, 14904, 14905, 14910, 15070);
+-- Phasing ZG quest NPCs on YoJamba Isle and in Tanaris
+UPDATE `creature` SET `ScriptName` = 'npc_ipp_zg' WHERE `id1` IN (10460, 14902, 14903, 14904, 14905, 14910, 15070);
 
 -- Phasing NPCs until after the outdoors AQ war has been completed
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_aq' WHERE `entry` IN  (15498, 15499, 15500, 15540, 16091);                -- Cenarion Hold

--- a/data/sql/world/base/zone_tanaris.sql
+++ b/data/sql/world/base/zone_tanaris.sql
@@ -113,7 +113,7 @@ UPDATE `creature_loot_template` SET `Chance` = 10 WHERE `Item` = 8428;
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 19 AND `ConditionTypeOrReference` = 8 AND `SourceEntry` IN (5065, 10445);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
 `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
-(19, 0, 5065, 0, 0, 8, 0, 66003, 0, 0, 0, 0, 0, '', 'Prospector Ironboot - Hide \'The Lost Tablets of Mosh\'aru\' until the player reaches Pre-AQ'),
+-- (19, 0, 5065, 0, 0, 8, 0, 66003, 0, 0, 0, 0, 0, '', 'Prospector Ironboot - Hide \'The Lost Tablets of Mosh\'aru\' until the player reaches Pre-AQ'),
 (19, 0, 10445, 0, 0, 8, 0, 66009, 0, 0, 0, 0, 0, '', 'Soridormi - Hide \'The Vials of Eternity\' until the player reaches TBC T2');
     
 DELETE FROM `creature_text` WHERE `CreatureID` IN (5465, 5471, 5472, 5473, 5474, 5475);

--- a/src/IndividualProgressionAwareness.cpp
+++ b/src/IndividualProgressionAwareness.cpp
@@ -256,6 +256,38 @@ public:
     }
 };
 
+class npc_ipp_zg : public CreatureScript
+{
+public:
+    npc_ipp_zg() : CreatureScript("npc_ipp_zg") { }
+
+    struct npc_ipp_zgAI: ScriptedAI
+    {
+        explicit npc_ipp_zgAI(Creature* creature) : ScriptedAI(creature) { };
+
+        bool CanBeSeen(Player const* player) override
+        {
+            if (player->IsGameMaster() || !sIndividualProgression->enabled)
+                return true;
+
+            Player* target = ObjectAccessor::FindConnectedPlayer(player->GetGUID());
+
+            uint32 PLAYER_PROGRESSION = sIndividualProgression->GetPlayerProgressionFromQuests(target);
+            ProgressionState REQUIRED_ZG_PROGRESSION = static_cast<ProgressionState>(sIndividualProgression->RequiredZulGurubProgression);
+
+            if (PLAYER_PROGRESSION >= REQUIRED_ZG_PROGRESSION)
+                return true;
+            else
+                return false;
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_ipp_zgAI(creature);
+    }
+};
+
 class npc_ipp_we : public CreatureScript
 {
 public:
@@ -776,6 +808,7 @@ void AddSC_mod_individual_progression_awareness()
     new gobject_ipp_tbc_t4();         // Shattered Sun
     new gobject_ipp_wotlk();
     new npc_ipp_preaq();              // Cenarion Hold NPCs
+    new npc_ipp_zg();
     new npc_ipp_we();                 // War Effort NPCs in cities
     new npc_ipp_aq();
     new npc_ipp_aqwewar();            // only visible during AQ war effort and AQ war


### PR DESCRIPTION
now the quest NPCs on Yojamba island and Prospector Ironboot in Tanaris are phased based on ZG being available or not.
it now looks at the config setting.