### PR TITLE
ip setrep command

### DIFF
--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -422,3 +422,26 @@ IndividualProgression.ExcludedAccountsRegex = "^RNDBOT.*"
 #        Default:     80
 #
 IndividualProgression.ExcludedAccountsMaxLevel = 80
+
+# IndividualProgression.EnableSetRepCommand
+#
+#        Description: Enable the .ip setrep command for normal AND gm account
+#                     This command will set the reputation of certain factions to the same value as the character that has the highest value on your account.
+#                     This will only work for factions that are shared between Alliance and Horde with several exceptions like Aldor/Scryers.
+#                     Use IndividualProgression.sharedFactionIdsRegex to set the allowed factions players can share with the characters on their account.
+#
+#        Default:     0 - Disabled
+#                     1 - Enabled
+#
+IndividualProgression.EnableSetRepCommand = 0
+
+# IndividualProgression.sharedFactionIdsRegex
+#
+#        Description: This is a list of faction ids that the player can share with other charactesr on his account.
+#                     EnableSetRepCommand needs to be enabled.
+#                     Valid faction ids are: 
+#                     see also: https://www.wowhead.com/wotlk/factions
+#
+#        Default:     "270|529|576|970|1077"
+#
+IndividualProgression.sharedFactionIdsRegex = "270|529|576|970|1077"

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -425,7 +425,7 @@ IndividualProgression.ExcludedAccountsMaxLevel = 80
 
 # IndividualProgression.EnableSetRepCommand
 #
-#        Description: Enable the .ip setrep command for normal AND gm account
+#        Description: Enable the .ip setrep command for normal AND gm accounts
 #                     This command will set the reputation of certain factions to the same value as the character that has the highest value on your account.
 #                     This will only work for factions that are shared between Alliance and Horde with several exceptions like Aldor/Scryers.
 #                     Use IndividualProgression.sharedFactionIdsRegex to set the allowed factions players can share with the characters on their account.
@@ -437,9 +437,9 @@ IndividualProgression.EnableSetRepCommand = 0
 
 # IndividualProgression.sharedFactionIdsRegex
 #
-#        Description: This is a list of faction ids that the player can share with other charactesr on his account.
+#        Description: This is a list of faction ids that the player can share with other characters on their account.
 #                     EnableSetRepCommand needs to be enabled.
-#                     Valid faction ids are: 
+#                     Valid faction ids are: 59|270|349|529|576|609|749|909|933|942|970|1011|1015|1077
 #                     see also: https://www.wowhead.com/wotlk/factions
 #
 #        Default:     "59|270|349|529|576|609|749|909|933|942|970|1011|1015|1077"

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -440,12 +440,12 @@ IndividualProgression.EnableSetRepCommand = 0
 #        Description: This is a list of faction ids that the player can share with other characters on their account.
 #                     EnableSetRepCommand needs to be enabled.
 #                     Valid faction ids are: 
-#                     - vanilla = 59|270|349|529|576|589|609|729|730|749|889|890|909
+#                     - vanilla = 59|270|349|509|510|529|576|589|609|729|730|749|889|890|909
 #                     - tbc     = 933|942|946|947|970|989|1011|1015|1038|1077
 #                     - wotlk   = 1037|1052|1073|1090|1091|1094|1098|1119|1124|1156
 #
 #                     see also: https://www.wowhead.com/wotlk/factions
 #
-#        Default:     "59|270|349|529|576|589|609|729|730|749|889|890|909"
+#        Default:     "59|270|349|509|510|529|576|589|609|729|730|749|889|890|909"
 #
-IndividualProgression.sharedFactionIdsRegex = "59|270|349|529|576|589|609|729|730|749|889|890|909"
+IndividualProgression.sharedFactionIdsRegex = "59|270|349|509|510|529|576|589|609|729|730|749|889|890|909"

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -442,6 +442,6 @@ IndividualProgression.EnableSetRepCommand = 0
 #                     Valid faction ids are: 
 #                     see also: https://www.wowhead.com/wotlk/factions
 #
