### PR TITLE
Enable all spell ranks config option

### DIFF
--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -454,6 +454,19 @@ IndividualProgression.BotAccountsRegex = "^RNDBOT.*"
 #
 IndividualProgression.ExcludedAccountsRegex = ""
 
+# IndividualProgression.EnableAllSpellRanks
+#
+#        Description: Enable this to allow all spell ranks to be cast during WotLK. 
+#                     All spell ranks had the same % mana cost during WotLK, there was no reason to cast lower ranks of spells.
+#                     By default Individual Progression will block vanilla and tbc ranks of spells after the player progresses to WotLK.
+#                     This is done because if patch-V is used these vanilla and tbc spells will have their static mana cost restored.
+#                     They should not exist during WotLK. But if you want them to be available anyways, you can enable this config option.
+#
+#        Default:     0 - Disabled
+#                     1 - Enabled
+#
+IndividualProgression.EnableAllSpellRanks = 0
+
 # IndividualProgression.EnableSetRepCommand
 #
 #        Description: Enable the .ip setrep command for normal AND gm accounts

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -922,6 +922,7 @@ private:
         sIndividualProgression->excludedAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.ExcludedAccountsRegex", "");
         sIndividualProgression->botAccountsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.BotAccountsRegex", "^RNDBOT.*");
         sIndividualProgression->EnableSetRepCommand = sConfigMgr->GetOption<bool>("IndividualProgression.EnableSetRepCommand", false);
+        sIndividualProgression->EnableAllSpellRanks = sConfigMgr->GetOption<bool>("IndividualProgression.EnableAllSpellRanks", false);
         sIndividualProgression->LimitedSetRepCommand = sConfigMgr->GetOption<bool>("IndividualProgression.LimitedSetRepCommand", true);
         sIndividualProgression->sharedFactionIdsRegex = sConfigMgr->GetOption<std::string>("IndividualProgression.sharedFactionIdsRegex", "59|270|349|509|510|529|576|589|609|729|730|749|889|890|909");
         sIndividualProgression->BotAccountsMaxLevel = sConfigMgr->GetOption<uint8>("IndividualProgression.BotAccountsMaxLevel", 80);

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -400,7 +400,7 @@ public:
     std::map<uint32, uint8> customProgressionMap;
     questXpMapType questXpMap;
     float vanillaPowerAdjustment, tbcPowerAdjustment, vanillaHealingAdjustment, tbcHealingAdjustment;
-    bool enabled, questXpFix, enforceGroupRules, EnableSetRepCommand, LimitedSetRepCommand, fishingFix, simpleConfigOverride, MaxMonsterSight, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, BotAccountsEarnPvPTitles, BotOnlyAdjustments;
+    bool enabled, questXpFix, enforceGroupRules, EnableSetRepCommand, EnableAllSpellRanks, LimitedSetRepCommand, fishingFix, simpleConfigOverride, MaxMonsterSight, questMoneyAtLevelCap, repeatableVanillaQuestsXp, disableDefaultProgression, earlyDungeonSet2, earlyScourgeBosses, requireNaxxStrath, doableNaxx40Bosses, DisableQuestMarkers, DisableRDF, VanillaPvpTitlesKeepPostVanilla, VanillaPvpTitlesEarnPostVanilla, BotAccountsEarnPvPTitles, BotOnlyAdjustments;
     int progressionLimit, startingProgression, tbcRacesProgressionLevel, tbcRacesStartingProgression, deathKnightProgressionLevel, deathKnightStartingProgression, RequiredZulGurubProgression, RequiredZulAmanProgression, tbcArenaSeason, wotlkArenaSeason, BotAccountsMaxLevel;
     uint32 VanillaPvpKillRank1, VanillaPvpKillRank2, VanillaPvpKillRank3, VanillaPvpKillRank4, VanillaPvpKillRank5, VanillaPvpKillRank6, VanillaPvpKillRank7, VanillaPvpKillRank8, VanillaPvpKillRank9, VanillaPvpKillRank10, VanillaPvpKillRank11, VanillaPvpKillRank12, VanillaPvpKillRank13, VanillaPvpKillRank14;
     std::string excludedAccountsRegex, botAccountsRegex, sharedFactionIdsRegex;

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -193,6 +193,9 @@ public:
         if (sIndividualProgression->isBotAccount(player)) // bots don't cast lower ranks of spells
             return;
 
+        if (sIndividualProgression->EnableAllSpellRanks)
+            return;
+        
         if (!sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5) || player->GetLevel() < 70) // no need to check spells if player is not in WotlK
             return;
 


### PR DESCRIPTION
to be clear, this is a cheat.

Vanilla and TBC ranks of spells should not be available during WotLK.

If you don't use any patches, or if you use patch-S then spell costs are all % based.
Every rank costs the same amount of mana to cast. There is no reason to cast a lower rank.
You would be casting a less powerful version for the same amount of mana.

If you use patch-V, vanilla and tbc spells will have their static mana costs restored.
Those spells for those mana costs did not exist during WotLK. That's why this module blocks players from casting them.

But if you want these Vanilla and TBC ranks to be available anyways, you can now enable this config option.

`IndividualProgression.EnableAllSpellRanks`

disabled by default.


edit:
I still have to work on TBC static mana costs.
Just included it in my explanation because it will be added.