### PR TITLE
Remove event pvp vendors

### DIFF
--- a/data/sql/world/base/00_cleanup.sql
+++ b/data/sql/world/base/00_cleanup.sql
@@ -9,8 +9,8 @@ UPDATE `creature_template` SET `unit_class` = 8 WHERE `entry` IN (29273);
 DELETE FROM `creature_addon` WHERE `guid` IN (133917, 133918, 133919, 133920, 133925);
 
 -- battlemasters
-DELETE FROM `game_event_creature` WHERE `guid` IN (207918, 207929, 207951, 208042, 208081, 208107, 208146, 208159, 208185); -- alliance
-DELETE FROM `game_event_creature` WHERE `guid` IN (208207, 208240, 208251, 208355, 208368, 208394, 208407); -- horde
+DELETE FROM `game_event_creature` WHERE `guid` IN (207918, 207929, 207951, 208042, 208081, 208107, 208146, 208159, 208185, 208511, 208512); -- alliance
+DELETE FROM `game_event_creature` WHERE `guid` IN (208207, 208240, 208251, 208355, 208368, 208394, 208407, 208509, 208510); -- horde
 
 -- remove AzerothCore area triggers used by WotLK Scourge Invasion Event
 DELETE FROM `areatrigger_involvedrelation` WHERE `id` IN (4092, 4094, 4095, 4096, 4098, 4099, 4100, 4101, 4103, 4104, 4105, 5151, 5152, 5153, 5154, 5158, 5159, 5160, 5161);


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/1212

Individual Progression handles the pvp vendors already
we don't use AC's arena events.