### PR TITLE
Separate bot accounts

### DIFF
--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -75,7 +75,7 @@ IndividualProgression.TBCHealingAdjustment = 1
 
 # IndividualProgression.BotOnlyAdjustments
 #
-#        Description: In dungeons and raids, the Vanilla and TBC adjustments effect bots only.
+#        Description: In dungeons and raids, the Vanilla and TBC adjustments effect RNDbots only.
 #                     Make dungeons and raids harder without effecting real players.
 #
 #        Default:     0 - Disabled

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -73,6 +73,16 @@ IndividualProgression.TBCPowerAdjustment = 1
 #
 IndividualProgression.TBCHealingAdjustment = 1
 
+# IndividualProgression.BotOnlyAdjustments
+#
+#        Description: In dungeons and raids, the Vanilla and TBC adjustments effect bots only.
+#                     Make dungeons and raids harder without effecting real players.
+#
+#        Default:     0 - Disabled
+#                     1 - Enabled
+#
+IndividualProgression.BotOnlyAdjustments = 0
+
 # IndividualProgression.QuestXPFix
 #
 #        Description: Quest XP for Vanilla and TBC quests was boosted as a catchup mechanism in patches 2.3.0 and 3.0.2

--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -396,44 +396,43 @@ IndividualProgression.VanillaPvpTitlesPersistAfterVanilla = 1
 #
 IndividualProgression.VanillaPvpEarnTitlesAfterVanilla = 0
 
-# IndividualProgression.ExcludedAccountsEarnPvPTitles
+# IndividualProgression.BotAccountsEarnPvPTitles
 #
-#        Description: Enable / Disable excluded accounts earning pvp titles. This includes playerbots.
+#        Description: Enable / Disable bot accounts earning pvp titles.
 #
 #        Default:     0 - Disabled
 #                     1 - Enabled
 #
-IndividualProgression.ExcludedAccountsEarnPvPTitles = 0
+IndividualProgression.BotAccountsEarnPvPTitles = 0
 
-# IndividualProgression.ExcludeAccounts
+# IndividualProgression.BotAccountsMaxLevel
 #
-#        Description: Enable or disable the exclusion of accounts from Individual Progression.
-#                     This is useful for accounts that are used for bots, testing, or other purposes where progression should not be enforced.
+#        Description: Set the maximum level for bot accounts
 #
-#        Default:     1 - Enabled
-#                     0 - Disabled
+#        Default:     80
 #
-IndividualProgression.ExcludeAccounts = 1
+IndividualProgression.BotAccountsMaxLevel = 80
 
-# IndividualProgression.ExcludedAccountsRegex
+# IndividualProgression.BotAccountsRegex
 #
 #        Description: A regular expression to match account names that should be excluded from Individual Progression.
-#                     Only used if ExcludeAccounts is enabled.
-#                     This is useful for accounts that are used for bots, testing, or other purposes where progression should not be enforced.
+#                     This is for accounts that are used for bots.
 #                     If the Playerbots module is enabled, "^RNDBOT.*" will exclude randombots from Individual Progression.
 #                     To add more accounts you need to use capital letters and this format: "(^RNDBOT.*|TEST1|TEST2)"
 #
 #        Default:     "^RNDBOT.*"
 #
-IndividualProgression.ExcludedAccountsRegex = "^RNDBOT.*"
+IndividualProgression.BotAccountsRegex = "^RNDBOT.*"
 
-# IndividualProgression.ExcludedAccountsMaxLevel
+# IndividualProgression.ExcludedAccountsRegex
 #
-#        Description: Set the maximum level for Excluded Accounts (RNDBOTS)
+#        Description: A regular expression to match account names that should be excluded from Individual Progression.
+#                     This is useful for accounts that are used for testing or other purposes where progression should not be enforced.
+#                     To add more accounts you need to use capital letters and this format: "(ACCOUNTA|ACCOUNTB)"
 #
-#        Default:     80
+#        Default:     ""
 #
-IndividualProgression.ExcludedAccountsMaxLevel = 80
+IndividualProgression.ExcludedAccountsRegex = ""
 
 # IndividualProgression.EnableSetRepCommand
 #

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -238,15 +238,39 @@ bool IndividualProgression::isAttuned(Player* player)
         return false;
 }
 
-bool IndividualProgression::isExcludedFromProgression(Player* player)
+bool IndividualProgression::isExcludedAccount(Player* player)
 {
-    if (!player || !sIndividualProgression->excludeAccounts)
+    if (!player)
         return false;
 
     std::string accountName;
     bool accountNameFound = AccountMgr::GetName(player->GetSession()->GetAccountId(), accountName);
     std::regex excludedAccountsRegex(sIndividualProgression->excludedAccountsRegex);
+
     return (accountNameFound && std::regex_match(accountName, excludedAccountsRegex));
+}
+
+bool IndividualProgression::isBotAccount(Player* player)
+{
+    if (!player)
+        return false;
+
+    std::string accountName;
+    bool accountNameFound = AccountMgr::GetName(player->GetSession()->GetAccountId(), accountName);
+    std::regex botAccountsRegex(sIndividualProgression->botAccountsRegex);
+
+    return (accountNameFound && std::regex_match(accountName, botAccountsRegex));
+}
+
+bool IndividualProgression::isNormalAccount(Player* player)
+{
+    if (!player)
+        return false;
+
+    if (sIndividualProgression->isExcludedAccount(player) || sIndividualProgression->isBotAccount(player))
+        return false;
+
+    return true;
 }
 
 void IndividualProgression::SyncBotsProgressionToLeader(Group* group)
@@ -259,7 +283,7 @@ void IndividualProgression::SyncBotsProgressionToLeader(Group* group)
         return;
 
     Player* leader = ObjectAccessor::FindPlayer(leaderGuid);
