### PR TITLE
solve IndividualProgressionPlayer.cpp:116:95 error

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -113,7 +113,7 @@ public:
         sIndividualProgression->CheckAdjustments(player);
     }
 
-    void OnPlayerResurrect(Player* player, float /*restore_percent*/, bool /*applySickness*/) override
+    void OnPlayerResurrect(Player* player, float /*restore_percent*/, bool& /*applySickness*/) override
     {
         if (!player || !player->IsInWorld())
             return;


### PR DESCRIPTION
related to: https://github.com/azerothcore/azerothcore-wotlk/pull/25353

AC recently updated `OnPlayerResurrect`
this hasn't reached the playerbots fork yet.

so for people using NPCbots or no bots at all, you have to make a small change.

edit `IndividualProgressionPlayer.cpp`. line 116
make it look like this:

<img width="1005" height="138" alt="Capture" src="https://github.com/user-attachments/assets/3e4812ae-69ca-4e96-964e-056baef635fa" />

add the `&` and save the file.
that's it.