### PR TITLE
Reward all progression quests

### DIFF
--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -57,16 +57,17 @@ void IndividualProgression::UpdateProgressionState(Player* player, ProgressionSt
     uint8 currentState = GetPlayerProgressionFromQuests(player);
     if (newState > currentState)
     {
-        uint32 PROGRESSION_QUEST = 66000 + newState;
-        if (player->GetQuestStatus(PROGRESSION_QUEST) != QUEST_STATUS_REWARDED)
+        for (uint8 i = currentState; i <= newState; ++i)
         {
+            uint32 PROGRESSION_QUEST = 66000 + i;
             Quest const* quest = sObjectMgr->GetQuestTemplate(PROGRESSION_QUEST);
-            if (quest)
-            {
-                player->AddQuest(quest, nullptr);
-                player->CompleteQuest(PROGRESSION_QUEST);
-                player->RewardQuest(quest, 0, player, false, false);
-            }
+
+            if (!quest)
+                continue;
+
+            player->AddQuest(quest, nullptr);
+            player->CompleteQuest(PROGRESSION_QUEST);
+            player->RewardQuest(quest, 0, player, false, false);
         }
     }
 }
@@ -74,6 +75,9 @@ void IndividualProgression::UpdateProgressionState(Player* player, ProgressionSt
 void IndividualProgression::ForceUpdateProgressionState(Player* player, ProgressionState newState)
 {
     if (!player || !player->IsInWorld())
+        return;
+
+    if (!newState)
         return;
 
     // remove all hidden progression quests first
@@ -84,17 +88,17 @@ void IndividualProgression::ForceUpdateProgressionState(Player* player, Progress
             player->RemoveRewardedQuest(PROGRESSION_QUEST);
     }
 
-    // if newState is non-zero, add the corresponding progression quest
-    if (newState)
+    for (uint8 i = PROGRESSION_MOLTEN_CORE; i <= newState; ++i)
     {
-        uint32 PROGRESSION_QUEST = 66000 + newState;
+        uint32 PROGRESSION_QUEST = 66000 + i;
         Quest const* quest = sObjectMgr->GetQuestTemplate(PROGRESSION_QUEST);
-        if (quest)
-        {
-            player->AddQuest(quest, nullptr);
-            player->CompleteQuest(PROGRESSION_QUEST);
-            player->RewardQuest(quest, 0, player, false, false);
-        }
+
+        if (!quest)
+            continue;
+
+        player->AddQuest(quest, nullptr);
+        player->CompleteQuest(PROGRESSION_QUEST);
+        player->RewardQuest(quest, 0, player, false, false);
     }
 }
 

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -1181,22 +1181,25 @@ public:
         if (!player || !player->IsInWorld() || !newArea)
             return;
 
-        if (!sIndividualProgression->enabled || player->IsGameMaster() || !sIndividualProgression->isNormalAccount(player))
+        if (!sIndividualProgression->enabled || player->IsGameMaster())
             return;
 
         uint32 mapid = player->GetMap()->GetId();
 
         if (mapid && mapid == MAP_OUTLAND) // prevent entering Sun's Reach Harbor in Quel'Danas without proper progression
         {
-            if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_4) && newArea == 4087) // Sun's Reach Harbor
+            if (sIndividualProgression->isNormalAccount(player))
             {
-                ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_4);
+                if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_4) && newArea == 4087) // Sun's Reach Harbor
+                {
+                    ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_TBC_TIER_4);
 
-                TeamId teamId = player->GetTeamId(true);
-                if (teamId == TEAM_ALLIANCE)
-                    player->TeleportTo(0, 2270.32f, -5341.56f, 87, 1.34946f); // Light's Hope Chapel
-                else // Horde
-                    player->TeleportTo(530, 9373.69f, -7168.46f, 9.17572f, 1.04876f); // Eversong Woods
+                    TeamId teamId = player->GetTeamId(true);
+                    if (teamId == TEAM_ALLIANCE)
+                        player->TeleportTo(0, 2270.32f, -5341.56f, 87, 1.34946f); // Light's Hope Chapel
+                    else // Horde
+                        player->TeleportTo(530, 9373.69f, -7168.46f, 9.17572f, 1.04876f); // Eversong Woods
+                }
             }
         }
 


### PR DESCRIPTION
- only the last progression quest was rewarded when `ForceUpdateProgressionState` was called.
this also effected the `.ip set` command.
this caused issues with checks for completed progression tiers.
now it rewards all previous progression quests as well, not just the last one.

- also fixed an issue with RNDbots not getting a phasing aura spell when changing areas.
