### PR TITLE
fix Stratholme Regression

### DIFF
--- a/data/sql/world/base/dungeon_stratholme.sql
+++ b/data/sql/world/base/dungeon_stratholme.sql
@@ -296,7 +296,7 @@ UPDATE gameobject_template_addon SET `flags` = 34 WHERE `entry` IN (175967, 1759
 
 -- service gate should open and close, but not lock itself again. I can't get this to work, so I'm keeping the gate open. (old Data2 value was 3000)
 UPDATE `gameobject_template` SET `Data2` = 0 WHERE `entry` = 175368; 
-  
+
 -- Gargoyles
 SET @CGUID    := 329000;  -- creature guid
 SET @WPID     := 3290000; -- waypoint ID

--- a/data/sql/world/base/dungeon_stratholme.sql
+++ b/data/sql/world/base/dungeon_stratholme.sql
@@ -256,12 +256,21 @@ UPDATE `creature_loot_template` SET `Chance` = 1.5  WHERE `entry` = 10463 AND `i
 UPDATE `creature_loot_template` SET `Chance` = 1.75 WHERE `entry` = 10464 AND `item` = 16714; -- Wailing Banshee - Wildheart Bracers
 UPDATE `creature_loot_template` SET `Chance` = 3    WHERE `entry` = 11043 AND `item` = 16671; -- Crimson Monk - Bindings of Elements
 
--- fix Timmy the Cruel spawn
-DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (10808, -54069);
+-- fix The Unforgiven and Timmy the Cruel spawns
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (10516, 10808, -54069);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
 `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
 `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
 `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(10516, 0, 0, 1, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 47, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                        'The Unforgiven - On Aggro - Set Visible'),
+(10516, 0, 1, 2, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 12, 10387, 8, 0, 0, 0, 0, 1, 0, 0, 0, 0, 3, 0, 0, 0,                 'The Unforgiven - On Aggro - Summon Creature'),
+(10516, 0, 2, 3, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 12, 10387, 8, 0, 0, 0, 0, 1, 0, 0, 0, 0, -3, 0, 0, 0,                'The Unforgiven - On Aggro - Summon Creature'),
+(10516, 0, 3, 4, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 12, 10387, 8, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, -3, 0, 0,                'The Unforgiven - On Aggro - Summon Creature'),
+(10516, 0, 4, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 12, 10387, 8, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 3, 0, 0,                 'The Unforgiven - On Aggro - Summon Creature'),
+(10516, 0, 5, 0, 0, 0, 100, 0, 6000, 10000, 11000, 14000, 0, 0, 11, 14907, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'The Unforgiven - In Combat - Cast Frost Nova'),
+(10516, 0, 6, 7, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 47, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'The Unforgiven - On Respawn - Set Invisible'),
+(10516, 0, 7, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 16331, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'The Unforgiven - On Respawn - Cast Incorporeal Defense');
 --
 (10808, 0, 0, 0, 0, 0, 100, 0, 3000, 8000, 9000, 14000, 0, 0, 11, 17470, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,       'Timmy the Cruel - In Combat - Cast Ravenous Claw'),
 (10808, 0, 1, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 11, 8599, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Timmy the Cruel - Between Health 0-30% - Cast Enrage'),
@@ -277,6 +286,9 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (-54069, 0, 5, 6, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 39, 30, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                     'Crimson Guardsman - On Death - Call For Help'),
 (-54069, 0, 6, 7, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 47, 1, 0, 0, 0, 0, 0, 10, 247227, 10808, 0, 0, 0, 0, 0, 0,            'Crimson Guardsman - On Death - Set Visible: Timmy the Cruel'),
 (-54069, 0, 7, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 2, 21, 0, 0, 0, 0, 0, 10, 247227, 10808, 0, 0, 0, 0, 0, 0,            'Crimson Guardsman - On Death - Set Faction: Timmy the Cruel');
+
+-- fix spawn location for The Unforgiven
+UPDATE `creature` SET `position_x` = 3719.82, `position_y` = -3426.25, `position_z` = 131.844, `orientation` = 3.3412 WHERE `id1` = 10516;
     
 -- stratholme living side, 3 doors not locked that should require the scarlet key
 UPDATE gameobject_template SET `Data1` = 299 WHERE `entry` IN (175967, 175968, 176194);

--- a/data/sql/world/base/dungeon_stratholme.sql
+++ b/data/sql/world/base/dungeon_stratholme.sql
@@ -270,13 +270,13 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (10516, 0, 4, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 12, 10387, 8, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 3, 0, 0,                 'The Unforgiven - On Aggro - Summon Creature'),
 (10516, 0, 5, 0, 0, 0, 100, 0, 6000, 10000, 11000, 14000, 0, 0, 11, 14907, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,     'The Unforgiven - In Combat - Cast Frost Nova'),
 (10516, 0, 6, 7, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 47, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'The Unforgiven - On Respawn - Set Invisible'),
-(10516, 0, 7, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 16331, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'The Unforgiven - On Respawn - Cast Incorporeal Defense');
+(10516, 0, 7, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 16331, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'The Unforgiven - On Respawn - Cast Incorporeal Defense'),
 --
 (10808, 0, 0, 0, 0, 0, 100, 0, 3000, 8000, 9000, 14000, 0, 0, 11, 17470, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,       'Timmy the Cruel - In Combat - Cast Ravenous Claw'),
 (10808, 0, 1, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 11, 8599, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Timmy the Cruel - Between Health 0-30% - Cast Enrage'),
-(10808, 0, 2, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                         'Timmy the Cruel - On Aggro - Say Line 0'),
-(10808, 0, 3, 4, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 47, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'Timmy the Cruel - On Respawn - Set Invisible'),
-(10808, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 2, 35, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'Timmy the Cruel - On Respawn - Set Faction'),
+(10808, 0, 2, 3, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 47, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'Timmy the Cruel - On Respawn - Set Invisible'),
+(10808, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 2, 35, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'Timmy the Cruel - On Respawn - Set Faction'),
+(10808, 0, 4, 0, 108, 0, 100, 1, 2, 2472270, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Timmy the Cruel - On Waypoint 2 Reached - Say Line 0'),
 --
 (-54069, 0, 0, 0, 9, 0, 100, 0, 0, 0, 10000, 10000, 8, 25, 11, 15749, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Crimson Guardsman - Within Range 8-25yd - Cast Shield Charge'),
 (-54069, 0, 1, 0, 0, 0, 100, 0, 4000, 15000, 12000, 25800, 0, 0, 11, 6713, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Crimson Guardsman - In Combat - Cast Disarm'),
@@ -285,10 +285,41 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (-54069, 0, 4, 5, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                        'Crimson Guardsman - On Death - Say Line 0'),
 (-54069, 0, 5, 6, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 39, 30, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                     'Crimson Guardsman - On Death - Call For Help'),
 (-54069, 0, 6, 7, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 47, 1, 0, 0, 0, 0, 0, 10, 247227, 10808, 0, 0, 0, 0, 0, 0,            'Crimson Guardsman - On Death - Set Visible: Timmy the Cruel'),
-(-54069, 0, 7, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 2, 21, 0, 0, 0, 0, 0, 10, 247227, 10808, 0, 0, 0, 0, 0, 0,            'Crimson Guardsman - On Death - Set Faction: Timmy the Cruel');
+(-54069, 0, 7, 8, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 2, 21, 0, 0, 0, 0, 0, 10, 247227, 10808, 0, 0, 0, 0, 0, 0,            'Crimson Guardsman - On Death - Set Faction: Timmy the Cruel'),
+(-54069, 0, 8, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 2472270, 0, 0, 0, 0, 0, 10, 247227, 10808, 0, 0, 0, 0, 0, 0,     'Crimson Guardsman - On Death - Start Waypoints: Timmy the Cruel');
 
--- fix spawn location for The Unforgiven
+-- fix spawn locations
 UPDATE `creature` SET `position_x` = 3719.82, `position_y` = -3426.25, `position_z` = 131.844, `orientation` = 3.3412 WHERE `id1` = 10516;
+UPDATE `creature` SET `position_x` = 3614.7, `position_y` = -3187.64, `position_z` = 131.406, `MovementType` = 0 WHERE `id1` = 10808;
+UPDATE `creature_template` SET `MovementType` = 0 WHERE `entry` = 10808; -- not 2, else waypoints will start on spawn
+
+-- fix waypoints Timmy the Cruel
+DELETE FROM `creature_addon` WHERE `guid` IN (247227);
+INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 
+(247227, 2472270, 0, 0, 1, 0, 0, NULL);
+
+DELETE FROM `waypoint_data` WHERE `id` IN (2472270);
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES 
+--
+(2472270, 1, 3614.7, -3187.64, 131.406, NULL, 0, 0, 0, 100, 0),
+(2472270, 2, 3614.7, -3187.64, 131.406, NULL, 0, 0, 0, 100, 0),
+(2472270, 3, 3643.04, -3202.96, 128.386, NULL, 0, 0, 0, 100, 0),
+(2472270, 4, 3667.77, -3207.47, 126.829, NULL, 0, 0, 0, 100, 0),
+(2472270, 5, 3687.95, -3196.14, 127.191, NULL, 0, 0, 0, 100, 0),
+(2472270, 6, 3698.67, -3175.77, 127.238, NULL, 0, 0, 0, 100, 0),
+(2472270, 7, 3696.27, -3155.81, 127.465, NULL, 0, 0, 0, 100, 0),
+(2472270, 8, 3681.1, -3154.65, 127.124, NULL, 0, 0, 0, 100, 0),
+(2472270, 9, 3672.27, -3166.2, 126.668, NULL, 0, 0, 0, 100, 0),
+(2472270, 10, 3677.42, -3174.55, 126.343, NULL, 0, 0, 0, 100, 0),
+(2472270, 11, 3684.8, -3176.73, 126.586, NULL, 0, 0, 0, 100, 0),
+(2472270, 12, 3692.54, -3177.11, 126.922, NULL, 0, 0, 0, 100, 0),
+(2472270, 13, 3697.09, -3165.99, 127.209, NULL, 0, 0, 0, 100, 0),
+(2472270, 14, 3693.52, -3156.76, 127.294, NULL, 0, 0, 0, 100, 0),
+(2472270, 15, 3682.33, -3156.29, 127.009, NULL, 0, 0, 0, 100, 0),
+(2472270, 16, 3672.98, -3168.33, 126.499, NULL, 0, 0, 0, 100, 0),
+(2472270, 17, 3678.39, -3174.43, 126.348, NULL, 0, 0, 0, 100, 0),
+(2472270, 18, 3692.2, -3176.01, 126.915, NULL, 0, 0, 0, 100, 0),
+(2472270, 19, 3694.37, -3153.05, 127.531, NULL, 0, 0, 0, 100, 0);
     
 -- stratholme living side, 3 doors not locked that should require the scarlet key
 UPDATE gameobject_template SET `Data1` = 299 WHERE `entry` IN (175967, 175968, 176194);

--- a/data/sql/world/base/dungeon_stratholme.sql
+++ b/data/sql/world/base/dungeon_stratholme.sql
@@ -235,8 +235,8 @@ UPDATE `creature_loot_template` SET `Chance` = 1    WHERE `entry` = 10398 AND `i
 UPDATE `creature_loot_template` SET `Chance` = 1    WHERE `entry` = 10398 AND `item` = 16702; -- Thuzadin Necromancer - Devout Bracers
 UPDATE `creature_loot_template` SET `Chance` = 1    WHERE `entry` = 10400 AND `item` = 16697; -- Thuzadin Necromancer - Devout Bracers
 UPDATE `creature_loot_template` SET `Chance` = 1    WHERE `entry` = 10400 AND `item` = 16702; -- Thuzadin Necromancer - Dreadmist Belt
-UPDATE `creature_loot_template` SET `Chance` = 1.75 WHERE `entry` = 10406 AND `item` = 16681; -- Ghoul Ravener - Beaststalker's Bindings
-UPDATE `creature_loot_template` SET `Chance` = 1.5  WHERE `entry` = 10407 AND `item` = 16681; -- Fleshflayer Ghoul - Beaststalker's Bindings
+UPDATE `creature_loot_template` SET `Chance` = 1.75 WHERE `entry` = 10406 AND `item` = 16681; -- Ghoul Ravener - Beaststalkers Bindings
+UPDATE `creature_loot_template` SET `Chance` = 1.5  WHERE `entry` = 10407 AND `item` = 16681; -- Fleshflayer Ghoul - Beaststalkers Bindings
 UPDATE `creature_loot_template` SET `Chance` = 2.25 WHERE `entry` = 10408 AND `item` = 16723; -- Rockwing Gargoyle - Lightforge Belt
 UPDATE `creature_loot_template` SET `Chance` = 2.25 WHERE `entry` = 10409 AND `item` = 16723; -- Rockwing Gargoyle - Lightforge Belt
 UPDATE `creature_loot_template` SET `Chance` = 1.25 WHERE `entry` = 10412 AND `item` = 16671; -- Crypt Crawler - Bindings of Elements
@@ -246,23 +246,45 @@ UPDATE `creature_loot_template` SET `Chance` = 2.25 WHERE `entry` = 10416 AND `i
 UPDATE `creature_loot_template` SET `Chance` = 2.25 WHERE `entry` = 10417 AND `item` = 16736; -- Venom Belcher - Belt of Valor
 UPDATE `creature_loot_template` SET `Chance` = 1.75 WHERE `entry` = 10418 AND `item` = 16723; -- Crimson Guardsman - Lightforge Belt
 UPDATE `creature_loot_template` SET `Chance` = 2    WHERE `entry` = 10420 AND `item` = 16697; -- Crimson Initiate - Devout Bracers
-UPDATE `creature_loot_template` SET `Chance` = 1.75 WHERE `entry` = 10421 AND `item` = 16681; -- Crimson Defender - Beaststalker's Bindings
-UPDATE `creature_loot_template` SET `Chance` = 2    WHERE `entry` = 10422 AND `item` = 16685; -- Crimson Sorcerer - Magister's Belt
+UPDATE `creature_loot_template` SET `Chance` = 1.75 WHERE `entry` = 10421 AND `item` = 16681; -- Crimson Defender - Beaststalkers Bindings
+UPDATE `creature_loot_template` SET `Chance` = 2    WHERE `entry` = 10422 AND `item` = 16685; -- Crimson Sorcerer - Magisters Belt
 UPDATE `creature_loot_template` SET `Chance` = 4    WHERE `entry` = 10423 AND `item` = 16697; -- Crimson Priest - Devout Bracers
 UPDATE `creature_loot_template` SET `Chance` = 1.75 WHERE `entry` = 10424 AND `item` = 16723; -- Crimson Gallant - Lightforge Belt
-UPDATE `creature_loot_template` SET `Chance` = 3    WHERE `entry` = 10425 AND `item` = 16685; -- Crimson Battle Mage - Magister's Belt
+UPDATE `creature_loot_template` SET `Chance` = 3    WHERE `entry` = 10425 AND `item` = 16685; -- Crimson Battle Mage - Magisters Belt
 UPDATE `creature_loot_template` SET `Chance` = 1.75 WHERE `entry` = 10426 AND `item` = 16714; -- Crimson Inquisitor - Wildheart Bracers
 UPDATE `creature_loot_template` SET `Chance` = 1.5  WHERE `entry` = 10463 AND `item` = 16714; -- Shrieking Banshee - Wildheart Bracers
 UPDATE `creature_loot_template` SET `Chance` = 1.75 WHERE `entry` = 10464 AND `item` = 16714; -- Wailing Banshee - Wildheart Bracers
 UPDATE `creature_loot_template` SET `Chance` = 3    WHERE `entry` = 11043 AND `item` = 16671; -- Crimson Monk - Bindings of Elements
 
+-- fix Timmy the Cruel spawn
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (10808, -54069);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
+`event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(10808, 0, 0, 0, 0, 0, 100, 0, 3000, 8000, 9000, 14000, 0, 0, 11, 17470, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,       'Timmy the Cruel - In Combat - Cast Ravenous Claw'),
+(10808, 0, 1, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 11, 8599, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Timmy the Cruel - Between Health 0-30% - Cast Enrage'),
+(10808, 0, 2, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                         'Timmy the Cruel - On Aggro - Say Line 0'),
+(10808, 0, 3, 4, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 47, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'Timmy the Cruel - On Respawn - Set Invisible'),
+(10808, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 2, 35, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                       'Timmy the Cruel - On Respawn - Set Faction'),
+--
+(-54069, 0, 0, 0, 9, 0, 100, 0, 0, 0, 10000, 10000, 8, 25, 11, 15749, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,          'Crimson Guardsman - Within Range 8-25yd - Cast Shield Charge'),
+(-54069, 0, 1, 0, 0, 0, 100, 0, 4000, 15000, 12000, 25800, 0, 0, 11, 6713, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,     'Crimson Guardsman - In Combat - Cast Disarm'),
+(-54069, 0, 2, 0, 105, 0, 100, 0, 10000, 12000, 10000, 12000, 0, 5, 11, 11972, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Crimson Guardsman - Victim Casting - Cast Shield Bash'),
+(-54069, 0, 3, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Crimson Guardsman - Between 0-15% Health - Flee For Assist'),
+(-54069, 0, 4, 5, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                        'Crimson Guardsman - On Death - Say Line 0'),
+(-54069, 0, 5, 6, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 39, 30, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                     'Crimson Guardsman - On Death - Call For Help'),
+(-54069, 0, 6, 7, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 47, 1, 0, 0, 0, 0, 0, 10, 247227, 10808, 0, 0, 0, 0, 0, 0,            'Crimson Guardsman - On Death - Set Visible: Timmy the Cruel'),
+(-54069, 0, 7, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 2, 21, 0, 0, 0, 0, 0, 10, 247227, 10808, 0, 0, 0, 0, 0, 0,            'Crimson Guardsman - On Death - Set Faction: Timmy the Cruel');
+    
 -- stratholme living side, 3 doors not locked that should require the scarlet key
 UPDATE gameobject_template SET `Data1` = 299 WHERE `entry` IN (175967, 175968, 176194);
 UPDATE gameobject_template_addon SET `flags` = 34 WHERE `entry` IN (175967, 175968, 176194);
 
 -- service gate should open and close, but not lock itself again. I can't get this to work, so I'm keeping the gate open. (old Data2 value was 3000)
 UPDATE `gameobject_template` SET `Data2` = 0 WHERE `entry` = 175368; 
-
+  
 -- Gargoyles
 SET @CGUID    := 329000;  -- creature guid
 SET @WPID     := 3290000; -- waypoint ID

--- a/data/sql/world/base/dungeon_stratholme.sql
+++ b/data/sql/world/base/dungeon_stratholme.sql
@@ -296,7 +296,7 @@ UPDATE `creature_template` SET `MovementType` = 0 WHERE `entry` = 10808; -- not 
 -- fix waypoints Timmy the Cruel
 DELETE FROM `creature_addon` WHERE `guid` IN (247227);
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 
-(247227, 2472270, 0, 0, 1, 0, 0, NULL);
+(247227, 2472270, 0, 0, 0, 0, 0, NULL);
 
 DELETE FROM `waypoint_data` WHERE `id` IN (2472270);
 INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES 


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/1222

Timmy the Cruel was visible.
He should spawn after the guards in front of the locked door are defeated.

The Unforgiven was visible and his spawn location was incorrect.
new spawn location taken from vMangos.

todo:
~~Timmy should have waypoints.~~
~~he should also shout his name when he becomes visible, not on aggro.~~