### PR TITLE
Update Group Attunements

### DIFF
--- a/data/sql/world/base/cs_individualProgression.sql
+++ b/data/sql/world/base/cs_individualProgression.sql
@@ -5,5 +5,5 @@ INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('ip setbot', 0, 'Syntax: .ip setbot\nSets all bots in the group to your progression level.'),
 ('ip setrep', 0, 'Syntax: .ip setrep\nSets your reputation of certain factions to the same value as the character that has the highest value on your account.'),
 ('ip tele', 2, 'Syntax: .ip tele $location\nTeleports the player to the given location.'),
-('ip attune', 0, 'Syntax: .ip tele $location\nGives all players in the group the required attument item.'),
+('ip attune', 0, 'Syntax: .ip attune $location\nGives all players in the group the required attument item.'),
 ('ip pvp', 0, 'Syntax: .ip pvp [$player]\nShows the current PvP rank and kills for yourself, your target, or a named player.');

--- a/data/sql/world/base/cs_individualProgression.sql
+++ b/data/sql/world/base/cs_individualProgression.sql
@@ -1,8 +1,9 @@
-DELETE FROM `command` WHERE `name` IN ('ip get', 'ip set', 'ip setbot', 'ip setrep', 'ip tele', 'ip pvp');
+DELETE FROM `command` WHERE `name` IN ('ip get', 'ip set', 'ip setbot', 'ip setrep', 'ip tele', 'ip pvp', 'ip attune');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('ip get', 0, 'Syntax: .ip get [$player]\nShows the current progression level for yourself, your target, or a named player.'),
 ('ip set', 2, 'Syntax: .ip set $progressionLevel\nSets the player to the given progression level.'),
 ('ip setbot', 0, 'Syntax: .ip setbot\nSets all bots in the group to your progression level.'),
 ('ip setrep', 0, 'Syntax: .ip setrep\nSets your reputation of certain factions to the same value as the character that has the highest value on your account.'),
 ('ip tele', 2, 'Syntax: .ip tele $location\nTeleports the player to the given location.'),
+('ip attune', 0, 'Syntax: .ip tele $location\nGives all players in the group the required attument item.'),
 ('ip pvp', 0, 'Syntax: .ip pvp [$player]\nShows the current PvP rank and kills for yourself, your target, or a named player.');

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -195,6 +195,61 @@ void IndividualProgression::UpdateAccountReputation(uint32 factionId, uint32 acc
     }
 }
 
