### PR TITLE
Swap the default for group rules

### DIFF
--- a/conf/individualProgression.conf.dist
+++ b/conf/individualProgression.conf.dist
@@ -22,12 +22,12 @@ IndividualProgression.Enable = 1
 
 # IndividualProgression.EnforceGroupRules
 #
-#        Description: Only allow players to group with others in the same progression phase
+#        Description: Enable this to only allow players to group with others in the same progression phase
 #
-#        Default:     1 - Enabled
-#                     0 - Disabled
+#        Default:     0 - Disabled
+#                     1 - Enabled
 #
-IndividualProgression.EnforceGroupRules = 1
+IndividualProgression.EnforceGroupRules = 0
 
 # IndividualProgression.VanillaPowerAdjustment
 #

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -901,7 +901,7 @@ private:
         sIndividualProgression->doableNaxx40Bosses_Gluth = sConfigMgr->GetOption<bool>("IndividualProgression.doableNaxx40Bosses_Gluth", false);
         sIndividualProgression->doableNaxx40Bosses_Patchwerk = sConfigMgr->GetOption<bool>("IndividualProgression.doableNaxx40Bosses_Patchwerk", false);
         sIndividualProgression->doableNaxx40Bosses_Razuvious = sConfigMgr->GetOption<bool>("IndividualProgression.doableNaxx40Bosses_Razuvious", false);
-        sIndividualProgression->enforceGroupRules = sConfigMgr->GetOption<bool>("IndividualProgression.EnforceGroupRules", true);
+        sIndividualProgression->enforceGroupRules = sConfigMgr->GetOption<bool>("IndividualProgression.EnforceGroupRules", false);
         sIndividualProgression->fishingFix = sConfigMgr->GetOption<bool>("IndividualProgression.FishingFix", true);
         sIndividualProgression->simpleConfigOverride = sConfigMgr->GetOption<bool>("IndividualProgression.SimpleConfigOverride", true);
         sIndividualProgression->progressionLimit = sConfigMgr->GetOption<uint8>("IndividualProgression.ProgressionLimit", 0);


### PR DESCRIPTION
the default was to not allow players to group with other players that are in a different progression tier.
this setting is really only useful for servers with many real players

I believe most people will want to disable this.