-    if (!leader || isExcludedFromProgression(leader))
+    if (!leader || isExcludedAccount(leader))
         return;
 
     uint8 refProgress = GetPlayerProgressionFromQuests(leader);
@@ -270,7 +294,7 @@ void IndividualProgression::SyncBotsProgressionToLeader(Group* group)
     for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
     {
         Player* member = itr->GetSource();
-        if (!member || !isExcludedFromProgression(member))
+        if (!member || !isExcludedAccount(member))
             continue;
 
         ForceUpdateProgressionState(member, static_cast<ProgressionState>(refProgress));
@@ -407,13 +431,13 @@ void IndividualProgression::checkIPPhasing(Player* player, uint32 newArea)
         case AREA_THE_DAWNING_SQUARE:
             player->RemoveAura(SONG_OF_VICTORY);
 
-            if (isExcludedFromProgression(player) || player->GetReputationRank(FACTION_SHATTERED_SUN) >= REP_REVERED)
+            if (isExcludedAccount(player) || player->GetReputationRank(FACTION_SHATTERED_SUN) >= REP_REVERED)
             {
                 player->CastSpell(player, IPP_PHASE_II, false);
                 player->CastSpell(player, IPP_PHASE_III, false);
                 player->CastSpell(player, IPP_PHASE_IV, false);
 
-                if (isExcludedFromProgression(player) ||
+                if (isExcludedAccount(player) ||
                     (player->GetQuestStatus(QUEST_CRUSH_DAWNBLADE) == QUEST_STATUS_REWARDED &&
                      player->GetQuestStatus(QUEST_GREENGILL_COAST) == QUEST_STATUS_REWARDED &&
                      player->GetQuestStatus(QUEST_ENEMY_AT_BAY) == QUEST_STATUS_REWARDED))
@@ -537,7 +561,7 @@ void IndividualProgression::checkIPPhasing(Player* player, uint32 newArea)
             {
                 player->RemoveAura(SONG_OF_VICTORY);
 
-                if (isExcludedFromProgression(player) ||
+                if (isExcludedAccount(player) ||
                     (player->GetQuestStatus(QUEST_CRUSH_DAWNBLADE) == QUEST_STATUS_REWARDED &&
                      player->GetQuestStatus(QUEST_GREENGILL_COAST) == QUEST_STATUS_REWARDED &&
                      player->GetQuestStatus(QUEST_ENEMY_AT_BAY) == QUEST_STATUS_REWARDED))
@@ -812,7 +836,7 @@ void IndividualProgression::AwardEarnedVanillaPvpTitles(Player* player)
         }
 
         const uint32_t chosenTitleId = player->GetUInt32Value(PLAYER_CHOSEN_TITLE);
-        const bool usesPvPTitle = ((chosenTitleId != 0 && chosenTitleId < 29) || isExcludedFromProgression(player)); // PvP Titles go from 1 to 28.
+        const bool usesPvPTitle = ((chosenTitleId != 0 && chosenTitleId < 29) || isExcludedAccount(player)); // PvP Titles go from 1 to 28.
 
         // remove all titles except highest
         for (IppPvPTitles title : pvpTitlesList)
@@ -876,16 +900,17 @@ private:
         sIndividualProgression->VanillaPvpKillRank14 = sConfigMgr->GetOption<uint32>("IndividualProgression.VanillaPvpKillRequirement.Rank14", 24000);
         sIndividualProgression->VanillaPvpTitlesKeepPostVanilla = sConfigMgr->GetOption<bool>("IndividualProgression.VanillaPvpTitlesPersistAfterVanilla", true);
         sIndividualProgression->VanillaPvpTitlesEarnPostVanilla = sConfigMgr->GetOption<bool>("IndividualProgression.VanillaPvpEarnTitlesAfterVanilla", false);
-        sIndividualProgression->ExcludedAccountsEarnPvPTitles = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludedAccountsEarnPvPTitles", false);
+        sIndividualProgression->BotAccountsEarnPvPTitles = sConfigMgr->GetOption<bool>("IndividualProgression.BotAccountsEarnPvPTitles", false);
         sIndividualProgression->DisableRDF = sConfigMgr->GetOption<bool>("IndividualProgression.DisableRDF", false);
         sIndividualProgression->DisableQuestMarkers = sConfigMgr->GetOption<bool>("IndividualProgression.DisableQuestMarkers", true);
         sIndividualProgression->MaxMonsterSight = sConfigMgr->GetOption<bool>("IndividualProgression.MaxMonsterSight", true);
-        sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", true);
-        sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "^RNDBOT.*");
+//        sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", true);
+        sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "");
+        sIndividualProgression->botAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.BotAccountsRegex", "^RNDBOT.*");
         sIndividualProgression->EnableSetRepCommand = sConfigMgr->GetOption<bool>("IndividualProgression.EnableSetRepCommand", false);
         sIndividualProgression->LimitedSetRepCommand = sConfigMgr->GetOption<bool>("IndividualProgression.LimitedSetRepCommand", true);
         sIndividualProgression->sharedFactionIdsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.sharedFactionIdsRegex", "59|270|349|509|510|529|576|589|609|729|730|749|889|890|909");
-        sIndividualProgression->ExcludedAccountsMaxLevel = sConfigMgr->GetOption<uint8>("IndividualProgression.ExcludedAccountsMaxLevel", 80);
+        sIndividualProgression->BotAccountsMaxLevel = sConfigMgr->GetOption<uint8>("IndividualProgression.BotAccountsMaxLevel", 80);
     }
 
     static void LoadXpValues()

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -292,7 +292,7 @@ void IndividualProgression::SyncBotsProgressionToLeader(Group* group)
         return;
 
     Player* leader = ObjectAccessor::FindPlayer(leaderGuid);
-    if (!leader || isExcludedAccount(leader))
+    if (!leader || !isNormalAccount(leader))
         return;
 
     uint8 refProgress = GetPlayerProgressionFromQuests(leader);
@@ -303,7 +303,7 @@ void IndividualProgression::SyncBotsProgressionToLeader(Group* group)
     for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
     {
         Player* member = itr->GetSource();
-        if (!member || !isExcludedAccount(member))
+        if (!member || isNormalAccount(member))
             continue;
 
         ForceUpdateProgressionState(member, static_cast<ProgressionState>(refProgress));
@@ -440,13 +440,13 @@ void IndividualProgression::checkIPPhasing(Player* player, uint32 newArea)
         case AREA_THE_DAWNING_SQUARE:
             player->RemoveAura(SONG_OF_VICTORY);
 
-            if (isExcludedAccount(player) || player->GetReputationRank(FACTION_SHATTERED_SUN) >= REP_REVERED)
+            if (isBotAccount(player) || player->GetReputationRank(FACTION_SHATTERED_SUN) >= REP_REVERED)
             {
                 player->CastSpell(player, IPP_PHASE_II, false);
                 player->CastSpell(player, IPP_PHASE_III, false);
                 player->CastSpell(player, IPP_PHASE_IV, false);
 
-                if (isExcludedAccount(player) ||
+                if (isBotAccount(player) ||
                     (player->GetQuestStatus(QUEST_CRUSH_DAWNBLADE) == QUEST_STATUS_REWARDED &&
                      player->GetQuestStatus(QUEST_GREENGILL_COAST) == QUEST_STATUS_REWARDED &&
                      player->GetQuestStatus(QUEST_ENEMY_AT_BAY) == QUEST_STATUS_REWARDED))
@@ -570,7 +570,7 @@ void IndividualProgression::checkIPPhasing(Player* player, uint32 newArea)
             {
                 player->RemoveAura(SONG_OF_VICTORY);
 
-                if (isExcludedAccount(player) ||
+                if (isBotAccount(player) ||
                     (player->GetQuestStatus(QUEST_CRUSH_DAWNBLADE) == QUEST_STATUS_REWARDED &&
                      player->GetQuestStatus(QUEST_GREENGILL_COAST) == QUEST_STATUS_REWARDED &&
                      player->GetQuestStatus(QUEST_ENEMY_AT_BAY) == QUEST_STATUS_REWARDED))
@@ -845,7 +845,7 @@ void IndividualProgression::AwardEarnedVanillaPvpTitles(Player* player)
         }
 
         const uint32_t chosenTitleId = player->GetUInt32Value(PLAYER_CHOSEN_TITLE);
-        const bool usesPvPTitle = ((chosenTitleId != 0 && chosenTitleId < 29) || isExcludedAccount(player)); // PvP Titles go from 1 to 28.
+        const bool usesPvPTitle = ((chosenTitleId != 0 && chosenTitleId < 29) || isBotAccount(player)); // PvP Titles go from 1 to 28.
 
         // remove all titles except highest
         for (IppPvPTitles title : pvpTitlesList)

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -273,6 +273,15 @@ bool IndividualProgression::isNormalAccount(Player* player)
     return true;
 }
 
+bool IndividualProgression::isPlayerInDungeonOrRaid(Player* player)
+{
+    if (!player || !player->IsInWorld())
+        return false;
+
+    Map const* map = player->GetMap();
+    return (map && (map->IsDungeon() || map->IsRaid()));
+}
+
 void IndividualProgression::SyncBotsProgressionToLeader(Group* group)
 {
     if (!group)
@@ -904,7 +913,7 @@ private:
         sIndividualProgression->DisableRDF = sConfigMgr->GetOption<bool>("IndividualProgression.DisableRDF", false);
         sIndividualProgression->DisableQuestMarkers = sConfigMgr->GetOption<bool>("IndividualProgression.DisableQuestMarkers", true);
         sIndividualProgression->MaxMonsterSight = sConfigMgr->GetOption<bool>("IndividualProgression.MaxMonsterSight", true);
-//        sIndividualProgression->excludeAccounts = sConfigMgr->GetOption<bool>("IndividualProgression.ExcludeAccounts", true);
+        sIndividualProgression->BotOnlyAdjustments = sConfigMgr->GetOption<bool>("IndividualProgression.BotOnlyAdjustments", false);
         sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "");
         sIndividualProgression->botAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.BotAccountsRegex", "^RNDBOT.*");
         sIndividualProgression->EnableSetRepCommand = sConfigMgr->GetOption<bool>("IndividualProgression.EnableSetRepCommand", false);

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -400,7 +400,7 @@ public:
     std::map<uint32, uint8> customProgressionMap;
     questXpMapType questXpMap;
     float vanillaPowerAdjustment, tbcPowerAdjustment, vanillaHealingAdjustment, tbcHealingAdjustment;
-    bool enabled, questXpFix, enforceGroupRules, EnableSetRepCommand, LimitedSetRepCommand, fishingFix, simpleConfigOverride, MaxMonsterSight, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, BotAccountsEarnPvPTitles;
+    bool enabled, questXpFix, enforceGroupRules, EnableSetRepCommand, LimitedSetRepCommand, fishingFix, simpleConfigOverride, MaxMonsterSight, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, BotAccountsEarnPvPTitles, BotOnlyAdjustments;
     int progressionLimit, startingProgression, tbcRacesProgressionLevel, tbcRacesStartingProgression, deathKnightProgressionLevel, deathKnightStartingProgression, RequiredZulGurubProgression, tbcArenaSeason, wotlkArenaSeason, BotAccountsMaxLevel;
     uint32 VanillaPvpKillRank1, VanillaPvpKillRank2, VanillaPvpKillRank3, VanillaPvpKillRank4, VanillaPvpKillRank5, VanillaPvpKillRank6, VanillaPvpKillRank7, VanillaPvpKillRank8, VanillaPvpKillRank9, VanillaPvpKillRank10, VanillaPvpKillRank11, VanillaPvpKillRank12, VanillaPvpKillRank13, VanillaPvpKillRank14;
     std::string excludedAccountsRegex, botAccountsRegex, sharedFactionIdsRegex;
@@ -420,6 +420,7 @@ public:
     bool isNormalAccount(Player* player);
     void SyncBotsProgressionToLeader(Group* group);
     bool isAttuned(Player* player);
+    bool isPlayerInDungeonOrRaid(Player* player);
     void checkIPPhasing(Player* player, uint32 newArea);
     void checkIPProgression(Player* player);
     void UpdateProgressionAchievements(Player* player, uint16 achievementID);

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -400,10 +400,10 @@ public:
     std::map<uint32, uint8> customProgressionMap;
     questXpMapType questXpMap;
     float vanillaPowerAdjustment, tbcPowerAdjustment, vanillaHealingAdjustment, tbcHealingAdjustment;
-    bool enabled, questXpFix, enforceGroupRules, EnableSetRepCommand, LimitedSetRepCommand, fishingFix, simpleConfigOverride, MaxMonsterSight, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, excludeAccounts, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, ExcludedAccountsEarnPvPTitles;
-    int progressionLimit, startingProgression, tbcRacesProgressionLevel, tbcRacesStartingProgression, deathKnightProgressionLevel, deathKnightStartingProgression, RequiredZulGurubProgression, tbcArenaSeason, wotlkArenaSeason, ExcludedAccountsMaxLevel;
+    bool enabled, questXpFix, enforceGroupRules, EnableSetRepCommand, LimitedSetRepCommand, fishingFix, simpleConfigOverride, MaxMonsterSight, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, BotAccountsEarnPvPTitles;
+    int progressionLimit, startingProgression, tbcRacesProgressionLevel, tbcRacesStartingProgression, deathKnightProgressionLevel, deathKnightStartingProgression, RequiredZulGurubProgression, tbcArenaSeason, wotlkArenaSeason, BotAccountsMaxLevel;
     uint32 VanillaPvpKillRank1, VanillaPvpKillRank2, VanillaPvpKillRank3, VanillaPvpKillRank4, VanillaPvpKillRank5, VanillaPvpKillRank6, VanillaPvpKillRank7, VanillaPvpKillRank8, VanillaPvpKillRank9, VanillaPvpKillRank10, VanillaPvpKillRank11, VanillaPvpKillRank12, VanillaPvpKillRank13, VanillaPvpKillRank14;
-    std::string excludedAccountsRegex, sharedFactionIdsRegex;
+    std::string excludedAccountsRegex, botAccountsRegex, sharedFactionIdsRegex;
 
     // progression is derived from rewarded hidden quests (IDs 66000 + progression)
     uint8 GetPlayerProgressionFromQuests(Player* player) const;
@@ -415,7 +415,9 @@ public:
 
     void CheckAdjustments(Player* player) const;
     bool hasCustomProgressionValue(uint32 creatureEntry);
-    bool isExcludedFromProgression(Player* player);
+    bool isExcludedAccount(Player* player);
+    bool isBotAccount(Player* player);
+    bool isNormalAccount(Player* player);
     void SyncBotsProgressionToLeader(Group* group);
     bool isAttuned(Player* player);
     void checkIPPhasing(Player* player, uint32 newArea);

--- a/src/IndividualProgressionAwareness.cpp
+++ b/src/IndividualProgressionAwareness.cpp
@@ -475,7 +475,7 @@ public:
                 return true;
 
             Player* target = ObjectAccessor::FindConnectedPlayer(player->GetGUID());
-            if (sIndividualProgression->hasPassedProgression(target, PROGRESSION_AQ))
+            if (sIndividualProgression->hasPassedProgression(target, PROGRESSION_AQ) || sIndividualProgression->isExcludedAccount(target))
                 return true;
             else
                 return false;

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -86,8 +86,7 @@ public:
         if (!sIndividualProgression->enabled || !player || !player->IsInWorld() || !newArea)
             return;
 
-        if (sIndividualProgression->isNormalAccount(player))
-            sIndividualProgression->checkIPPhasing(player, newArea);
+        sIndividualProgression->checkIPPhasing(player, newArea);
     }
 
     void OnPlayerEquip(Player* player, Item* /*it*/, uint8 /*bag*/, uint8 /*slot*/, bool /*update*/) override

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -25,16 +25,13 @@ public:
         if (!player || !player->IsInWorld())
             return;
 
-        if (!sIndividualProgression->isExcludedFromProgression(player))
-            sIndividualProgression->checkIPProgression(player);
-
-        if (sIndividualProgression->ExcludedAccountsEarnPvPTitles || !sIndividualProgression->isExcludedFromProgression(player))
+        if (!sIndividualProgression->isBotAccount(player) || sIndividualProgression->BotAccountsEarnPvPTitles)
         {
             sIndividualProgression->AwardEarnedVanillaPvpTitles(player);
             sIndividualProgression->CleanUpVanillaPvpTitles(player);
         }
 
-		if (sIndividualProgression->isExcludedFromProgression(player) && sIndividualProgression->excludeAccounts)
+        if (!sIndividualProgression->isNormalAccount(player)) // bot or exluded account
         {
             if (player->GetLevel() <= 60)
                 sIndividualProgression->ForceUpdateProgressionState(player, static_cast<ProgressionState>(0));
@@ -43,8 +40,7 @@ public:
             else
                 sIndividualProgression->ForceUpdateProgressionState(player, static_cast<ProgressionState>(13));
         }
-
-        if (!sIndividualProgression->isExcludedFromProgression(player) || !sIndividualProgression->excludeAccounts)
+        else // normal account
         {
             if ((player->getRace() == RACE_DRAENEI || player->getRace() == RACE_BLOODELF) && sIndividualProgression->tbcRacesStartingProgression && !sIndividualProgression->hasPassedProgression(player, static_cast<ProgressionState>(sIndividualProgression->tbcRacesStartingProgression)))
             {
@@ -62,6 +58,7 @@ public:
             }
         }
 
+        sIndividualProgression->checkIPProgression(player);
         sIndividualProgression->CheckAdjustments(player);
 
         if (sIndividualProgression->enabled)
@@ -78,7 +75,7 @@ public:
         if (!sIndividualProgression->enabled || !player || !player->IsInWorld())
             return;
 
-        if (!sIndividualProgression->isExcludedFromProgression(player))
+        if (sIndividualProgression->isNormalAccount(player))
             sIndividualProgression->checkIPProgression(player);
 
         sIndividualProgression->CheckAdjustments(player);
@@ -89,7 +86,8 @@ public:
         if (!sIndividualProgression->enabled || !player || !player->IsInWorld() || !newArea)
             return;
 
-        sIndividualProgression->checkIPPhasing(player, newArea);
+        if (!sIndividualProgression->isExcludedAccount(player))
+            sIndividualProgression->checkIPPhasing(player, newArea);
     }
 
     void OnPlayerEquip(Player* player, Item* /*it*/, uint8 /*bag*/, uint8 /*slot*/, bool /*update*/) override
@@ -97,6 +95,7 @@ public:
         if (!player || !player->IsInWorld())
             return;
 
+        // exluded accounts should be effected by server nerfs as well
         sIndividualProgression->CheckAdjustments(player);
     }
 
@@ -132,9 +131,12 @@ public:
         if (!sIndividualProgression->enabled || !player || !player->IsInWorld() || !amount)
             return;
 
-        if (sIndividualProgression->isExcludedFromProgression(player))
+        if (sIndividualProgression->isExcludedAccount(player))
+            return;
+
+        if (sIndividualProgression->isBotAccount(player))
         {
-            if (player->GetLevel() >= sIndividualProgression->ExcludedAccountsMaxLevel)
+            if (player->GetLevel() >= sIndividualProgression->BotAccountsMaxLevel)
             {
                 // Still award XP to pets - they won't be able to pass the player's level
                 Pet* pet = player->GetPet();
@@ -144,7 +146,7 @@ public:
                 amount = 0;
             }
         }
-        else
+        else // normal account
         {
             // Player is still in Vanilla content - do not give XP past level 60
             if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC) && player->GetLevel() >= 60)