-#        Default:     "59|270|349|529|576|609|749|909|933|970|1011|1015|1077"
+#        Default:     "59|270|349|529|576|609|749|909|933|942|970|1011|1015|1077"
 #
-IndividualProgression.sharedFactionIdsRegex = "59|270|349|529|576|609|749|909|933|970|1011|1015|1077"
+IndividualProgression.sharedFactionIdsRegex = "59|270|349|529|576|609|749|909|933|942|970|1011|1015|1077"

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -439,9 +439,13 @@ IndividualProgression.EnableSetRepCommand = 0
 #
 #        Description: This is a list of faction ids that the player can share with other characters on their account.
 #                     EnableSetRepCommand needs to be enabled.
-#                     Valid faction ids are: 59|270|349|529|576|609|749|909|933|942|970|1011|1015|1077
+#                     Valid faction ids are: 
+#                     - vanilla = 59|270|349|529|576|589|609|729|730|749|889|890|909
+#                     - tbc     = 933|942|946|947|970|989|1011|1015|1038|1077
+#                     - wotlk   = 1037|1052|1073|1090|1091|1094|1098|1119|1124|1156
+#
 #                     see also: https://www.wowhead.com/wotlk/factions
 #
-#        Default:     "59|270|349|529|576|609|749|909|933|942|970|1011|1015|1077"
+#        Default:     "59|270|349|529|576|589|609|729|730|749|889|890|909"
 #
-IndividualProgression.sharedFactionIdsRegex = "59|270|349|529|576|609|749|909|933|942|970|1011|1015|1077"
+IndividualProgression.sharedFactionIdsRegex = "59|270|349|529|576|589|609|729|730|749|889|890|909"

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -442,6 +442,6 @@ IndividualProgression.EnableSetRepCommand = 0
 #                     Valid faction ids are: 
 #                     see also: https://www.wowhead.com/wotlk/factions
 #
-#        Default:     "270|529|576|970|1077"
+#        Default:     "59|270|349|529|576|609|749|909|933|970|1011|1015|1077"
 #
-IndividualProgression.sharedFactionIdsRegex = "270|529|576|970|1077"
+IndividualProgression.sharedFactionIdsRegex = "59|270|349|529|576|609|749|909|933|970|1011|1015|1077"

--- a/data/sql/world/base/cs_individualProgression.sql
+++ b/data/sql/world/base/cs_individualProgression.sql
@@ -1,6 +1,7 @@
-DELETE FROM `command` WHERE `name` IN ('individualProgression set', 'ip set', 'ip setbot', 'ip get', 'ip view', 'ip tele');
+DELETE FROM `command` WHERE `name` IN ('ip get', 'ip set', 'ip setbot', 'ip setrep', 'ip tele');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
+('ip get', 0, 'Syntax: .ip get\nShows your or your targets current progression level.'),
 ('ip set', 2, 'Syntax: .ip set $progressionLevel\nSets the player to the given progression level.'),
 ('ip setbot', 0, 'Syntax: .ip setbot\nSets all bots in the group to your progression level.'),
-('ip get', 0, 'Syntax: .ip get\nShows your or your targets current progression level.'),
+('ip setrep', 0, 'Syntax: .ip setrep\nSets your reputation of certain factions to the same value as the character that has the highest value on your account.'),
 ('ip tele', 2, 'Syntax: .ip tele $location\nTeleports the player to the given location.');

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -869,7 +869,7 @@ private:
         sIndividualProgression->DisableQuestMarkers = sConfigMgr->GetOption<bool>("IndividualProgression.DisableQuestMarkers", true);
         sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", true);
         sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "^RNDBOT.*");
