### PR TITLE
allow excluded account to make all characters

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -1153,14 +1153,20 @@ public:
         {
             return true;
         }
+
+        // Check if the account is excluded from progression (bots)
+        std::string accountName;
+        bool accountNameFound = AccountMgr::GetName(accountId, accountName);
+        std::regex excludedAccountsRegex(sIndividualProgression->excludedAccountsRegex);
+  
+        if (accountNameFound && std::regex_match(accountName, excludedAccountsRegex))
+			return true;
+
         uint8 highestProgression = sIndividualProgression->GetAccountProgression(accountId);
         if (charRace == RACE_DRAENEI || charRace == RACE_BLOODELF)
         {
-            if (sIndividualProgression->tbcRacesProgressionLevel)
-            {
-                if (highestProgression < sIndividualProgression->tbcRacesProgressionLevel)
-                    return false;
-            }
+            if (highestProgression < sIndividualProgression->tbcRacesProgressionLevel)
+                return false;
         }
         if (charClass == CLASS_DEATH_KNIGHT && sIndividualProgression->deathKnightProgressionLevel)
         {


### PR DESCRIPTION
if `IndividualProgression.TbcRacesUnlockProgression` was set to anything but 0 
it also prevented excluded accounts from creating Draenei and Blood Elves.

this could cause issues for playersbots when creating new bots.

now allowing excluded accounts to create all races and classes.