@@ -174,7 +176,7 @@ public:
         if (!player || !player->IsInWorld())
             return false;
 
-        if (!sIndividualProgression->enabled || player->IsGameMaster() || sIndividualProgression->isExcludedFromProgression(player))
+        if (!sIndividualProgression->enabled || player->IsGameMaster() || sIndividualProgression->isBotAccount(player))
             return true;
 
         if ((player->GetQuestStatus(NAXX40_ATTUNEMENT_1) == QUEST_STATUS_REWARDED) || (player->GetQuestStatus(NAXX40_ATTUNEMENT_2) == QUEST_STATUS_REWARDED) || (player->GetQuestStatus(NAXX40_ATTUNEMENT_3) == QUEST_STATUS_REWARDED))
@@ -188,7 +190,7 @@ public:
         if (!sIndividualProgression->enabled || !player || !player->IsInWorld() || !spell)
             return;
 
-        if (sIndividualProgression->isExcludedFromProgression(player)) // bots don't cast lower ranks of spells
+        if (sIndividualProgression->isBotAccount(player)) // bots don't cast lower ranks of spells
             return;
 
         if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5) || player->GetLevel() < 70) // no need to check spells if player is not in WotlK
@@ -606,7 +608,7 @@ public:
         if (!player || !player->IsInWorld())
             return false;
 