-        sIndividualProgression->sharedFactionIdsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.sharedFactionIdsRegex", "59|270|349|529|576|589|609|729|730|749|889|890|909");
+        sIndividualProgression->sharedFactionIdsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.sharedFactionIdsRegex", "59|270|349|509|510|529|576|589|609|729|730|749|889|890|909");
         sIndividualProgression->ExcludedAccountsMaxLevel = sConfigMgr->GetOption<uint8>("IndividualProgression.ExcludedAccountsMaxLevel", 80);
     }
 

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -151,35 +151,36 @@ void IndividualProgression::UpdateAccountReputation(uint32 factionId, uint32 acc
     if (!factionId || !accountId || !player || !player->IsInWorld())
         return;
 
+    Group* group = player->GetGroup();
+    uint32 account = player->GetSession()->GetAccountId();
+
+    if (!group)
+        return;
+
     uint32 curRep = player->GetReputationMgr().GetReputation(factionId);
     uint32 newRep = 0;
 
-    if (!curRep)
-        curRep = 0;
-
-    // Query reputation value for all characters on the account
-    QueryResult result = CharacterDatabase.Query(
-        "SELECT standing FROM character_reputation WHERE faction = {} AND guid IN(SELECT guid FROM characters WHERE ACCOUNT = {});",
-        factionId, accountId);
-
-    // set current reputation to the highest reputation value found on the account for the given faction
-    if (result)
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
     {
-        do
-        {
-            uint32 repAmount = (*result)[0].Get<uint32>();
+        Player* member = itr->GetSource();
+        if (!member || member->GetSession()->GetAccountId() != accountId)
+            continue;
 
-            if (repAmount > newRep)
-                newRep = repAmount;
-        } while (result->NextRow());
+        uint32 repAmount = member->GetReputationMgr().GetReputation(factionId);
+
+        if (repAmount > newRep)
+            newRep = repAmount;
     }
+
+    // ChatHandler(player->GetSession()).PSendSysMessage("Current {} Reputation = {}", factionId, curRep);
+    // ChatHandler(player->GetSession()).PSendSysMessage("Highest {} Reputation = {}", factionId, newRep);
 
     if (newRep > curRep)
     {
         std::string factionName = sFactionStore.LookupEntry(factionId)->name[0];
-        FactionEntry const* factionEntry = sFactionStore.LookupEntry(factionId);
+        uint32 addRep = newRep - curRep;
 
-        player->GetReputationMgr().SetReputation(factionEntry, static_cast<float>(newRep));
+        player->GetReputationMgr().ModifyReputation(sFactionStore.LookupEntry(factionId), addRep);
         ChatHandler(player->GetSession()).PSendSysMessage("New {} Reputation = {}", factionName, newRep);
     }
 }

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -868,7 +868,7 @@ private:
         sIndividualProgression->DisableQuestMarkers = sConfigMgr->GetOption<bool>("IndividualProgression.DisableQuestMarkers", true);
         sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", true);
         sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "^RNDBOT.*");
-        sIndividualProgression->sharedFactionIdsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.sharedFactionIdsRegex", "270|529|576|970|1077");
+        sIndividualProgression->sharedFactionIdsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.sharedFactionIdsRegex", "59|270|349|529|576|609|749|909|933|942|970|1011|1015|1077");
         sIndividualProgression->ExcludedAccountsMaxLevel = sConfigMgr->GetOption<uint8>("IndividualProgression.ExcludedAccountsMaxLevel", 80);
     }
 

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -179,7 +179,7 @@ void IndividualProgression::UpdateAccountReputation(uint32 factionId, uint32 acc
         std::string factionName = sFactionStore.LookupEntry(factionId)->name[0];
         FactionEntry const* factionEntry = sFactionStore.LookupEntry(factionId);
 
-        player->GetReputationMgr().SetReputation(factionEntry, static_cast<float>(curRep));
+        player->GetReputationMgr().SetReputation(factionEntry, static_cast<float>(newRep));
         ChatHandler(player->GetSession()).PSendSysMessage("New {} Reputation = {}", factionName, newRep);
     }
 }

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -4,6 +4,7 @@
 
 #include "IndividualProgression.h"
 #include "naxxramas_40.h"
+#include "ReputationMgr.h"
 
 IndividualProgression* IndividualProgression::instance()
 {
@@ -143,6 +144,44 @@ uint8 IndividualProgression::GetAccountProgression(uint32 accountId)
         } while (result->NextRow());
     }
     return progressionLevel;
