### PR TITLE
Limited setrep command

### DIFF
--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -438,10 +438,10 @@ IndividualProgression.EnableSetRepCommand = 0
 
 # IndividualProgression.HonoredSetRepCommand
 #
-#        Description: To avoid abuse, the player needs to be at least honored already with a faction to gain reputation for it.
+#        Description: To avoid abuse, the player needs to be at least neutral/friend/honored already with a faction to gain reputation for it. (depending on the faction)
 #                     This will help prevent a group of 5 characters to hand in a quest 1 by 1 and use the '.ip setrep' command in between each time to get 5x the reputation.
 #                     Needing to be honored means you already did most quests or already put in some reputation grind yourself.
-#                     (There are a few exceptions like the Cenarion Expedition, that many players will not do quests for until they are honored.)
+#                     PvP factions will require neutral reputation, so they are not effected. (see: cs_individualProgression.cpp for the full list)
 #
 #        Default:     1 - Enabled
 #                     0 - Disabled
@@ -454,7 +454,7 @@ IndividualProgression.HonoredSetRepCommand = 1
 #                     EnableSetRepCommand needs to be enabled.
 #                     Valid faction ids are: 
 #                     - vanilla = 59|270|349|509|510|529|576|589|609|729|730|749|889|890|909
-#                     - tbc     = 922|933|941|942|946|947|967|970|978|989|990|1011|1012|1015|1031|1038|1077
+#                     - tbc     = 922|932|933|934|941|942|946|947|967|970|978|989|990|1011|1012|1015|1031|1038|1077
 #                     - wotlk   = 1037|1052|1073|1090|1091|1094|1098|1119|1124|1156
 #
 #                     see also: https://www.wowhead.com/wotlk/factions

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -428,7 +428,7 @@ IndividualProgression.ExcludedAccountsMaxLevel = 80
 #        Description: Enable the .ip setrep command for normal AND gm accounts
 #                     This command will set the reputation of certain factions to the same value as the character that has the highest value on your account.
 #                     This will not work for factions like Aldor/Scryers, because characters could have made different choices.
-#                     To avoid abuse this command will by default not work for factions you aren't already honored with.
+#                     To avoid abuse this command will by default not work for factions you aren't already neutral/friend/honored with. (depending on the faction)
 #                     Use IndividualProgression.sharedFactionIdsRegex to set the allowed factions players can share with the characters on their account.
 #
 #        Default:     0 - Disabled

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -428,7 +428,7 @@ IndividualProgression.ExcludedAccountsMaxLevel = 80
 #        Description: Enable the .ip setrep command for normal AND gm accounts
 #                     This command will set the reputation of certain factions to the same value as the character that has the highest value on your account.
 #                     This will not work for factions like Aldor/Scryers, because characters could have made different choices.
-#                     To avoid abuse this command will by default not work for factions you aren't already neutral/friend/honored with. (depending on the faction)
+#                     To avoid abuse this command will by default not work for factions you aren't already neutral/friendly/honored with. (depending on the faction)
 #                     Use IndividualProgression.sharedFactionIdsRegex to set the allowed factions players can share with the characters on their account.
 #
 #        Default:     0 - Disabled
@@ -438,7 +438,7 @@ IndividualProgression.EnableSetRepCommand = 0
 
 # IndividualProgression.HonoredSetRepCommand
 #
-#        Description: To avoid abuse, the player needs to be at least neutral/friend/honored already with a faction to gain reputation for it. (depending on the faction)
+#        Description: To avoid abuse, the player needs to be at least neutral/friendly/honored already with a faction to gain reputation for it. (depending on the faction)
 #                     This will help prevent a group of 5 characters to hand in a quest 1 by 1 and use the '.ip setrep' command in between each time to get 5x the reputation.
 #                     Needing to be honored means you already did most quests or already put in some reputation grind yourself.
 #                     PvP factions will require neutral reputation, so they are not effected. (see: cs_individualProgression.cpp for the full list)

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -427,13 +427,26 @@ IndividualProgression.ExcludedAccountsMaxLevel = 80
 #
 #        Description: Enable the .ip setrep command for normal AND gm accounts
 #                     This command will set the reputation of certain factions to the same value as the character that has the highest value on your account.
