### PR TITLE
separate quest marker and sparkle removal

### DIFF
--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -162,10 +162,9 @@ IndividualProgression.FishingFix = 1
 #                     For more advanced individual tuning, disable this option and change the respective values in worldserver.conf
 #
 #                     Changed options include:
-#                     Water Breath Timer to 1 Minute (Vanilla value, changed to 3 Minutes in WotLK)
-#                     Disable Quest Object sparkle and object quest markers (added in patch 2.3)
-#                     Enable PlayerSettings (required by Individual Progression module)
-#                     Do not enforce DBC Item Attributes, so that Vanilla item changes can override client values
+#                     - Water Breath Timer to 1 Minute (Vanilla value, changed to 3 Minutes in WotLK)
+#                     - Enable PlayerSettings (required by Individual Progression module)
+#                     - Do not enforce DBC Item Attributes, so that Vanilla item changes can override client values
 #
 #        Default:     1 - Enabled
 #                     0 - Disabled

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -171,6 +171,15 @@ IndividualProgression.FishingFix = 1
 #
 IndividualProgression.SimpleConfigOverride = 1
 
+# IndividualProgression.DisableQuestMarkers
+#
+#        Description: Disable Quest Object markers and sparkles (added in patch 2.3)
+#
+#        Default:     1 - Markers and Sparkles Disabled
+#                     0 - Markers and Sparkles Enabled
+#
+IndividualProgression.DisableQuestMarkers = 1
+
 # IndividualProgression.DisableRDF
 #
 #        Description: Enable or disable the Random Dungeon Finder feature within the context of Individual Progression.

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -867,7 +867,7 @@ public:
         if (sIndividualProgression->DisableRDF)
             sWorld->setIntConfig(CONFIG_LFG_OPTIONSMASK, 4);
 
-        if (IndividualProgression.DisableQuestMarkers)
+        if (sIndividualProgression->DisableQuestMarkers)
         {
             sWorld->setBoolConfig(CONFIG_OBJECT_QUEST_MARKERS, false);
             sWorld->setBoolConfig(CONFIG_OBJECT_SPARKLES, false);

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -818,6 +818,7 @@ private:
         sIndividualProgression->VanillaPvpTitlesEarnPostVanilla = sConfigMgr->GetOption<bool>("IndividualProgression.VanillaPvpEarnTitlesAfterVanilla", false);
         sIndividualProgression->ExcludedAccountsEarnPvPTitles = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludedAccountsEarnPvPTitles", false);
         sIndividualProgression->DisableRDF = sConfigMgr->GetOption<bool>("IndividualProgression.DisableRDF", false);
+        sIndividualProgression->DisableQuestMarkers = sConfigMgr->GetOption<bool>("IndividualProgression.DisableQuestMarkers", true);
         sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", true);
         sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "^RNDBOT.*");
         sIndividualProgression->ExcludedAccountsMaxLevel = sConfigMgr->GetOption<uint8>("IndividualProgression.ExcludedAccountsMaxLevel", 80);
@@ -865,6 +866,12 @@ public:
 
         if (sIndividualProgression->DisableRDF)
             sWorld->setIntConfig(CONFIG_LFG_OPTIONSMASK, 4);
+
+        if (IndividualProgression.DisableQuestMarkers)
+        {
+            sWorld->setBoolConfig(CONFIG_OBJECT_QUEST_MARKERS, false);
+            sWorld->setBoolConfig(CONFIG_OBJECT_SPARKLES, false);
+        }
     }
 };
 

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -858,8 +858,6 @@ public:
         if (sIndividualProgression->simpleConfigOverride)
         {
             sWorld->setIntConfig(CONFIG_WATER_BREATH_TIMER, 60000);
-            sWorld->setBoolConfig(CONFIG_OBJECT_QUEST_MARKERS, false);
-            sWorld->setBoolConfig(CONFIG_OBJECT_SPARKLES, false);
             sWorld->setBoolConfig(CONFIG_PLAYER_SETTINGS_ENABLED, true);
             sWorld->setBoolConfig(CONFIG_LOW_LEVEL_REGEN_BOOST, false);
             sWorld->setBoolConfig(CONFIG_DBC_ENFORCE_ITEM_ATTRIBUTES, false);

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -400,7 +400,7 @@ public:
     std::map<uint32, uint8> customProgressionMap;
     questXpMapType questXpMap;
     float vanillaPowerAdjustment, tbcPowerAdjustment, vanillaHealingAdjustment, tbcHealingAdjustment;
-    bool enabled, questXpFix, enforceGroupRules, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableRDF, excludeAccounts, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, ExcludedAccountsEarnPvPTitles;
+    bool enabled, questXpFix, enforceGroupRules, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, excludeAccounts, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, ExcludedAccountsEarnPvPTitles;
     int progressionLimit, startingProgression, tbcRacesProgressionLevel, tbcRacesStartingProgression, deathKnightProgressionLevel, deathKnightStartingProgression, RequiredZulGurubProgression, tbcArenaSeason, wotlkArenaSeason, ExcludedAccountsMaxLevel;
     uint32 VanillaPvpKillRank1, VanillaPvpKillRank2, VanillaPvpKillRank3, VanillaPvpKillRank4, VanillaPvpKillRank5, VanillaPvpKillRank6, VanillaPvpKillRank7, VanillaPvpKillRank8, VanillaPvpKillRank9, VanillaPvpKillRank10, VanillaPvpKillRank11, VanillaPvpKillRank12, VanillaPvpKillRank13, VanillaPvpKillRank14;
     std::string excludedAccountsRegex;


### PR DESCRIPTION
Someone pointed this out to me
it can be hard to spot certain quest items

this was part of the simple config override
I've made this a separate option, still disabled by default
but now easy to re-enable.