-        if (!sIndividualProgression->enabled || player->IsGameMaster() || sIndividualProgression->isExcludedFromProgression(player))
+        if (!sIndividualProgression->enabled || player->IsGameMaster() || !sIndividualProgression->isNormalAccount(player))
             return true;
 
         if (mapid == MAP_BLACKWING_LAIR && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_MOLTEN_CORE))
@@ -797,6 +799,9 @@ public:
         if (!player || !player->IsInWorld() || !quest || !sIndividualProgression->enabled)
             return;
 
+        if (!sIndividualProgression->isNormalAccount(player))
+            return;
+
         if (sIndividualProgression->questMoneyAtLevelCap)
         {
             int32 moneyRew = 0;
@@ -823,37 +828,31 @@ public:
             }
         }
 
-        if (!sIndividualProgression->isExcludedFromProgression(player) || !sIndividualProgression->excludeAccounts)
+        switch (quest->GetQuestId())
         {
-            switch (quest->GetQuestId())
+        case BANG_A_GONG:
+        case SIMPLY_BANG_A_GONG:
+            if (!sIndividualProgression->disableDefaultProgression)
+                 sIndividualProgression->UpdateProgressionState(player, PROGRESSION_PRE_AQ);
+            break;
+        case CHAOS_AND_DESTRUCTION:
+            if (!sIndividualProgression->disableDefaultProgression)
+                 sIndividualProgression->UpdateProgressionState(player, PROGRESSION_AQ_WAR);
+            break;
+        case INTO_THE_BREACH:
+            if (!sIndividualProgression->disableDefaultProgression)
+                 sIndividualProgression->UpdateProgressionState(player, PROGRESSION_PRE_TBC);
+            break;
+        case QUEST_MORROWGRAIN:
+        case QUEST_TROLL_NECKLACE:
+        case QUEST_DEADWOOD:
+        case QUEST_WINTERFALL:
+            if (sIndividualProgression->repeatableVanillaQuestsXp)
             {
-            case BANG_A_GONG:
-                if (!sIndividualProgression->disableDefaultProgression)
-                    sIndividualProgression->UpdateProgressionState(player, PROGRESSION_PRE_AQ);
-                break;
-            case SIMPLY_BANG_A_GONG:
-                if (!sIndividualProgression->disableDefaultProgression)
-                    sIndividualProgression->UpdateProgressionState(player, PROGRESSION_PRE_AQ);
-                break;
-            case CHAOS_AND_DESTRUCTION:
-                if (!sIndividualProgression->disableDefaultProgression)
-                    sIndividualProgression->UpdateProgressionState(player, PROGRESSION_AQ_WAR);
-                break;
-            case INTO_THE_BREACH:
-                if (!sIndividualProgression->disableDefaultProgression)
-                    sIndividualProgression->UpdateProgressionState(player, PROGRESSION_PRE_TBC);
-                break;
-            case QUEST_MORROWGRAIN:
-            case QUEST_TROLL_NECKLACE:
-            case QUEST_DEADWOOD:
-            case QUEST_WINTERFALL:
-                if (sIndividualProgression->repeatableVanillaQuestsXp)
-                {
-                    // Reset the quest status so the player can take it and receive rewards again
-                    player->RemoveRewardedQuest(quest->GetQuestId());
-                }
-                break;
+                // Reset the quest status so the player can take it and receive rewards again
+                player->RemoveRewardedQuest(quest->GetQuestId());
             }
+            break;
         }
     }
 