-#                     This will not work for factions like Aldor/Scryers, because characters could have made different choices.
+#                     This will not work for factionss like Aldor/Scryers, because characters could have made different choices.
+#                     To avoid abuse this command will by default not work for factions you aren't already honored with.
 #                     Use IndividualProgression.sharedFactionIdsRegex to set the allowed factions players can share with the characters on their account.
 #
 #        Default:     0 - Disabled
 #                     1 - Enabled
 #
 IndividualProgression.EnableSetRepCommand = 0
+
+# IndividualProgression.HonoredSetRepCommand
+#
+#        Description: To avoid abuse, the player needs to be at least honored already with a faction to gain reputation for it.
+#                     This will help prevent a group of 5 characters to hand in a quest 1 by 1 and use the '.ip set' command in between each time to get 5x the reputation.
+#                     Needing to be honored means you already did most quests or already put in some reputation grind yourself.
+#                     (There are a few exceptions like the Cenarion Expedition, that many players will not do quests for until they are honored.)
+#
+#        Default:     1 - Enabled
+#                     0 - Disabled
+#
+IndividualProgression.HonoredSetRepCommand = 1
 
 # IndividualProgression.sharedFactionIdsRegex
 #

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -452,7 +452,7 @@ IndividualProgression.HonoredSetRepCommand = 1
 #        Description: This is a list of faction ids that the player can share with other characters on their account.
 #                     EnableSetRepCommand needs to be enabled.
 #                     Valid faction ids are: 
-#                     - vanilla = 59|270|349|509|510|529|576|589|609|729|730|749|889|890|909
+#                     - vanilla = 59|270|349|509|510|529|576|589|609|729|730|749|889|890|909|910
 #                     - tbc     = 922|932|933|934|935|941|942|946|947|967|970|978|989|990|1011|1012|1015|1031|1038|1077
 #                     - wotlk   = 1037|1052|1073|1090|1091|1094|1098|1119|1124|1156
 #

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -454,7 +454,7 @@ IndividualProgression.HonoredSetRepCommand = 1
 #                     EnableSetRepCommand needs to be enabled.
 #                     Valid faction ids are: 
 #                     - vanilla = 59|270|349|509|510|529|576|589|609|729|730|749|889|890|909
-#                     - tbc     = 922|932|933|934|941|942|946|947|967|970|978|989|990|1011|1012|1015|1031|1038|1077
+#                     - tbc     = 922|932|933|934|935|941|942|946|947|967|970|978|989|990|1011|1012|1015|1031|1038|1077
 #                     - wotlk   = 1037|1052|1073|1090|1091|1094|1098|1119|1124|1156
 #
 #                     see also: https://www.wowhead.com/wotlk/factions

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -427,7 +427,6 @@ IndividualProgression.ExcludedAccountsMaxLevel = 80
 #
 #        Description: Enable the .ip setrep command for normal AND gm accounts
 #                     This command will set the reputation of certain factions to the same value as the character that has the highest value on your account.
-#                     This will not work for factions like Aldor/Scryers, because characters could have made different choices.
 #                     To avoid abuse this command will by default not work for factions you aren't already neutral/friendly/honored with. (depending on the faction)
 #                     Use IndividualProgression.sharedFactionIdsRegex to set the allowed factions players can share with the characters on their account.
 #

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -441,6 +441,7 @@ IndividualProgression.EnableSetRepCommand = 0
 #                     This will help prevent a group of 5 characters to hand in a quest 1 by 1 and use the '.ip setrep' command in between each time to get 5x the reputation.
 #                     Needing to be honored means you already did most quests or already put in some reputation grind yourself.
 #                     PvP factions will require neutral reputation, so they are not effected. (see: cs_individualProgression.cpp for the full list)
+#                     The Aldor, The Scryers and the Brood of Nozdormu are exceptions. You need to be honored with them, even if this setting is disabled.
 #
 #        Default:     1 - Enabled
 #                     0 - Disabled

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -439,7 +439,7 @@ IndividualProgression.EnableSetRepCommand = 0
 # IndividualProgression.HonoredSetRepCommand
 #
 #        Description: To avoid abuse, the player needs to be at least honored already with a faction to gain reputation for it.
-#                     This will help prevent a group of 5 characters to hand in a quest 1 by 1 and use the '.ip set' command in between each time to get 5x the reputation.
+#                     This will help prevent a group of 5 characters to hand in a quest 1 by 1 and use the '.ip setrep' command in between each time to get 5x the reputation.
 #                     Needing to be honored means you already did most quests or already put in some reputation grind yourself.
 #                     (There are a few exceptions like the Cenarion Expedition, that many players will not do quests for until they are honored.)
 #

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -435,7 +435,7 @@ IndividualProgression.ExcludedAccountsMaxLevel = 80
 #
 IndividualProgression.EnableSetRepCommand = 0
 