+void IndividualProgression::UpdateGroupAttunement(Player* player, std::string location)
+{
+    if (!player || !player->IsInWorld() )
+        return;
+
+    if (location.empty())
+        return;
+
+    Group* group = player->GetGroup();
+
+    if (!group)
+        return;
+
+    if (location == "onyxia40" || location == "onyxia")
+    {
+        if (player->HasItemCount(ITEM_DRAKEFIRE_AMULET))
+        {
+            for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+            {
+                Player* member = itr->GetSource();
+                if (!member || sIndividualProgression->isBotAccount(member) || member->GetLevel() < 50)
+                    continue;
+
+                member->AddItem(ITEM_DRAKEFIRE_AMULET, 1);
+            }
+            return;
+        }
+        else
+        {
+            ChatHandler(player->GetSession()).PSendSysMessage("You must have the Drakefire Amulet in your inventory to use this command.");
+            return;
+        }
+    }
+    else if (location == "bt" || location == "blacktemple")
+    {
+        if (player->HasItemCount(ITEM_MEDALLION_OF_KARABOR) || player->HasItemCount(ITEM_BLESSED_MEDALLION_OF_KARABOR))
+        {
+            for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+            {
+                Player* member = itr->GetSource();
+                if (!member || sIndividualProgression->isBotAccount(member) || member->GetLevel() < 70)
+                    continue;
+
+                member->AddItem(ITEM_MEDALLION_OF_KARABOR, 1);
+            }
+            return;
+        }
+        else
+        {
+            ChatHandler(player->GetSession()).PSendSysMessage("You must have the Medallion of Karabor in your inventory to use this command.");
+            return;
+        }
+    }
+}
+
 void IndividualProgression::RemovePlayerAchievement(uint16 playerGUID, uint16 achievementId)
 {
 	if (!playerGUID || !achievementId)

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -226,6 +226,12 @@ void IndividualProgression::UpdateGroupAttunement(Player* player, std::string lo
 
                 if (!member->HasItemCount(ITEM_DRAKEFIRE_AMULET))
                 {
+                    if (member->HasItemCount(ITEM_DRAKEFIRE_AMULET, 1, true))
+                    {
+                        ChatHandler(player->GetSession()).PSendSysMessage("|cff00ffff{}|r has the Drakefire Amulet in their bank.", member->GetName());
+                        continue;
+                    }
+
                     member->AddItem(ITEM_DRAKEFIRE_AMULET, 1);
                     ChatHandler(player->GetSession()).PSendSysMessage("|cff00ffff{}|r received the Drakefire Amulet.", member->GetName());
                 }
@@ -262,6 +268,12 @@ void IndividualProgression::UpdateGroupAttunement(Player* player, std::string lo
 
                 if (!member->HasItemCount(ITEM_MEDALLION_OF_KARABOR) && !member->HasItemCount(ITEM_BLESSED_MEDALLION_OF_KARABOR))
                 {
+                    if (member->HasItemCount(ITEM_MEDALLION_OF_KARABOR, 1, true) || member->HasItemCount(ITEM_BLESSED_MEDALLION_OF_KARABOR, 1, true))
+                    {
+                        ChatHandler(player->GetSession()).PSendSysMessage("|cff00ffff{}|r has the Medallion of Karabor in their bank.", member->GetName());
+                        continue;
+                    }
+
                     member->AddItem(ITEM_MEDALLION_OF_KARABOR, 1);
                     ChatHandler(player->GetSession()).PSendSysMessage("|cff00ffff{}|r received the Medallion of Karabor.", member->GetName());
                 }

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -218,7 +218,8 @@ void IndividualProgression::UpdateGroupAttunement(Player* player, std::string lo
                 if (!member || sIndividualProgression->isBotAccount(member) || member->GetLevel() < 50)
                     continue;
 
-                member->AddItem(ITEM_DRAKEFIRE_AMULET, 1);
+                if (!member->HasItemCount(ITEM_DRAKEFIRE_AMULET))
+                    member->AddItem(ITEM_DRAKEFIRE_AMULET, 1);
             }
             return;
         }
@@ -238,7 +239,8 @@ void IndividualProgression::UpdateGroupAttunement(Player* player, std::string lo
                 if (!member || sIndividualProgression->isBotAccount(member) || member->GetLevel() < 70)
                     continue;
 
-                member->AddItem(ITEM_MEDALLION_OF_KARABOR, 1);
+                if (!member->HasItemCount(ITEM_MEDALLION_OF_KARABOR) && !member->HasItemCount(ITEM_BLESSED_MEDALLION_OF_KARABOR))
+                    member->AddItem(ITEM_MEDALLION_OF_KARABOR, 1);
             }
             return;
         }

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -215,11 +215,20 @@ void IndividualProgression::UpdateGroupAttunement(Player* player, std::string lo
             for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
             {
                 Player* member = itr->GetSource();
-                if (!member || sIndividualProgression->isBotAccount(member) || member->GetLevel() < 50)
+                if (!member || sIndividualProgression->isBotAccount(member))
                     continue;
 
+                if (member->GetLevel() < 50)
+                {
+                    ChatHandler(player->GetSession()).PSendSysMessage("|cff00ffff{}|r needs to be at least level 50.", member->GetName());
+                    continue;
+                }
+
                 if (!member->HasItemCount(ITEM_DRAKEFIRE_AMULET))
+                {
                     member->AddItem(ITEM_DRAKEFIRE_AMULET, 1);
+                    ChatHandler(player->GetSession()).PSendSysMessage("|cff00ffff{}|r received the Drakefire Amulet.", member->GetName());
+                }
             }
             return;
         }
@@ -236,11 +245,26 @@ void IndividualProgression::UpdateGroupAttunement(Player* player, std::string lo
             for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
             {
                 Player* member = itr->GetSource();
-                if (!member || sIndividualProgression->isBotAccount(member) || member->GetLevel() < 70 || isBeforeProgression(member, PROGRESSION_TBC_TIER_2))
+                if (!member || sIndividualProgression->isBotAccount(member))
                     continue;
 
+                if (member->GetLevel() < 70)
+                {
+                    ChatHandler(player->GetSession()).PSendSysMessage("|cff00ffff{}|r needs to be at least level 70.", member->GetName());
+                    continue;
+                }
+
+                if (isBeforeProgression(member, PROGRESSION_TBC_TIER_2))
+                {
+                    ChatHandler(player->GetSession()).PSendSysMessage("|cff00ffff{}|r needs to have progression level 10 (TBC Tier 2).", member->GetName());
+                    continue;
+                }
+
                 if (!member->HasItemCount(ITEM_MEDALLION_OF_KARABOR) && !member->HasItemCount(ITEM_BLESSED_MEDALLION_OF_KARABOR))
+                {
                     member->AddItem(ITEM_MEDALLION_OF_KARABOR, 1);
+                    ChatHandler(player->GetSession()).PSendSysMessage("|cff00ffff{}|r received the Medallion of Karabor.", member->GetName());
+                }
             }
             return;
         }

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -236,7 +236,7 @@ void IndividualProgression::UpdateGroupAttunement(Player* player, std::string lo
             for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
             {
                 Player* member = itr->GetSource();
-                if (!member || sIndividualProgression->isBotAccount(member) || member->GetLevel() < 70)
+                if (!member || sIndividualProgression->isBotAccount(member) || member->GetLevel() < 70 || isBeforeProgression(member, PROGRESSION_TBC_TIER_2))
                     continue;
 
                 if (!member->HasItemCount(ITEM_MEDALLION_OF_KARABOR) && !member->HasItemCount(ITEM_BLESSED_MEDALLION_OF_KARABOR))

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -429,6 +429,7 @@ public:
     void checkIPPhasing(Player* player, uint32 newArea);
     void checkIPProgression(Player* player);
     void UpdateProgressionAchievements(Player* player, uint16 achievementID);
+    void UpdateGroupAttunement(Player* player, std::string location);
     void checkKillProgression(Player* player, Creature* killed);
 	void UpdateAccountReputation(uint32 factionId, uint32 accountId, Player* player);
     void CleanUpVanillaPvpTitles(Player* player);

--- a/src/cs_individualProgression.cpp
+++ b/src/cs_individualProgression.cpp
@@ -21,6 +21,7 @@ public:
             { "setbot", HandleSetBotIndividualProgressionCommand, SEC_GAMEMASTER,    Console::Yes },
             { "setrep", HandleSetRepIndividualProgressionCommand, SEC_GAMEMASTER,    Console::Yes },
             { "pvp",    HandlePVPIndividualProgressionCommand,    SEC_GAMEMASTER,    Console::Yes },
+            { "attune", HandleAttuneIndividualProgressionCommand, SEC_GAMEMASTER,    Console::Yes },
         };
 
         static ChatCommandTable commandTable =
@@ -400,6 +401,30 @@ public:
         }
 
         return false;
+    }
+
+    static bool HandleAttuneIndividualProgressionCommand(ChatHandler* handler, std::string location)
+    {
+        Player* player = handler->GetSession()->GetPlayer();
+
+        if (!player)
+        {
+            handler->SendSysMessage("Player not found.");
+            return false;
+        }
+
+        if (location.empty())
+            return false;
+        
+        if (location != "onyxia40" && location != "onyxia" && location != "bt" && location != "blacktemple")
+        {
+            handler->PSendSysMessage("|cff00ffff{}|r is not a valid attunement.", location);
+            return false;
+        }
+
+        sIndividualProgression->UpdateGroupAttunement(player, location);
+
+        return true;
     }
 
     static bool HandlePVPIndividualProgressionCommand(ChatHandler* handler, Optional<PlayerIdentifier> player)


### PR DESCRIPTION
new command
`.ip attune onyxia/onyxia40`
`.ip attune blacktemple/bt`

this will check if you have the required item in your inventory
if the player that uses the command has the item, it will give the attunement item to all players in the party/raid.
now giving confirmation messages and reasons why the player can't get the item
now also checking the bank of the party/raid members

this will not complete the attunement quests for the players that did not have the item yet.
this will only work for ALTbots and real players. RNDbots don't need the item.
this will only work for onyxia if the player is level 50+
this will only work for black temple if 
- the player is level 70+
- the player is at progression level 10+

todo:
- ~~testing~~
