### PR TITLE
OnPlayerSetMaxLevel seems to do nothing

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -69,7 +69,7 @@ public:
         }
     }
 
-    void OnPlayerSetMaxLevel(Player* player, uint32& maxPlayerLevel) override
+    /* void OnPlayerSetMaxLevel(Player* player, uint32& maxPlayerLevel) override
     {
         if (!sIndividualProgression->enabled || !maxPlayerLevel || !player || !player->IsInWorld() || sIndividualProgression->isExcludedFromProgression(player))
             return;
@@ -84,7 +84,7 @@ public:
             if (sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL) > IP_LEVEL_TBC)
                 maxPlayerLevel = IP_LEVEL_TBC;
         }
-    }
+    } */
 
     void OnPlayerMapChanged(Player* player) override
     {


### PR DESCRIPTION
This function seems to do nothing.

I think it is supposed to prevent the player from setting his max level above 60 while he's still in Vanilla.
And 70 while still in TBC.

But this does not work at all. 
You can set your max level above 60 while still below progression level 8.

OnPlayerGiveXP handles the not gaining xp part at level 60 and before progression level 8.

so I really don't know why IP has the OnPlayerSetMaxLevel override.

as always, everyone is a tester for this module. so I'll just go ahead and merge this.
we'll find out if I'm overlooking something.