-# IndividualProgression.HonoredSetRepCommand
+# IndividualProgression.LimitedSetRepCommand
 #
 #        Description: To avoid abuse, the player needs to be at least neutral/friendly/honored already with a faction to gain reputation for it. (depending on the faction)
 #                     This will help prevent a group of 5 characters to hand in a quest 1 by 1 and use the '.ip setrep' command in between each time to get 5x the reputation.
@@ -446,7 +446,7 @@ IndividualProgression.EnableSetRepCommand = 0
 #        Default:     1 - Enabled
 #                     0 - Disabled
 #
-IndividualProgression.HonoredSetRepCommand = 1
+IndividualProgression.LimitedSetRepCommand = 1
 
 # IndividualProgression.sharedFactionIdsRegex
 #

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -427,7 +427,7 @@ IndividualProgression.ExcludedAccountsMaxLevel = 80
 #
 #        Description: Enable the .ip setrep command for normal AND gm accounts
 #                     This command will set the reputation of certain factions to the same value as the character that has the highest value on your account.
-#                     This will not work for factionss like Aldor/Scryers, because characters could have made different choices.
+#                     This will not work for factions like Aldor/Scryers, because characters could have made different choices.
 #                     To avoid abuse this command will by default not work for factions you aren't already honored with.
 #                     Use IndividualProgression.sharedFactionIdsRegex to set the allowed factions players can share with the characters on their account.
 #

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -872,7 +872,7 @@ private:
         sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", true);
         sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "^RNDBOT.*");
         sIndividualProgression->EnableSetRepCommand = sConfigMgr->GetOption<bool>("IndividualProgression.EnableSetRepCommand", false);
-        sIndividualProgression->HonoredSetRepCommand = sConfigMgr->GetOption<bool>("IndividualProgression.HonoredSetRepCommand", true);
+        sIndividualProgression->LimitedSetRepCommand = sConfigMgr->GetOption<bool>("IndividualProgression.LimitedSetRepCommand", true);
         sIndividualProgression->sharedFactionIdsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.sharedFactionIdsRegex", "59|270|349|509|510|529|576|589|609|729|730|749|889|890|909");
         sIndividualProgression->ExcludedAccountsMaxLevel = sConfigMgr->GetOption<uint8>("IndividualProgression.ExcludedAccountsMaxLevel", 80);
     }

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -833,7 +833,6 @@ private:
         sIndividualProgression->requireNaxxStrath = sConfigMgr->GetOption<bool>("IndividualProgression.RequireNaxxStrathEntrance", false);
         sIndividualProgression->doableNaxx40Bosses = sConfigMgr->GetOption<bool>("IndividualProgression.doableNaxx40Bosses", false);
         sIndividualProgression->enforceGroupRules = sConfigMgr->GetOption<bool>("IndividualProgression.EnforceGroupRules", true);
-        sIndividualProgression->EnableSetRepCommand = sConfigMgr->GetOption<bool>("IndividualProgression.EnableSetRepCommand", false);
         sIndividualProgression->fishingFix = sConfigMgr->GetOption<bool>("IndividualProgression.FishingFix", true);
         sIndividualProgression->simpleConfigOverride = sConfigMgr->GetOption<bool>("IndividualProgression.SimpleConfigOverride", true);
         sIndividualProgression->progressionLimit = sConfigMgr->GetOption<uint8>("IndividualProgression.ProgressionLimit", 0);
@@ -872,6 +871,8 @@ private:
         sIndividualProgression->DisableQuestMarkers = sConfigMgr->GetOption<bool>("IndividualProgression.DisableQuestMarkers", true);
         sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", true);
         sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "^RNDBOT.*");
