### PR TITLE
Zora Regal Ashi kill quest credit

### DIFF
--- a/data/sql/world/base/aq_war.sql
+++ b/data/sql/world/base/aq_war.sql
@@ -16,11 +16,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (15634, 0, 0, 0, 101, 0, 100, 0, 1, 20, 0, 50000, 60000, 0, 11, 25839, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,       'Priestess of the Moon - On Near Player - Cast Mass Healing'),
 --
 (15740, 0, 0, 0, 0, 0, 100, 0, 60000, 60000, 60000, 60000, 0, 0, 11, 26167, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,  'Colossus of Zora - In Combat - Cast Colossal Smash'), -- https://www.youtube.com/watch?v=F4aAAo_GSrw
-(15740, 0, 1, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 15, 108745, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0,                'Colossus of Zora - On Death - Reward Quest Credit'),
 (15741, 0, 0, 0, 0, 0, 100, 0, 60000, 60000, 60000, 60000, 0, 0, 11, 26167, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,  'Colossus of Regal - In Combat - Cast Colossal Smash'),
-(15741, 0, 1, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 15, 108746, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0,                'Colossus of Regal - On Death - Reward Quest Credit'),
 (15742, 0, 0, 0, 0, 0, 100, 0, 60000, 60000, 60000, 60000, 0, 0, 11, 26167, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,  'Colossus of Ashi - In Combat - Cast Colossal Smash'),
-(15742, 0, 1, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 15, 108747, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0,                'Colossus of Ashi - On Death - Reward Quest Credit'),
 --
 (15758, 0, 0, 0, 0, 0, 100, 0, 8000, 12000, 8000, 12000, 0, 0, 11, 11971, 0, 0, 0, 0, 0, 21, 5, 0, 0, 0, 0, 0, 0, 0,   'Supreme Anubisath Warbringer - Within 0-5 Range - Cast Sundering Cleave'),
 (15810, 0, 0, 0, 9, 0, 100, 0, 0, 0, 6000, 9000, 0, 5, 11, 15496, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,            'Eroded Anubisath Warbringer - 0-5 Range - Cast Cleave'),

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -48,7 +48,10 @@ enum ProgressionBossIDs
     HALION               = 39863,
     RHAHK_ZOR            = 644,
     SNEED                = 643,
-    GILNID               = 1763
+    GILNID               = 1763,
+    COLOSSUS_ZORA        = 15740,
+    COLOSSUS_REGAL       = 15741,
+    COLOSSUS_ASHI        = 15742
 };
 
 enum BuffSpells
@@ -83,7 +86,10 @@ enum ProgressionQuestIDs
     BATTLE_UNDERCITY_HORDE    = 13267,
     BATTLE_UNDERCITY_ALLIANCE = 13377,
     SIMPLY_BANG_A_GONG        = 108743,
-    CHAOS_AND_DESTRUCTION     = 108744
+    CHAOS_AND_DESTRUCTION     = 108744,
+    QUEST_COLOSSUS_ZORA       = 108745,
+    QUEST_COLOSSUS_REGAL      = 108746,
+    QUEST_COLOSSUS_ASHI       = 108747
 };
 
 enum WarEffortQuestIDs

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -1125,11 +1125,39 @@ public:
         
         if (killed->GetCreatureTemplate()->rank > CREATURE_ELITE_NORMAL)
         {
-            sIndividualProgression->checkKillProgression(killer, killed);
             Group* group = killer->GetGroup();
             if (!group)
                 return;
 
+            if (killed->GetEntry() == COLOSSUS_ZORA || killed->GetEntry() == COLOSSUS_REGAL || killed->GetEntry() == COLOSSUS_ASHI)
+            {
+                for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+                {
+                    Player* member = itr->GetSource();
+                    if (!member || sIndividualProgression->isExcludedFromProgression(member))
+                        continue;
+
+                    if (killed->GetEntry() == COLOSSUS_ZORA)
+                    {
+                        if (member->hasQuest(QUEST_COLOSSUS_ZORA))
+                            member->CompleteQuest(QUEST_COLOSSUS_ZORA);
+                    }
+                    else if (killed->GetEntry() == COLOSSUS_REGAL)
+                    {
+                        if (member->hasQuest(QUEST_COLOSSUS_REGAL))
+                            member->CompleteQuest(QUEST_COLOSSUS_REGAL);
+                    }
+                    else if (killed->GetEntry() == COLOSSUS_ASHI)
+                    {
+                        if (member->hasQuest(QUEST_COLOSSUS_ASHI))
+                            member->CompleteQuest(QUEST_COLOSSUS_ASHI);
+                    }
+                }
+                return;
+            }
+
+            sIndividualProgression->checkKillProgression(killer, killed);
+            
             for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
             {
                 Player* member = itr->GetSource();

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -1139,17 +1139,17 @@ public:
 
                     if (killed->GetEntry() == COLOSSUS_ZORA)
                     {
-                        if (member->hasQuest(QUEST_COLOSSUS_ZORA))
+                        if (member->hasQuest(QUEST_COLOSSUS_ZORA) && member->GetQuestStatus(QUEST_COLOSSUS_ZORA) != QUEST_STATUS_COMPLETE)
                             member->CompleteQuest(QUEST_COLOSSUS_ZORA);
                     }
                     else if (killed->GetEntry() == COLOSSUS_REGAL)
                     {
-                        if (member->hasQuest(QUEST_COLOSSUS_REGAL))
+                        if (member->hasQuest(QUEST_COLOSSUS_REGAL) && member->GetQuestStatus(QUEST_COLOSSUS_REGAL) != QUEST_STATUS_COMPLETE)
                             member->CompleteQuest(QUEST_COLOSSUS_REGAL);
                     }
                     else if (killed->GetEntry() == COLOSSUS_ASHI)
                     {
-                        if (member->hasQuest(QUEST_COLOSSUS_ASHI))
+                        if (member->hasQuest(QUEST_COLOSSUS_ASHI) && member->GetQuestStatus(QUEST_COLOSSUS_ASHI) != QUEST_STATUS_COMPLETE)
                             member->CompleteQuest(QUEST_COLOSSUS_ASHI);
                     }
                 }


### PR DESCRIPTION
Several players still reported not getting quest credit.
I still can't reproduce the issue, which makes it guess work what could possibly fix this,
because I can't test if something made a difference.

So here is another guess.

I'm now using cpp. On kill I'm completing the related quest for members that have the quest.

I've removed the previous method of doing this with smartAI, 
that clearly didn't fix it for the people that experience this issue.