+}
+
+void IndividualProgression::UpdateAccountReputation(uint32 factionId, uint32 accountId, Player* player)
+{
+    if (!factionId || !accountId || !player || !player->IsInWorld())
+        return;
+
+    uint32 curRep = player->GetReputationMgr().GetReputation(factionId);
+    uint32 newRep = 0;
+
+    if (!curRep)
+        curRep = 0;
+
+    // Query reputation value for all characters on the account
+    QueryResult result = CharacterDatabase.Query(
+        "SELECT standing FROM character_reputation WHERE faction = {} AND guid IN(SELECT guid FROM characters WHERE ACCOUNT = {});",
+        factionId, accountId);
+
+    // set current reputation to the highest reputation value found on the account for the given faction
+    if (result)
+    {
+        do
+        {
+            uint32 repAmount = (*result)[0].Get<uint32>();
+
+            if (repAmount > newRep)
+                newRep = repAmount;
+        } while (result->NextRow());
+    }
+
+    if (newRep > curRep)
+    {
+        std::string factionName = sFactionStore.LookupEntry(factionId)->name[0];
+        FactionEntry const* factionEntry = sFactionStore.LookupEntry(factionId);
+
+        player->GetReputationMgr().SetReputation(factionEntry, static_cast<float>(curRep));
+        ChatHandler(player->GetSession()).PSendSysMessage("New {} Reputation = {}", factionName, newRep);
+    }
 }
 
 void IndividualProgression::RemovePlayerAchievement(uint16 playerGUID, uint16 achievementId)
@@ -806,8 +845,8 @@ private:
         sIndividualProgression->LoadCustomProgressionEntries(sConfigMgr->GetOption<std::string>("IndividualProgression.CustomProgression", ""));
         sIndividualProgression->earlyDungeonSet2 = sConfigMgr->GetOption<bool>("IndividualProgression.AllowEarlyDungeonSet2", false);
         sIndividualProgression->earlyScourgeBosses = sConfigMgr->GetOption<bool>("IndividualProgression.AllowEarlyScourgeBosses", false);
-		sIndividualProgression->tbcArenaSeason = sConfigMgr->GetOption<uint8>("IndividualProgression.TBC.ArenaSeason", 1);
-		sIndividualProgression->wotlkArenaSeason = sConfigMgr->GetOption<uint8>("IndividualProgression.WotLK.ArenaSeason", 5);
+        sIndividualProgression->tbcArenaSeason = sConfigMgr->GetOption<uint8>("IndividualProgression.TBC.ArenaSeason", 1);
+        sIndividualProgression->wotlkArenaSeason = sConfigMgr->GetOption<uint8>("IndividualProgression.WotLK.ArenaSeason", 5);
         sIndividualProgression->VanillaPvpKillRank1 = sConfigMgr->GetOption<uint32>("IndividualProgression.VanillaPvpKillRequirement.Rank1", 100);
         sIndividualProgression->VanillaPvpKillRank2 = sConfigMgr->GetOption<uint32>("IndividualProgression.VanillaPvpKillRequirement.Rank2", 200);
         sIndividualProgression->VanillaPvpKillRank3 = sConfigMgr->GetOption<uint32>("IndividualProgression.VanillaPvpKillRequirement.Rank3", 400);
@@ -829,6 +868,7 @@ private:
         sIndividualProgression->DisableQuestMarkers = sConfigMgr->GetOption<bool>("IndividualProgression.DisableQuestMarkers", true);
         sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", true);
         sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "^RNDBOT.*");
+        sIndividualProgression->sharedFactionIdsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.sharedFactionIdsRegex", "270|529|576|970|1077");
         sIndividualProgression->ExcludedAccountsMaxLevel = sConfigMgr->GetOption<uint8>("IndividualProgression.ExcludedAccountsMaxLevel", 80);
     }
 

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -868,7 +868,7 @@ private:
         sIndividualProgression->DisableQuestMarkers = sConfigMgr->GetOption<bool>("IndividualProgression.DisableQuestMarkers", true);
         sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", true);
         sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "^RNDBOT.*");