+        sIndividualProgression->EnableSetRepCommand = sConfigMgr->GetOption<bool>("IndividualProgression.EnableSetRepCommand", false);
+        sIndividualProgression->HonoredSetRepCommand = sConfigMgr->GetOption<bool>("IndividualProgression.HonoredSetRepCommand", true);
         sIndividualProgression->sharedFactionIdsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.sharedFactionIdsRegex", "59|270|349|509|510|529|576|589|609|729|730|749|889|890|909");
         sIndividualProgression->ExcludedAccountsMaxLevel = sConfigMgr->GetOption<uint8>("IndividualProgression.ExcludedAccountsMaxLevel", 80);
     }

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -400,7 +400,7 @@ public:
     std::map<uint32, uint8> customProgressionMap;
     questXpMapType questXpMap;
     float vanillaPowerAdjustment, tbcPowerAdjustment, vanillaHealingAdjustment, tbcHealingAdjustment;
-    bool enabled, questXpFix, enforceGroupRules, EnableSetRepCommand, HonoredSetRepCommand, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, excludeAccounts, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, ExcludedAccountsEarnPvPTitles;
+    bool enabled, questXpFix, enforceGroupRules, EnableSetRepCommand, LimitedSetRepCommand, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, excludeAccounts, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, ExcludedAccountsEarnPvPTitles;
     int progressionLimit, startingProgression, tbcRacesProgressionLevel, tbcRacesStartingProgression, deathKnightProgressionLevel, deathKnightStartingProgression, RequiredZulGurubProgression, tbcArenaSeason, wotlkArenaSeason, ExcludedAccountsMaxLevel;
     uint32 VanillaPvpKillRank1, VanillaPvpKillRank2, VanillaPvpKillRank3, VanillaPvpKillRank4, VanillaPvpKillRank5, VanillaPvpKillRank6, VanillaPvpKillRank7, VanillaPvpKillRank8, VanillaPvpKillRank9, VanillaPvpKillRank10, VanillaPvpKillRank11, VanillaPvpKillRank12, VanillaPvpKillRank13, VanillaPvpKillRank14;
     std::string excludedAccountsRegex, sharedFactionIdsRegex;

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -400,7 +400,7 @@ public:
     std::map<uint32, uint8> customProgressionMap;
     questXpMapType questXpMap;
     float vanillaPowerAdjustment, tbcPowerAdjustment, vanillaHealingAdjustment, tbcHealingAdjustment;
-    bool enabled, questXpFix, enforceGroupRules, EnableSetRepCommand, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, excludeAccounts, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, ExcludedAccountsEarnPvPTitles;
+    bool enabled, questXpFix, enforceGroupRules, EnableSetRepCommand, HonoredSetRepCommand, fishingFix, simpleConfigOverride, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, excludeAccounts, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, ExcludedAccountsEarnPvPTitles;
     int progressionLimit, startingProgression, tbcRacesProgressionLevel, tbcRacesStartingProgression, deathKnightProgressionLevel, deathKnightStartingProgression, RequiredZulGurubProgression, tbcArenaSeason, wotlkArenaSeason, ExcludedAccountsMaxLevel;
     uint32 VanillaPvpKillRank1, VanillaPvpKillRank2, VanillaPvpKillRank3, VanillaPvpKillRank4, VanillaPvpKillRank5, VanillaPvpKillRank6, VanillaPvpKillRank7, VanillaPvpKillRank8, VanillaPvpKillRank9, VanillaPvpKillRank10, VanillaPvpKillRank11, VanillaPvpKillRank12, VanillaPvpKillRank13, VanillaPvpKillRank14;
     std::string excludedAccountsRegex, sharedFactionIdsRegex;

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -276,42 +276,42 @@ public:
 
         std::regex sharedFactionIdsRegex(sIndividualProgression->sharedFactionIdsRegex);
         TeamId teamId = player->GetTeamId(true);
