### PR TITLE
ip pvp command

### DIFF
--- a/data/sql/world/base/cs_individualProgression.sql
+++ b/data/sql/world/base/cs_individualProgression.sql
@@ -1,7 +1,8 @@
-DELETE FROM `command` WHERE `name` IN ('ip get', 'ip set', 'ip setbot', 'ip setrep', 'ip tele');
+DELETE FROM `command` WHERE `name` IN ('ip get', 'ip set', 'ip setbot', 'ip setrep', 'ip tele', 'ip pvp');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('ip get', 0, 'Syntax: .ip get\nShows your or your targets current progression level.'),
 ('ip set', 2, 'Syntax: .ip set $progressionLevel\nSets the player to the given progression level.'),
 ('ip setbot', 0, 'Syntax: .ip setbot\nSets all bots in the group to your progression level.'),
 ('ip setrep', 0, 'Syntax: .ip setrep\nSets your reputation of certain factions to the same value as the character that has the highest value on your account.'),
-('ip tele', 2, 'Syntax: .ip tele $location\nTeleports the player to the given location.');
+('ip tele', 2, 'Syntax: .ip tele $location\nTeleports the player to the given location.'),
+('ip pvp', 0, 'Syntax: .ip tele $location\nTeleports the player to the given location.');

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -20,6 +20,7 @@ public:
             { "tele",   HandleTeleIndividualProgressionCommand,   SEC_GAMEMASTER,    Console::Yes },
             { "setbot", HandleSetBotIndividualProgressionCommand, SEC_GAMEMASTER,    Console::Yes },
             { "setrep", HandleSetRepIndividualProgressionCommand, SEC_GAMEMASTER,    Console::Yes },
+            { "pvp",    HandlePVPIndividualProgressionCommand,    SEC_GAMEMASTER,    Console::Yes },
         };
 
         static ChatCommandTable commandTable =
@@ -411,6 +412,92 @@ public:
         }
 
         return false;
+    }
+
+    static bool HandlePVPIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player)
+    {
+        player = PlayerIdentifier::FromTargetOrSelf(handler);
+
+        if (!player)
+        {
+            handler->SendSysMessage("Player not found.");
+            return false;
+        }
+
+        Player* target = player->GetConnectedPlayer();
+        uint32 kills = target->GetUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS);
+        std::string playername = target->GetName();
+        TeamId teamId = target->GetTeamId(true);
+
+        IppPvPTitles const pvpTitlesList[14] =
+        {
+            { sIndividualProgression->VanillaPvpKillRank14, TitleData[RANK_FOURTEEN].TitleId[teamId] },
+            { sIndividualProgression->VanillaPvpKillRank13, TitleData[RANK_THIRTEEN].TitleId[teamId] },
+            { sIndividualProgression->VanillaPvpKillRank12, TitleData[RANK_TWELVE].TitleId[teamId]   },
+            { sIndividualProgression->VanillaPvpKillRank11, TitleData[RANK_ELEVEN].TitleId[teamId]   },
+            { sIndividualProgression->VanillaPvpKillRank10, TitleData[RANK_TEN].TitleId[teamId]      },
+            { sIndividualProgression->VanillaPvpKillRank9,  TitleData[RANK_NINE].TitleId[teamId]     },
+            { sIndividualProgression->VanillaPvpKillRank8,  TitleData[RANK_EIGHT].TitleId[teamId]    },
+            { sIndividualProgression->VanillaPvpKillRank7,  TitleData[RANK_SEVEN].TitleId[teamId]    },
+            { sIndividualProgression->VanillaPvpKillRank6,  TitleData[RANK_SIX].TitleId[teamId]      },
+            { sIndividualProgression->VanillaPvpKillRank5,  TitleData[RANK_FIVE].TitleId[teamId]     },
+            { sIndividualProgression->VanillaPvpKillRank4,  TitleData[RANK_FOUR].TitleId[teamId]     },
+            { sIndividualProgression->VanillaPvpKillRank3,  TitleData[RANK_THREE].TitleId[teamId]    },
+            { sIndividualProgression->VanillaPvpKillRank2,  TitleData[RANK_TWO].TitleId[teamId]      },
+            { sIndividualProgression->VanillaPvpKillRank1,  TitleData[RANK_ONE].TitleId[teamId]      },
+        };
+
+        int highestTitle = -1;
+        int nextPvPRank = -1;
+        uint32 killsForNextRank = 0;
+        uint32 killsToNextRank = 0;
+
+        constexpr int ALLIANCE_PVP_RANK_OFFSET = 1;
+        constexpr int HORDE_PVP_RANK_OFFSET = 14;  // horde titles start at ID 15
+
+        for (IppPvPTitles title : pvpTitlesList)
+        {
+            if (kills >= title.RequiredKills)
+            {
+                highestTitle = title.TitleId;
+                break;
+            }
+            else
+            {
+                killsForNextRank = title.RequiredKills;
+                nextPvPRank = title.TitleId;
+            }
+        }
+
+        if (killsForNextRank > 0)
+            killsToNextRank = killsForNextRank - kills;
+
+        if (nextPvPRank == -1)
+        {
+            handler->PSendSysMessage("|cff00ffff{}|r has achieved the highest PvP rank and currently has {} honorable kills.", playername, kills);
+            return true;
+        }
+        else if (highestTitle == -1)
+        {
+            handler->PSendSysMessage("|cff00ffff{}|r has not achieved any PvP rank and currently has {} honorable kills.", playername, kills);
+            handler->PSendSysMessage("|cff00ffff{}|r needs {} more honorable kills for rank 1.", playername, killsToNextRank);
+            return true;
+        }
+        else
+        {
+            if (teamId == TEAM_ALLIANCE)
+            {
+                handler->PSendSysMessage("PvP rank for |cff00ffff{}|r = |cff00ffff{}|r", playername, highestTitle + ALLIANCE_PVP_RANK_OFFSET);
+                handler->PSendSysMessage("|cff00ffff{}|r needs {} more honorable kills for rank {}.", playername, killsToNextRank, nextPvPRank + ALLIANCE_PVP_RANK_OFFSET);
+                return true;
+            }
+            else // teamId == TEAM_HORDE
+            {
+                handler->PSendSysMessage("PvP rank for |cff00ffff{}|r = |cff00ffff{}|r", playername, highestTitle - HORDE_PVP_RANK_OFFSET);
+                handler->PSendSysMessage("|cff00ffff{}|r needs {} more honorable kills for rank {}.", playername, killsToNextRank, nextPvPRank - HORDE_PVP_RANK_OFFSET);
+                return true;
+            }
+        }
     }
 };
 


### PR DESCRIPTION
new command: `.ip pvp`

shows your targets current pvp rank and how many more kills your target needs for the next rank.
if no target is selected it will show the information for yourself.