@@ -862,7 +861,7 @@ public:
         if (!player || !player->IsInWorld())
             return false;
 
-        if (!sIndividualProgression->enabled)
+        if (!sIndividualProgression->enabled || sIndividualProgression->isBotAccount(player))
             return true;
 
         Player* otherPlayer = ObjectAccessor::FindPlayerByName(membername, false);
@@ -871,9 +870,9 @@ public:
 
         if (sIndividualProgression->enforceGroupRules) // enforceGroupRules enabled
         {
-            if (!sIndividualProgression->isExcludedFromProgression(player)) // player has a normal account
+            if (sIndividualProgression->isNormalAccount(player))
             {
-                if (sIndividualProgression->isExcludedFromProgression(otherPlayer)) // RNDbot
+                if (sIndividualProgression->isBotAccount(otherPlayer))
                 {
                     if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC)) // player is in vanilla
                     {
@@ -917,9 +916,9 @@ public:
                     return (currentState == otherPlayerState);
                 }
             }
-            else // player has an excluded account
+            else if (sIndividualProgression->isExcludedAccount(player))
             {
-                if (sIndividualProgression->isExcludedFromProgression(otherPlayer)) // RNDbot
+                if (!sIndividualProgression->isNormalAccount(otherPlayer)) // other player is either excluded or a RNDbot
                 {
                     if (player->GetLevel() <= 60) // player is in vanilla
                     {
@@ -927,7 +926,7 @@ public:
                         {
                             return true;
                         }
-                        else
+                        else // excluded accounts in vanilla cannot group with TBC or WotLK accounts when enforceGroupRules is enabled, to avoid bypassing progression requirements
                         {
                             ChatHandler(player->GetSession()).SendSysMessage("|cff00ff00Enforce Group Rules is enabled: |cffccccccthis player's level is too high.|r");
                             return false;
@@ -960,7 +959,7 @@ public:
                 }
                 else // player or ALTbot
                 {
-                    ChatHandler(player->GetSession()).SendSysMessage("|cff00ff00Enforce Group Rules is enabled: |cffccccccthis player does not have an excluded account.|r");
+                    ChatHandler(player->GetSession()).SendSysMessage("|cff00ff00Enforce Group Rules is enabled: |cffccccccthis player is not a bot or does not have an excluded account.|r");
                     return false;
                 }
             }
@@ -983,13 +982,13 @@ public:
         if (!sIndividualProgression->enabled)
             return true;
 
-        if (sIndividualProgression->isExcludedFromProgression(player))
+        if (!sIndividualProgression->isNormalAccount(player)) // player is either a RNDbot or has an excluded account
         {
             if (sIndividualProgression->enforceGroupRules)
             {
-                if (groupLeaderState <= 7) // Group leader is in Vanilla
+                if (groupLeaderState < PROGRESSION_PRE_TBC) // Group leader is in Vanilla
                 {
-                    if (player->GetLevel() <= 60) // invited excluded player is in Vanilla
+                    if (player->GetLevel() <= 60) // invited player is in Vanilla
                     {
                         sIndividualProgression->ForceUpdateProgressionState(player, static_cast<ProgressionState>(groupLeaderState));
                         return true;
@@ -997,7 +996,7 @@ public:
                     else
                         return false;
                 }
-                else if (groupLeaderState > 7 && groupLeaderState < 13) // Group leader is in TBC
+                else if (groupLeaderState >= PROGRESSION_PRE_TBC && groupLeaderState < PROGRESSION_TBC_TIER_5) // Group leader is in TBC
                 {
                     if (player->GetLevel() > 60 && player->GetLevel() <= 70) // invited excluded player is in TBC
                     {
@@ -1118,7 +1117,7 @@ public:
                 for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
                 {
                     Player* member = itr->GetSource();
-                    if (!member || sIndividualProgression->isExcludedFromProgression(member))
+                    if (!member || !sIndividualProgression->isNormalAccount(member))
                         continue;
 
                     if (killed->GetEntry() == COLOSSUS_ZORA)
@@ -1136,7 +1135,7 @@ public:
             for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
             {
                 Player* member = itr->GetSource();
-                if (!member || sIndividualProgression->isExcludedFromProgression(member))
+                if (!member || !sIndividualProgression->isNormalAccount(member))
                     continue;
 
                 if (killer->IsAtLootRewardDistance(member))
@@ -1152,6 +1151,7 @@ public:
 
         if (!sIndividualProgression->enabled || !sIndividualProgression->fishingFix)
             return true;
+
         if (chance < roll)
             return false;
 
@@ -1163,11 +1163,14 @@ public:
         if (!player || !player->IsInWorld() || !newArea)
             return;
 
+        if (!sIndividualProgression->enabled || player->IsGameMaster() || !sIndividualProgression->isNormalAccount(player))
+            return;
+
         uint32 mapid = player->GetMap()->GetId();
 
         if (mapid && mapid == MAP_OUTLAND) // prevent entering Sun's Reach Harbor in Quel'Danas without proper progression
         {
-            if (!sIndividualProgression->isExcludedFromProgression(player) && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_4) && newArea == 4087) // Sun's Reach Harbor
+            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_4) && newArea == 4087) // Sun's Reach Harbor
             {
                 ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_4);
 
@@ -1201,13 +1204,14 @@ public:
             return true;
         }
 
-        // Check if the account is excluded from progression (bots)
+        // Check if the account is a bot or excluded from progression
         std::string accountName;
         bool accountNameFound = AccountMgr::GetName(accountId, accountName);
+        std::regex botAccountsRegex(sIndividualProgression->botAccountsRegex);
         std::regex excludedAccountsRegex(sIndividualProgression->excludedAccountsRegex);
   
-        if (accountNameFound && std::regex_match(accountName, excludedAccountsRegex))
-			return true;
+        if (accountNameFound && (std::regex_match(accountName, botAccountsRegex) || std::regex_match(accountName, excludedAccountsRegex)))
+            return true;
 
         uint8 highestProgression = sIndividualProgression->GetAccountProgression(accountId);
         if (charRace == RACE_DRAENEI || charRace == RACE_BLOODELF)
@@ -1215,7 +1219,7 @@ public:
             if (highestProgression < sIndividualProgression->tbcRacesProgressionLevel)
                 return false;
         }
-        if (charClass == CLASS_DEATH_KNIGHT && sIndividualProgression->deathKnightProgressionLevel)
+        else if (charClass == CLASS_DEATH_KNIGHT && sIndividualProgression->deathKnightProgressionLevel)
         {
             if (highestProgression < sIndividualProgression->deathKnightProgressionLevel)
                 return false;

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -1275,6 +1275,12 @@ public:
 
         Player* player = isPet ? healer->GetOwner()->ToPlayer() : healer->ToPlayer();
 
+        if (sIndividualProgression->BotOnlyAdjustments)
+        {
+            if (!sIndividualProgression->isBotAccount(player) && sIndividualProgression->isPlayerInDungeonOrRaid(player))
+                return;
+        }
+
         if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC))
             heal *= sIndividualProgression->ComputeVanillaAdjustment(player->GetLevel(), sIndividualProgression->vanillaHealingAdjustment);
         else if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC) && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5))
@@ -1296,6 +1302,12 @@ public:
 
         Player* player = isPet ? attacker->GetOwner()->ToPlayer() : attacker->ToPlayer();
 
+        if (sIndividualProgression->BotOnlyAdjustments)
+        {
+            if (!sIndividualProgression->isBotAccount(player) && sIndividualProgression->isPlayerInDungeonOrRaid(player))
+                return;
+        }
+
         if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC))
             damage *= sIndividualProgression->ComputeVanillaAdjustment(player->GetLevel(), sIndividualProgression->vanillaPowerAdjustment);
         else if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC) && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5))