-        sIndividualProgression->sharedFactionIdsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.sharedFactionIdsRegex", "59|270|349|529|576|609|749|909|933|942|970|1011|1015|1077");
+        sIndividualProgression->sharedFactionIdsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.sharedFactionIdsRegex", "59|270|349|529|576|589|609|729|730|749|889|890|909");
         sIndividualProgression->ExcludedAccountsMaxLevel = sConfigMgr->GetOption<uint8>("IndividualProgression.ExcludedAccountsMaxLevel", 80);
     }
 

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -400,10 +400,10 @@ public:
     std::map<uint32, uint8> customProgressionMap;
     questXpMapType questXpMap;
     float vanillaPowerAdjustment, tbcPowerAdjustment, vanillaHealingAdjustment, tbcHealingAdjustment;
-    bool enabled, questXpFix, enforceGroupRules, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, excludeAccounts, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, ExcludedAccountsEarnPvPTitles;
+    bool enabled, questXpFix, enforceGroupRules, EnableSetRepCommand, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, excludeAccounts, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, ExcludedAccountsEarnPvPTitles;
     int progressionLimit, startingProgression, tbcRacesProgressionLevel, tbcRacesStartingProgression, deathKnightProgressionLevel, deathKnightStartingProgression, RequiredZulGurubProgression, tbcArenaSeason, wotlkArenaSeason, ExcludedAccountsMaxLevel;
     uint32 VanillaPvpKillRank1, VanillaPvpKillRank2, VanillaPvpKillRank3, VanillaPvpKillRank4, VanillaPvpKillRank5, VanillaPvpKillRank6, VanillaPvpKillRank7, VanillaPvpKillRank8, VanillaPvpKillRank9, VanillaPvpKillRank10, VanillaPvpKillRank11, VanillaPvpKillRank12, VanillaPvpKillRank13, VanillaPvpKillRank14;
-    std::string excludedAccountsRegex;
+    std::string excludedAccountsRegex, sharedFactionIdsRegex;
 
     // progression is derived from rewarded hidden quests (IDs 66000 + progression)
     uint8 GetPlayerProgressionFromQuests(Player* player) const;

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -19,6 +19,7 @@ public:
             { "set",    HandleSetIndividualProgressionCommand,    SEC_GAMEMASTER,    Console::Yes },
             { "tele",   HandleTeleIndividualProgressionCommand,   SEC_GAMEMASTER,    Console::Yes },
             { "setbot", HandleSetBotIndividualProgressionCommand, SEC_GAMEMASTER,    Console::Yes },
+            { "setrep", HandleSetRepIndividualProgressionCommand, SEC_GAMEMASTER,    Console::Yes },
         };
 
         static ChatCommandTable commandTable =
@@ -173,8 +174,43 @@ public:
             sIndividualProgression->checkIPPhasing(member, currentArea);
         }
 
-        handler->PSendSysMessage("Updated Progression Level for all RND bots = |cff00ffff{}|r", currentState);
+        handler->PSendSysMessage("Updated Progression Level for all bots = |cff00ffff{}|r", currentState);
         return true;
+    }
+
+    static bool HandleSetRepIndividualProgressionCommand(ChatHandler* handler)
+    {
+        Player* player = handler->GetSession()->GetPlayer();
+        uint32 accountId = handler->GetSession()->GetAccountId();
+
+        if (!player || !accountId)
+            return false;
+
+        if (!sIndividualProgression->EnableSetRepCommand)
+        {
+            handler->SendSysMessage("The .ip setrep command is currently disabled.");
+            return false;
+        }
+
+        static constexpr std::array<uint32, 5> Faction_Checklist =
+        {
+            270, // Zandalar Tribe
+            529, // Argent Dawn
+            576, // Timbermaw Hold
+            970, // Sporeggar
+            1077 // Shattered Sun Offensive
+        };
+
+        std::regex sharedFactionIdsRegex(sIndividualProgression->sharedFactionIdsRegex);
+
+        for (uint32 factionId : Faction_Checklist)
+        {
+            if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+            {
+                sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+                return true;
+            }
+        }
     }
 
     static bool HandleTeleIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player, std::string location)

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -234,11 +234,9 @@ public:
         for (uint32 factionId : Faction_Checklist)
         {
             if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
-            {
                 sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
-                return true;
-            }
         }