-        
+
+        for (uint32 factionId : Shared_Honored_Checklist)
+        {
+            if (sIndividualProgression->LimitedSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
+                continue;
+
+            if ((factionId == 910 || factionId == 932 || factionId == 934) && player->GetReputationRank(factionId) < REP_HONORED) // Skip if not Honored
+                continue;
+
+            if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+        }
+
+        for (uint32 factionId : Shared_Friendly_Checklist)
+        {
+            if (sIndividualProgression->LimitedSetRepCommand && player->GetReputationRank(factionId) < REP_FRIENDLY)
+                continue;
+
+            if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+        }
+
+        for (uint32 factionId : Shared_Neutral_Checklist)
+        {
+            if (sIndividualProgression->LimitedSetRepCommand && player->GetReputationRank(factionId) < REP_NEUTRAL)
+                continue;
+
+            if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+        }
+
         if (teamId == TEAM_ALLIANCE)
         {
-            for (uint32 factionId : Shared_Honored_Checklist)
-            {
-                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
-                    continue;
-
-                if ((factionId == 910 || factionId == 932 || factionId == 934) && player->GetReputationRank(factionId) < REP_HONORED) // Skip if not Honored
-                    continue;
-
-                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
-                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
-            }
-
-            for (uint32 factionId : Shared_Friendly_Checklist)
-            {
-                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_FRIENDLY)
-                    continue;
-
-                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
-                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
-            }
-
-            for (uint32 factionId : Shared_Neutral_Checklist)
-            {
-                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_NEUTRAL)
-                    continue;
-
-                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
-                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
-            }
-
             for (uint32 factionId : Alliance_Honored_Checklist)
             {
-                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
+                if (sIndividualProgression->LimitedSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
                     continue;
 
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
@@ -320,40 +320,19 @@ public:
 
             for (uint32 factionId : Alliance_Neutral_Checklist)
             {
-                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_NEUTRAL)
+                if (sIndividualProgression->LimitedSetRepCommand && player->GetReputationRank(factionId) < REP_NEUTRAL)
                     continue;
 
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }
         }
-        
+
         if (teamId == TEAM_HORDE)
         {
-            for (uint32 factionId : Shared_Honored_Checklist)
-            {
-                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
-                    continue;
-
-                if ((factionId == 910 || factionId == 932 || factionId == 934) && player->GetReputationRank(factionId) < REP_HONORED) // Skip if not Honored
-                    continue;
-                
-                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
-                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
-            }
-
-            for (uint32 factionId : Shared_Neutral_Checklist)
-            {
-                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_NEUTRAL)
-                    continue;
-
-                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
-                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
-            }
-
             for (uint32 factionId : Horde_Honored_Checklist)
             {
-                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
+                if (sIndividualProgression->LimitedSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
                     continue;
 
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
@@ -362,7 +341,7 @@ public:
 
             for (uint32 factionId : Horde_Neutral_Checklist)
             {
-                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_NEUTRAL)
+                if (sIndividualProgression->LimitedSetRepCommand && player->GetReputationRank(factionId) < REP_NEUTRAL)
                     continue;
 
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -218,11 +218,12 @@ public:
             1156  // The Ashen Verdict
         };
 
-        static constexpr std::array<uint32, 6> Shared_Friendly_Checklist =
+        static constexpr std::array<uint32, 7> Shared_Friendly_Checklist =
         {
             59,   // Thorium Brotherhood
             529,  // Argent Dawn
             609,  // Cenarion Circle
+            935,  // The Sha'tar
             1031, // Sha'tari Skyguard
             1038, // Ogri'la
             1098  // Knights of the Ebon Blade

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -200,36 +200,35 @@ public:
             return false;
         }
 
-        static constexpr std::array<uint32, 14> Shared_Honored_Checklist =
+        static constexpr std::array<uint32, 10> Shared_Honored_Checklist =
         {
+            910,  // Brood of Nozdormu
             932,  // The Aldor
             933,  // The Consortium
             934,  // The Scryers
             942,  // Cenarion Expedition
-            967,  // The Violet Eye
             989,  // Keepers of Time
-            990,  // The Scale of the Sands
             1011, // Lower City
-            1012, // Ashtongue Deathsworn
             1073, // The Kalu'ak
             1090, // Kirin Tor
-            1091, // The Wyrmrest Accord
-            1119, // The Sons of Hodir
-            1156  // The Ashen Verdict
+            1098  // Knights of the Ebon Blade
         };
 
-        static constexpr std::array<uint32, 7> Shared_Friendly_Checklist =
+        static constexpr std::array<uint32, 10> Shared_Friendly_Checklist =
         {
             59,   // Thorium Brotherhood
             529,  // Argent Dawn
             609,  // Cenarion Circle
             935,  // The Sha'tar
+            967,  // The Violet Eye
+            990,  // The Scale of the Sands
+            1012, // Ashtongue Deathsworn
             1031, // Sha'tari Skyguard
-            1038, // Ogri'la
-            1098  // Knights of the Ebon Blade
+            1091, // The Wyrmrest Accord
+            1119  // The Sons of Hodir
         };
 
-        static constexpr std::array<uint32, 8> Shared_Neutral_Checklist =
+        static constexpr std::array<uint32, 10> Shared_Neutral_Checklist =
         {
             270,  // Zandalar Tribe
             349,  // Ravenholdt
@@ -238,7 +237,9 @@ public:
             909,  // Darkmoon Faire
             970,  // Sporeggar
             1015, // Netherwing
-            1077  // Shattered Sun Offensive
+            1038, // Ogri'la
+            1077, // Shattered Sun Offensive
+            1156  // The Ashen Verdict
         };
 
         static constexpr std::array<uint32, 4> Alliance_Honored_Checklist =
@@ -275,7 +276,7 @@ public:
 
         std::regex sharedFactionIdsRegex(sIndividualProgression->sharedFactionIdsRegex);
         TeamId teamId = player->GetTeamId(true);
-
+        
         if (teamId == TEAM_ALLIANCE)
         {
             for (uint32 factionId : Shared_Honored_Checklist)
@@ -283,9 +284,9 @@ public:
                 if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
                     continue;
 
-                if ((factionId == 932 || factionId == 934) && player->GetReputationRank(factionId) < REP_HONORED) // Skip Aldor and Scryers if not Honored, as they are mutually exclusive factions
+                if ((factionId == 910 || factionId == 932 || factionId == 934) && player->GetReputationRank(factionId) < REP_HONORED) // Skip if not Honored
                     continue;
-                
+
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }
@@ -294,7 +295,7 @@ public:
             {
                 if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_FRIENDLY)
                     continue;
-               
+
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }
@@ -326,7 +327,7 @@ public:
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }
         }
