### PR TITLE
Set group raid difficulty

### DIFF
--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -348,7 +348,13 @@ public:
             {
                 if (sIndividualProgression->isAttuned(target))
                 {
-                    target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                    Group* group = target->GetGroup();
+
+                    if (group)
+                        group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                    else
+                        target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+
                     target->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
                     return true;
                 }
@@ -370,7 +376,13 @@ public:
             {
                 if (target->HasItemCount(ITEM_DRAKEFIRE_AMULET))
                 {
-                    target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                    Group* group = target->GetGroup();
+
+                    if (group)
+                        group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                    else
+                        target->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                   
                     target->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);
                     return true;
                 }

--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -41,7 +41,13 @@ public:
         {
             if (sIndividualProgression->isAttuned(player))
             {
-                player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                Group* group = player->GetGroup();
+
+                if (group)
+                    group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                else
+                    player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+
                 player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
                 return true;
             }

--- a/src/vanillaScripts/instance_onyxias_lair.cpp
+++ b/src/vanillaScripts/instance_onyxias_lair.cpp
@@ -60,17 +60,13 @@ public:
             {
                 case GO_WHELP_SPAWNER:
                     if (instance->GetDifficulty() == RAID_DIFFICULTY_10MAN_HEROIC)
-                    {
                         go->CastSpell((Unit*)nullptr, 91003);
-                    }
                     else
-                    {
                         go->CastSpell((Unit*)nullptr, 17646);
-                    }
+
                     if (Creature* onyxia = GetCreature(DATA_ONYXIA))
-                    {
                         onyxia->AI()->DoAction(-1);
-                    }
+
                     break;
             }
         }
@@ -78,9 +74,7 @@ public:
         bool SetBossState(uint32 type, EncounterState state) override
         {
             if (!InstanceScript::SetBossState(type, state))
-            {
                 return false;
-            }
 
             if (type == DATA_ONYXIA && state == NOT_STARTED)
             {
@@ -159,7 +153,13 @@ public:
                 return false;
             }
 
-            player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+            Group* group = player->GetGroup();
+
+            if (group)
+                group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+            else
+                player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+
             player->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);
             return true;
 
@@ -171,11 +171,6 @@ public:
                 handler.PSendSysMessage("You need to be level 80 to enter Onyxia\'s Lair.");
                 return false;
             }
-            /* if (!player->HasItemCount(ITEM_DRAKEFIRE_AMULET) && !sIndividualProgression->isExcludedFromProgression(player))
-            {
-                handler.PSendSysMessage("You must have the Drakefire Amulet in your inventory to enter Onyxia\'s Lair.");
-                return false;
-            } */
 
             player->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);
             return true;


### PR DESCRIPTION
again, Onyxia40 and Naxx40 entry issues

even though raid difficulty was set to 10 man heroic for the player, it was not always done so for the group.
making it possible for the player to end up in the wotlk version of Onyxia/Naxxramas.

now the raid difficulty for the group is also set to 10man heroic.

credit and thank you to `Crow` for finding this
and being able to show me how to reproduce it.