@@ -1312,6 +1324,12 @@ public:
             return;
 
         Player* player = isPet ? attacker->GetOwner()->ToPlayer() : attacker->ToPlayer();
+
+        if (sIndividualProgression->BotOnlyAdjustments)
+        {
+            if (!sIndividualProgression->isBotAccount(player) && sIndividualProgression->isPlayerInDungeonOrRaid(player))
+                return;
+        }
 
         if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC))
             damage *= sIndividualProgression->ComputeVanillaAdjustment(player->GetLevel(), sIndividualProgression->vanillaPowerAdjustment);
@@ -1340,6 +1358,12 @@ public:
             return;
 
         Player* player = isPet ? attacker->GetOwner()->ToPlayer() : attacker->ToPlayer();
+
+        if (sIndividualProgression->BotOnlyAdjustments)
+        {
+            if (!sIndividualProgression->isBotAccount(player) && sIndividualProgression->isPlayerInDungeonOrRaid(player))
+                return;
+        }
 
         if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_PRE_TBC))
             damage *= sIndividualProgression->ComputeVanillaAdjustment(player->GetLevel(), sIndividualProgression->vanillaPowerAdjustment);

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -86,7 +86,7 @@ public:
         if (!sIndividualProgression->enabled || !player || !player->IsInWorld() || !newArea)
             return;
 
