### PR TITLE
update progression directly after kill

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -1108,11 +1108,40 @@ public:
         if (killed->GetCreatureTemplate()->rank > CREATURE_ELITE_NORMAL)
         {
             Group* group = killer->GetGroup();
-
-            if (!group)
-                return;
-
+            
             if (killed->GetEntry() == COLOSSUS_ZORA || killed->GetEntry() == COLOSSUS_REGAL || killed->GetEntry() == COLOSSUS_ASHI)
+            {
+                // no group
+                if (killed->GetEntry() == COLOSSUS_ZORA)
+                    killer->CompleteQuest(QUEST_COLOSSUS_ZORA);
+                else if (killed->GetEntry() == COLOSSUS_REGAL)
+                    killer->CompleteQuest(QUEST_COLOSSUS_REGAL);
+                else if (killed->GetEntry() == COLOSSUS_ASHI)
+                    killer->CompleteQuest(QUEST_COLOSSUS_ASHI);    
+               
+                if (group)
+                {
+                    for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+                    {
+                        Player* member = itr->GetSource();
+                        if (!member || !sIndividualProgression->isNormalAccount(member))
+                            continue;
+
+                        if (killed->GetEntry() == COLOSSUS_ZORA)
+                            member->CompleteQuest(QUEST_COLOSSUS_ZORA);
+                        else if (killed->GetEntry() == COLOSSUS_REGAL)
+                            member->CompleteQuest(QUEST_COLOSSUS_REGAL);
+                        else if (killed->GetEntry() == COLOSSUS_ASHI)
+                            member->CompleteQuest(QUEST_COLOSSUS_ASHI);
+                    }
+                }
+
+                return;
+            }
+
+            sIndividualProgression->checkKillProgression(killer, killed); // no group
+
+            if (group)
             {
                 for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
                 {
@@ -1120,26 +1149,9 @@ public:
                     if (!member || !sIndividualProgression->isNormalAccount(member))
                         continue;
 
-                    if (killed->GetEntry() == COLOSSUS_ZORA)
-                        member->CompleteQuest(QUEST_COLOSSUS_ZORA);
-                    else if (killed->GetEntry() == COLOSSUS_REGAL)
-                        member->CompleteQuest(QUEST_COLOSSUS_REGAL);
-                    else if (killed->GetEntry() == COLOSSUS_ASHI)
-                        member->CompleteQuest(QUEST_COLOSSUS_ASHI);
+                    if (killer->IsAtLootRewardDistance(member))
+                        sIndividualProgression->checkKillProgression(member, killed);
                 }
-                return;
-            }
-
-            sIndividualProgression->checkKillProgression(killer, killed);
-
-            for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
-            {
-                Player* member = itr->GetSource();
-                if (!member || !sIndividualProgression->isNormalAccount(member))
-                    continue;
-
-                if (killer->IsAtLootRewardDistance(member))
-                    sIndividualProgression->checkKillProgression(member, killed);
             }
         }
     }


### PR DESCRIPTION
this was already the case if you're in a group or raid.

if you weren't in a group it didn't update your progression right away
it still did so on changing map, but now also directly.

this can help if you're playing with a module like AutoBalance, 
to avoid confusion if someone were to check his progression immediately.

or if you happen to be solo and got the tag on a Hive boss.
you didn't get credit for it, but now you do.