### PR TITLE
Onyxia Entrance Trigger Without Teleport

### DIFF
--- a/src/vanillaScripts/instance_onyxias_lair.cpp
+++ b/src/vanillaScripts/instance_onyxias_lair.cpp
@@ -135,46 +135,74 @@ public:
 
         ChatHandler handler(player->GetSession());
 
+        Group* group = player->GetGroup();
+
         if (player->GetLevel() <= 70)
         {
-            if (player->GetLevel() < 50)
-            {
-                handler.PSendSysMessage("You need to be at least level 50 to enter Onyxia\'s Lair.");
-                return false;
-            }
-            if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5)) // death knights
-            {
-                handler.PSendSysMessage("Your progression level is too high to enter the level 60 version of Onyxia\'s Lair.");
-                return false;
-            }
-            if (!player->HasItemCount(ITEM_DRAKEFIRE_AMULET) && !sIndividualProgression->isBotAccount(player))
-            {
-                handler.PSendSysMessage("You must have the Drakefire Amulet in your inventory to enter Onyxia\'s Lair.");
-                return false;
-            }
-
-            Group* group = player->GetGroup();
-
             if (group)
-                group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
-            else
-                player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
-
-            player->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);
-            return true;
-
-        }
-	    else // (player->GetLevel() > 70)
-        {
-            if (player->GetLevel() != 80)
             {
-                handler.PSendSysMessage("You need to be level 80 to enter Onyxia\'s Lair.");
-                return false;
-            }
+                for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+                {
+                    Player* member = itr->GetSource();
+                    if (!member || sIndividualProgression->isBotAccount(member))
+                        continue;
 
-            player->TeleportTo(249, 29.1607f, -71.3372f, -8.18032f, 4.58f);
-            return true;
+                    bool allowed = true;
+
+                    if (member->GetLevel() < 50)
+                    {
+                        handler.PSendSysMessage("|cff00ffff{}|r needs to be at least level 50.", member->GetName());
+                        allowed = false;
+                    }
+                    if (sIndividualProgression->hasPassedProgression(member, PROGRESSION_TBC_TIER_5)) // death knights
+                    {
+                        handler.PSendSysMessage("|cff00ffff{}|r progression level is too high.", member->GetName());
+                        allowed = false;
+                    }
+                    if (!member->HasItemCount(ITEM_DRAKEFIRE_AMULET))
+                    {
+                        if (member->getGender() == GENDER_MALE)
+                            handler.PSendSysMessage("|cff00ffff{}|r does not have the Drakefire Amulet in his inventory.", member->GetName());
+                        else 
+                            handler.PSendSysMessage("|cff00ffff{}|r does not have the Drakefire Amulet in her inventory.", member->GetName());
+
+                        allowed = false;
+                    }
+                    if (member->IsGameMaster())
+                    {
+                        handler.PSendSysMessage("|cff00ffff{}|r is a GM.", member->GetName());
+                        allowed = true;
+                    }
+
+                    if (allowed)
+                        handler.PSendSysMessage("|cff00ffff{}|r is allowed to enter.", member->GetName());
+
+                    member->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                }
+
+                group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+            }
+            else
+            {
+                if (player->GetLevel() < 50)
+                    handler.PSendSysMessage("You need to be at least level 50.");
+
+                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5)) // death knights
+                    handler.PSendSysMessage("Your progression level is too high.");
+
+                if (!player->HasItemCount(ITEM_DRAKEFIRE_AMULET))
+                    handler.PSendSysMessage("You need to have the Drakefire Amulet in your inventory.");
+
+                player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+            }
         }
+        else
+        {
+            if (player->GetLevel() < 80)
+                handler.PSendSysMessage("You need to be level 80 to enter Onyxia's Lair.");
+        }
+
+        return false;
     }
 };
 


### PR DESCRIPTION
because this has been an issue for years now
people not understanding why they can't enter
I'm going over the top with this

- now letting AC do the teleporting
- now every raid member gets checked for requirements, not just per player. every player checks all raid members.
- now you get messages for each raid member explaining why they can't get in