-        if (!sIndividualProgression->isExcludedAccount(player))
+        if (sIndividualProgression->isNormalAccount(player))
             sIndividualProgression->checkIPPhasing(player, newArea);
     }
 

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -915,7 +915,7 @@ public:
                     return (currentState == otherPlayerState);
                 }
             }
-            else if (sIndividualProgression->isExcludedAccount(player))
+            else // if (sIndividualProgression->isExcludedAccount(player))
             {
                 if (!sIndividualProgression->isNormalAccount(otherPlayer)) // other player is either excluded or a RNDbot
                 {

--- a/src/IndividualProgressionPvP.cpp
+++ b/src/IndividualProgressionPvP.cpp
@@ -15,7 +15,7 @@ public:
             Player* target = ObjectAccessor::FindConnectedPlayer(player->GetGUID());
 			uint32 PVP_RANK6_QUEST = 66106;
 
-            if (player->IsGameMaster() || !sIndividualProgression->enabled || sIndividualProgression->isExcludedFromProgression(target) || sIndividualProgression->hasPassedProgression(target, PROGRESSION_PRE_TBC))
+            if (player->IsGameMaster() || !sIndividualProgression->enabled || sIndividualProgression->isBotAccount(target) || sIndividualProgression->hasPassedProgression(target, PROGRESSION_PRE_TBC))
                 return false;
 
             if (target->GetQuestStatus(PVP_RANK6_QUEST) == QUEST_STATUS_REWARDED)
@@ -45,7 +45,7 @@ public:
             Player* target = ObjectAccessor::FindConnectedPlayer(player->GetGUID());
 			uint32 PVP_RANK6_QUEST = 66106;
 
-            if (player->IsGameMaster() || !sIndividualProgression->enabled || sIndividualProgression->isExcludedFromProgression(target) || sIndividualProgression->hasPassedProgression(target, PROGRESSION_PRE_TBC))
+            if (player->IsGameMaster() || !sIndividualProgression->enabled || sIndividualProgression->isBotAccount(target) || sIndividualProgression->hasPassedProgression(target, PROGRESSION_PRE_TBC))
                 return true;
 
             if (target->GetQuestStatus(PVP_RANK6_QUEST) == QUEST_STATUS_REWARDED)

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -166,7 +166,7 @@ public:
         for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
         {
             Player* member = itr->GetSource();
-            if (!member || !sIndividualProgression->isExcludedFromProgression(member))
+            if (!member || sIndividualProgression->isNormalAccount(member))
                 continue;
 
             sIndividualProgression->ForceUpdateProgressionState(member, static_cast<ProgressionState>(currentState));
@@ -367,9 +367,9 @@ public:
 
         if (location == "naxx" || location == "naxx40")
         {
- 			if ((progressionLevel < PROGRESSION_TBC_TIER_5) && (target->GetLevel() <= 70))
+ 			if (target->GetLevel() <= 70 && ((progressionLevel < PROGRESSION_TBC_TIER_5) || sIndividualProgression->isExcludedAccount(target)))
             {
-                if (sIndividualProgression->isAttuned(target) || sIndividualProgression->isExcludedFromProgression(target))
+                if (sIndividualProgression->isAttuned(target))
                 {
                     target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
                     target->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
@@ -389,9 +389,9 @@ public:
         }
         else if (location == "onyxia" || location == "onyxia40")
         {
-            if ((progressionLevel < PROGRESSION_TBC_TIER_5) && (target->GetLevel() <= 70))
+            if (target->GetLevel() <= 70 && ((progressionLevel < PROGRESSION_TBC_TIER_5) || sIndividualProgression->isExcludedAccount(target)))
             {
-                if (target->HasItemCount(ITEM_DRAKEFIRE_AMULET) || sIndividualProgression->isExcludedFromProgression(target))
+                if (target->HasItemCount(ITEM_DRAKEFIRE_AMULET))
                 {
                     target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
                     target->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);

--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -37,10 +37,9 @@ public:
             return false;
         }
 
-        if (sIndividualProgression->isExcludedFromProgression(player) ||
-            ((!sIndividualProgression->requireNaxxStrath || player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_REWARDED)))
+        if (!sIndividualProgression->requireNaxxStrath || player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_REWARDED)
         {
-            if (sIndividualProgression->isAttuned(player) || sIndividualProgression->isExcludedFromProgression(player))
+            if (sIndividualProgression->isAttuned(player))
             {
                 player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
                 player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);

--- a/src/vanillaScripts/instance_onyxias_lair.cpp
+++ b/src/vanillaScripts/instance_onyxias_lair.cpp
@@ -153,7 +153,7 @@ public:
                 handler.PSendSysMessage("Your progression level is too high to enter the level 60 version of Onyxia\'s Lair.");
                 return false;
             }
-            if (!player->HasItemCount(ITEM_DRAKEFIRE_AMULET) && !sIndividualProgression->isExcludedFromProgression(player))
+            if (!player->HasItemCount(ITEM_DRAKEFIRE_AMULET) && !sIndividualProgression->isBotAccount(player))
             {
                 handler.PSendSysMessage("You must have the Drakefire Amulet in your inventory to enter Onyxia\'s Lair.");
                 return false;


### PR DESCRIPTION
- Separate RNDbot accounts from excluded accounts
- new config option `BotOnlyAdjustments` (default = disabled)
- removed the option to disable/enable excluded accounts.

when `BotOnlyAdjustments` is enabled only bots will get the damage and healing adjustments inside dungeons and raids.
anywhere else the adjustments effect everyone.

there is now a difference between excluded accounts and bot accounts.
excluded accounts are meant for real players that don't want to deal with progression.
excluded accounts still need attunements, because that has nothing to do with progression.

enabling/disabling the excluded accounts was a silly config option. there was no need for it.
if you don't want any excluded accounts, you simply do not list any in the `ExcludedAccountsRegex`.
