### PR TITLE
Fix Stormwind phasing

### DIFF
--- a/data/sql/world/base/ipp_aware_npcs.sql
+++ b/data/sql/world/base/ipp_aware_npcs.sql
@@ -13,7 +13,7 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN
 (19915, 19909, 19911, 26012, 26007, 26075, 26307, 26309, 26760, 19912, 19859, 19860, 19861, 20499, 20497, 30610, 30611, 32832);
 
 -- Stormwind
-UPDATE `creature` SET `phaseMask` = @IPPPHASE     WHERE `id1` = 1749;  -- Lady Katrana Prestor
+UPDATE `creature` SET `phaseMask` = @IPPPHASE_II  WHERE `id1` = 1749;  -- Lady Katrana Prestor
 UPDATE `creature` SET `phaseMask` = @IPPPHASE_III WHERE `id1` = 29611; -- King Varian Wrynn
 
 -- Orgrimmar

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -438,7 +438,7 @@ void IndividualProgression::checkIPPhasing(Player* player, uint32 newArea)
         case AREA_STORMWIND_CITY:
             if (!hasPassedProgression(player, PROGRESSION_PRE_TBC))
             {
-                player->CastSpell(player, IPP_PHASE, false);
+                player->CastSpell(player, IPP_PHASE_II, false);
             }
             else if (hasPassedProgression(player, PROGRESSION_TBC_TIER_5))
             {


### PR DESCRIPTION
Stormwind phasing was using the same phasemask as the Scourge Invasion creatures just outside the gate in Elwynn Forest.
You could see the ghosts from just inside the city borders.