+        return true;
     }
 
     static bool HandleTeleIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player, std::string location)

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -192,7 +192,7 @@ public:
             return false;
         }
 
-        static constexpr std::array<uint32, 5> Faction_Checklist =
+        static constexpr std::array<uint32, 14> Faction_Checklist =
         {
             59,   // Thorium Brotherhood
             270,  // Zandalar Tribe

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -182,60 +182,103 @@ public:
     {
         Player* player = handler->GetSession()->GetPlayer();
         uint32 accountId = handler->GetSession()->GetAccountId();
-
+        
         if (!player || !accountId)
             return false;
 
+        Group* group = player->GetGroup();
+        
         if (!sIndividualProgression->EnableSetRepCommand)
         {
             handler->SendSysMessage("The .ip setrep command is currently disabled.");
             return false;
         }
+        
+        if (!group)
+        {
+            ChatHandler(player->GetSession()).PSendSysMessage("You need to be in a group to use this command.");
+            return false;
+        }
 
-        static constexpr std::array<uint32, 33> Faction_Checklist =
+        static constexpr std::array<uint32, 22> Shared_Checklist =
         {
             59,   // Thorium Brotherhood
             270,  // Zandalar Tribe
             349,  // Ravenholdt
             529,  // Argent Dawn
             576,  // Timbermaw Hold
-            589,  // Wintersaber Trainers
             609,  // Cenarion Circle
-            729,  // Frostwolf Clan
-            730,  // Stormpike Guard
             749,  // Hydraxian Waterlords
-            889,  // Warsong Outriders
-            890,  // Silverwing Sentinels
             909,  // Darkmoon Faire
             933,  // The Consortium
             942,  // Cenarion Expedition
-            946,  // Honor Hold
-            947,  // Thrallmar
             970,  // Sporeggar
             989,  // Keepers of Time
             1011, // Lower City
             1015, // Netherwing
-            1037, // Alliance Vanguard
             1038, // Ogri'la
-            1052, // Horde Expedition
             1073, // The Kalu'ak
             1077, // Shattered Sun Offensive
             1090, // Kirin Tor
             1091, // The Wyrmrest Accord
-            1094, // The Silver Covenant
             1098, // Knights of the Ebon Blade
             1119, // The Sons of Hodir
-            1124, // The Sunreavers
             1156  // The Ashen Verdict
+        };
+
+        static constexpr std::array<uint32, 7> Alliance_Checklist =
+        {
+            509,  // The League of Arathor
+            589,  // Wintersaber Trainers
+            730,  // Stormpike Guard
+            890,  // Silverwing Sentinels
+            946,  // Honor Hold
+            1037, // Alliance Vanguard
+            1094  // The Silver Covenant
+        };
+
+        static constexpr std::array<uint32, 6> Horde_Checklist =
+        {
+            510,  // The Defilers
+            729,  // Frostwolf Clan
+            889,  // Warsong Outriders
+            947,  // Thrallmar
+            1052, // Horde Expedition
+            1124  // The Sunreavers
         };
 
         std::regex sharedFactionIdsRegex(sIndividualProgression->sharedFactionIdsRegex);
 
-        for (uint32 factionId : Faction_Checklist)
+        TeamId teamId = player->GetTeamId(true);
+        if (teamId == TEAM_ALLIANCE)
         {
-            if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
-                sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+            for (uint32 factionId : Shared_Checklist)
+            {
+                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+            }
+
+            for (uint32 factionId : Alliance_Checklist)
+            {
+                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+            }
         }
+        if (teamId == TEAM_HORDE)
+        {
+            for (uint32 factionId : Shared_Checklist)
+            {
+                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+            }
+
+            for (uint32 factionId : Horde_Checklist)
+            {
+                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+            }
+        }
+
         return true;
     }
 

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -194,11 +194,20 @@ public:
 
         static constexpr std::array<uint32, 5> Faction_Checklist =
         {
-            270, // Zandalar Tribe
-            529, // Argent Dawn
-            576, // Timbermaw Hold
-            970, // Sporeggar
-            1077 // Shattered Sun Offensive
+            59,   // Thorium Brotherhood
+            270,  // Zandalar Tribe
+            349,  // Ravenholdt
+            529,  // Argent Dawn
+            576,  // Timbermaw Hold
+            609,  // Cenarion Circle
+            749,  // Hydraxian Waterlords
+            909,  // Darkmoon Faire
+            933,  // The Consortium
+            942,  // Cenarion Expedition
+            970,  // Sporeggar
+            1011, // Lower City
+            1015, // Netherwing
+            1077  // Shattered Sun Offensive
         };
 
         std::regex sharedFactionIdsRegex(sIndividualProgression->sharedFactionIdsRegex);

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -174,7 +174,7 @@ public:
             sIndividualProgression->checkIPPhasing(member, currentArea);
         }
 