-
+        
         if (teamId == TEAM_HORDE)
         {
             for (uint32 factionId : Shared_Honored_Checklist)
@@ -334,6 +335,9 @@ public:
                 if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
                     continue;
 
+                if ((factionId == 910 || factionId == 932 || factionId == 934) && player->GetReputationRank(factionId) < REP_HONORED) // Skip if not Honored
+                    continue;
+                
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -261,12 +261,18 @@ public:
         {
             for (uint32 factionId : Shared_Checklist)
             {
+                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
+                    continue;
+                
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }
 
             for (uint32 factionId : Alliance_Checklist)
             {
+                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
+                    continue;
+                
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }
@@ -275,12 +281,18 @@ public:
         {
             for (uint32 factionId : Shared_Checklist)
             {
+                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
+                    continue;
+                
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }
 
             for (uint32 factionId : Horde_Checklist)
             {
+                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
+                    continue;
+                
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -200,99 +200,166 @@ public:
             return false;
         }
 
-        static constexpr std::array<uint32, 26> Shared_Checklist =
+        static constexpr std::array<uint32, 14> Shared_Honored_Checklist =
         {
-            59,   // Thorium Brotherhood
-            270,  // Zandalar Tribe
-            349,  // Ravenholdt
-            529,  // Argent Dawn
-            576,  // Timbermaw Hold
-            609,  // Cenarion Circle
-            749,  // Hydraxian Waterlords
-            909,  // Darkmoon Faire
+            932,  // The Aldor
             933,  // The Consortium
+            934,  // The Scryers
             942,  // Cenarion Expedition
             967,  // The Violet Eye
-            970,  // Sporeggar
             989,  // Keepers of Time
             990,  // The Scale of the Sands
             1011, // Lower City
             1012, // Ashtongue Deathsworn
-            1015, // Netherwing
-            1031, // Sha'tari Skyguard
-            1038, // Ogri'la
             1073, // The Kalu'ak
-            1077, // Shattered Sun Offensive
             1090, // Kirin Tor
             1091, // The Wyrmrest Accord
-            1098, // Knights of the Ebon Blade
             1119, // The Sons of Hodir
             1156  // The Ashen Verdict
         };
 
-        static constexpr std::array<uint32, 8> Alliance_Checklist =
+        static constexpr std::array<uint32, 6> Shared_Friendly_Checklist =
         {
-            509,  // The League of Arathor
-            589,  // Wintersaber Trainers
-            730,  // Stormpike Guard
-            890,  // Silverwing Sentinels
+            59,   // Thorium Brotherhood
+            529,  // Argent Dawn
+            609,  // Cenarion Circle
+            1031, // Sha'tari Skyguard
+            1038, // Ogri'la
+            1098  // Knights of the Ebon Blade
+        };
+
+        static constexpr std::array<uint32, 8> Shared_Neutral_Checklist =
+        {
+            270,  // Zandalar Tribe
+            349,  // Ravenholdt
+            576,  // Timbermaw Hold
+            749,  // Hydraxian Waterlords
+            909,  // Darkmoon Faire
+            970,  // Sporeggar
+            1015, // Netherwing
+            1077  // Shattered Sun Offensive
+        };
+
+        static constexpr std::array<uint32, 4> Alliance_Honored_Checklist =
+        {
             946,  // Honor Hold
             978,  // Kurenai
             1037, // Alliance Vanguard
             1094  // The Silver Covenant
         };
 
-        static constexpr std::array<uint32, 8> Horde_Checklist =
+        static constexpr std::array<uint32, 4> Alliance_Neutral_Checklist =
         {
-            510,  // The Defilers
-            729,  // Frostwolf Clan
-            889,  // Warsong Outriders
-            922,  // Tranquillien
+            509,  // The League of Arathor
+            589,  // Wintersaber Trainers
+            730,  // Stormpike Guard
+            890   // Silverwing Sentinels
+        };
+
+        static constexpr std::array<uint32, 4> Horde_Honored_Checklist =
+        {
             941,  // Mag'har
             947,  // Thrallmar
             1052, // Horde Expedition
             1124  // The Sunreavers
         };
 
-        std::regex sharedFactionIdsRegex(sIndividualProgression->sharedFactionIdsRegex);
+        static constexpr std::array<uint32, 4> Horde_Neutral_Checklist =
+        {
+            510,  // The Defilers
+            729,  // Frostwolf Clan
+            889,  // Warsong Outriders
+            922   // Tranquillien
+        };
 
+        std::regex sharedFactionIdsRegex(sIndividualProgression->sharedFactionIdsRegex);
         TeamId teamId = player->GetTeamId(true);
+
         if (teamId == TEAM_ALLIANCE)
         {
-            for (uint32 factionId : Shared_Checklist)
+            for (uint32 factionId : Shared_Honored_Checklist)
             {
                 if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
+                    continue;
+
+                if ((factionId == 932 || factionId == 934) && player->GetReputationRank(factionId) < REP_HONORED) // Skip Aldor and Scryers if not Honored, as they are mutually exclusive factions
                     continue;
                 
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }
 
-            for (uint32 factionId : Alliance_Checklist)
+            for (uint32 factionId : Shared_Friendly_Checklist)
+            {
+                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_FRIENDLY)
+                    continue;
+               
+                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+            }
+
+            for (uint32 factionId : Shared_Neutral_Checklist)
+            {
+                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_NEUTRAL)
+                    continue;
+
+                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+            }
+
+            for (uint32 factionId : Alliance_Honored_Checklist)
             {
                 if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
                     continue;
-                
+
+                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+            }
+
+            for (uint32 factionId : Alliance_Neutral_Checklist)
+            {
+                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_NEUTRAL)
+                    continue;
+
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }
         }
