### PR TITLE
Allow .ip get to accept a player name

### DIFF
--- a/data/sql/world/base/cs_individualProgression.sql
+++ b/data/sql/world/base/cs_individualProgression.sql
@@ -1,6 +1,6 @@
 DELETE FROM `command` WHERE `name` IN ('ip get', 'ip set', 'ip setbot', 'ip setrep', 'ip tele', 'ip pvp');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
-('ip get', 0, 'Syntax: .ip get\nShows your or your targets current progression level.'),
+('ip get', 0, 'Syntax: .ip get [$player]\nShows the current progression level for yourself, your target, or a named player.'),
 ('ip set', 2, 'Syntax: .ip set $progressionLevel\nSets the player to the given progression level.'),
 ('ip setbot', 0, 'Syntax: .ip setbot\nSets all bots in the group to your progression level.'),
 ('ip setrep', 0, 'Syntax: .ip setrep\nSets your reputation of certain factions to the same value as the character that has the highest value on your account.'),

--- a/data/sql/world/base/cs_individualProgression.sql
+++ b/data/sql/world/base/cs_individualProgression.sql
@@ -5,4 +5,4 @@ INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('ip setbot', 0, 'Syntax: .ip setbot\nSets all bots in the group to your progression level.'),
 ('ip setrep', 0, 'Syntax: .ip setrep\nSets your reputation of certain factions to the same value as the character that has the highest value on your account.'),
 ('ip tele', 2, 'Syntax: .ip tele $location\nTeleports the player to the given location.'),
-('ip pvp', 0, 'Syntax: .ip pvp\nShows your or your targets pvp rank/kills information.');
+('ip pvp', 0, 'Syntax: .ip pvp [$player]\nShows the current PvP rank and kills for yourself, your target, or a named player.');

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -423,7 +423,8 @@ public:
 
     static bool HandlePVPIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player)
     {
-        player = PlayerIdentifier::FromTargetOrSelf(handler);
+        if (!player)
+            player = PlayerIdentifier::FromTargetOrSelf(handler);
 
         if (!player)
         {
@@ -431,9 +432,15 @@ public:
             return false;
         }
 
+        std::string playername = player->GetName();
         Player* target = player->GetConnectedPlayer();
+        if (!target)
+        {
+            handler->PSendSysMessage("Player |cff00ffff{}|r is not online.", playername);
+            return false;
+        }
+
         uint32 kills = target->GetUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS);
-        std::string playername = target->GetName();
         TeamId teamId = target->GetTeamId(true);
 
         IppPvPTitles const pvpTitlesList[14] =

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -97,7 +97,8 @@ public:
 
     static bool HandleGetIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player)
     {
-        player = PlayerIdentifier::FromTargetOrSelf(handler);
+        if (!player)
+            player = PlayerIdentifier::FromTargetOrSelf(handler);
 
         if (!player)
         {
@@ -105,9 +106,15 @@ public:
             return false;
         }
 
+        std::string playername = player->GetName();
         Player* target = player->GetConnectedPlayer();
+        if (!target)
+        {
+            handler->PSendSysMessage("Player |cff00ffff{}|r is not online.", playername);
+            return false;
+        }
+
         uint32 progressionLevel = sIndividualProgression->GetPlayerProgressionFromQuests(target);
-        std::string playername = target->GetName();
 
         handler->PSendSysMessage("Progression Level for |cff00ffff{}|r = |cff00ffff{}|r", playername, progressionLevel);
         return true;


### PR DESCRIPTION
This adds support for passing a player name to .ip get, so you can look up another character's progression tier without having to target them first.

**What's new:**
- `.ip get <name>` now shows that player's tier.
- If the player is offline, you get a clear `Player <name> is not online.` message.
- Updated the help text to reflect the new syntax: `.ip get [$player]`.

**Why this matters:**
I've had several requests for this from users of my addons — LichborneTracker and Playerbot Manager — which want to show the IP tier of every member in a group. The WoW client won't let an addon switch targets on its own, so the only practical way to look up a teammate's tier is to pass their name into the command directly. This change makes that possible.

**Behavior:**
| Command | Result |
|---|---|
| `.ip get` | Your own tier (unchanged) |
| `.ip get` with a target | Target's tier (unchanged) |
| `.ip get OnlinePlayer` | That player's tier (new) |
| `.ip get OfflinePlayer` | `Player <name> is not online.` (new) |
| `.ip get Nonexistent` | `Player not found.` (unchanged) |

Offline lookups are out of scope here — they'd need a separate database query path and can come as a follow-up.

**Tested:** All five cases above verified on a local server.

**Files changed:**
- `src/cs_individualProgression.cpp` — handler update
- `data/sql/world/base/cs_individualProgression.sql` — help text update

---
_Drafted with assistance from Claude (Anthropic)._