-        handler->PSendSysMessage("Updated Progression Level for all bots = |cff00ffff{}|r", currentState);
+        handler->PSendSysMessage("Updated Progression Level for all RND bots = |cff00ffff{}|r", currentState);
         return true;
     }
 

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -192,22 +192,41 @@ public:
             return false;
         }
 
-        static constexpr std::array<uint32, 14> Faction_Checklist =
+        static constexpr std::array<uint32, 33> Faction_Checklist =
         {
             59,   // Thorium Brotherhood
             270,  // Zandalar Tribe
             349,  // Ravenholdt
             529,  // Argent Dawn
             576,  // Timbermaw Hold
+            589,  // Wintersaber Trainers
             609,  // Cenarion Circle
+            729,  // Frostwolf Clan
+            730,  // Stormpike Guard
             749,  // Hydraxian Waterlords
+            889,  // Warsong Outriders
+            890,  // Silverwing Sentinels
             909,  // Darkmoon Faire
             933,  // The Consortium
             942,  // Cenarion Expedition
+            946,  // Honor Hold
+            947,  // Thrallmar
             970,  // Sporeggar
+            989,  // Keepers of Time
             1011, // Lower City
             1015, // Netherwing
-            1077  // Shattered Sun Offensive
+            1037, // Alliance Vanguard
+            1038, // Ogri'la
+            1052, // Horde Expedition
+            1073, // The Kalu'ak
+            1077, // Shattered Sun Offensive
+            1090, // Kirin Tor
+            1091, // The Wyrmrest Accord
+            1094, // The Silver Covenant
+            1098, // Knights of the Ebon Blade
+            1119, // The Sons of Hodir
+            1124, // The Sunreavers
+            1156  // The Ashen Verdict
         };
 
         std::regex sharedFactionIdsRegex(sIndividualProgression->sharedFactionIdsRegex);


### PR DESCRIPTION
new `.ip setrep` command
usable by all accounts (normal and gm)

if enabled in the config file, this will allow the player to set the reputation of certain factions to the same value as the character that has the highest value on their account. You need to be in a group to use this command.

this way players don't have to grind the same reputation multiple times.

~~I still need to figure out the complete list of faction ids that don't cause any issues.~~

~~there still is an issue with reading and writing the correct reputation value~~
~~when cur rep is 42000, it reads it as exalted. when it should be neutral.~~
~~but in game if you want to set your reputation to exalted you would modify it to 42000, not 84000~~
~~trying to figure this out.~~

<img width="257" height="260" alt="Capture" src="https://github.com/user-attachments/assets/e768e109-8d87-42bf-83d2-7a8187a8eee6" />