+
         if (teamId == TEAM_HORDE)
         {
-            for (uint32 factionId : Shared_Checklist)
+            for (uint32 factionId : Shared_Honored_Checklist)
             {
                 if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
                     continue;
-                
+
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }
 
-            for (uint32 factionId : Horde_Checklist)
+            for (uint32 factionId : Shared_Neutral_Checklist)
+            {
+                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_NEUTRAL)
+                    continue;
+
+                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+            }
+
+            for (uint32 factionId : Horde_Honored_Checklist)
             {
                 if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_HONORED)
                     continue;
-                
+
+                if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
+                    sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
+            }
+
+            for (uint32 factionId : Horde_Neutral_Checklist)
+            {
+                if (sIndividualProgression->HonoredSetRepCommand && player->GetReputationRank(factionId) < REP_NEUTRAL)
+                    continue;
+
                 if (std::regex_match(std::to_string(factionId), sharedFactionIdsRegex))
                     sIndividualProgression->UpdateAccountReputation(factionId, accountId, player);
             }


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/pull/1182

this PR adds a config option related to the `.ip setrep` command.

To avoid abuse, the player needs to be at least honored already with a faction to gain reputation for it.
This will help prevent a group of 5 characters to hand in a quest 1 by 1 and use the '.ip setrep' command in between each time to get 5x the reputation.

Needing to be honored means you already did most quests or already put in some reputation grind yourself.
(There are a few exceptions like the Cenarion Expedition, that many players will not do quests for until they are honored.)

edit:
I may need to make this more specific. Because I realize that for pvp factions getting to honored is already a serious grind.
