### PR TITLE
Vanilla Naxxramas entrance with messages

### DIFF
--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -25,38 +25,103 @@ public:
 
     bool OnGossipHello(Player* player, GameObject* /*go*/) override
     {
-        if (player->GetLevel() > 70)
-        {
-            ChatHandler(player->GetSession()).PSendSysMessage("Your level is too high to enter the level 60 version of Naxxramas.");
+        if (!player || !player->IsInWorld())
             return false;
-        }
 
-        if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5))
-        {
-            ChatHandler(player->GetSession()).PSendSysMessage("Your progression level is too high to enter the level 60 version of Naxxramas.");
-            return false;
-        }
+        ChatHandler handler(player->GetSession());
+        Group* group = player->GetGroup();
 
-        if (!sIndividualProgression->requireNaxxStrath || player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_REWARDED)
+        if (player->GetLevel() <= 70)
         {
-            if (sIndividualProgression->isAttuned(player))
+            bool allowed = true;
+
+            if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5)) // death knights
             {
-                Group* group = player->GetGroup();
+                handler.PSendSysMessage("Your progression level is too high.");
+                allowed = false;
+            }
 
-                if (group)
-                    group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+            if (sIndividualProgression->requireNaxxStrath)
+            {
+                if (player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_COMPLETE) {}
                 else
-                    player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                {
+                    handler.PSendSysMessage("You need to enter through Stratholme first. (RequireNaxxStrathEntrance is enabled)");
+                    allowed = false;
+                }
+            }
 
-                player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
-                return true;
-            }
-            else
+            if (!sIndividualProgression->isAttuned(player))
             {
-                ChatHandler(player->GetSession()).PSendSysMessage("You have not completed the Naxxramas attunement quest.");
-                return false;
+                handler.PSendSysMessage("You are not attuned to Naxxramas.");
+                return allowed = false;
             }
+
+            if (!allowed)
+                return false;
+
+            if (group)
+            {
+                group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+
+                for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+                {
+                    Player* member = itr->GetSource();
+                    if (!member || sIndividualProgression->isBotAccount(member))
+                        continue;
+
+                    if (member->GetGUID() == player->GetGUID()) // not checking the player who is using the teleporter again
+                        continue;
+
+                    bool allowed = true;
+
+                    if (sIndividualProgression->requireNaxxStrath)
+                    {
+                        if (member->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_COMPLETE) {}
+                        else
+                        {
+                            handler.PSendSysMessage("|cff00ffff{}|r needs to enter through Stratholme first. (RequireNaxxStrathEntrance is enabled)", member->GetName());
+                            allowed = false;
+                        }
+                    }
+
+                    if (sIndividualProgression->hasPassedProgression(member, PROGRESSION_TBC_TIER_5)) // death knights
+                    {
+                        handler.PSendSysMessage("|cff00ffff{}|r progression level is too high.", member->GetName());
+                        allowed = false;
+                    }
+
+                    if (!sIndividualProgression->isAttuned(member))
+                    {
+                        handler.PSendSysMessage("|cff00ffff{}|r is not attuned to Naxxramas.", member->GetName());
+                        allowed = false;
+                    }
+
+                    if (member->IsGameMaster())
+                    {
+                        handler.PSendSysMessage("|cff00ffff{}|r is a GM.", member->GetName());
+                        allowed = true;
+                    }
+
+                    if (allowed)
+                    {
+                        handler.PSendSysMessage("|cff00ffff{}|r is allowed to enter.", member->GetName());
+
+                        member->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                        member->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
+                    }
+                }
+            }
+
+            player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+            player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
+            return true;
         }
+        else
+        {
+            handler.PSendSysMessage("You need to be level 70 or below to enter this version of Naxxramas.");
+        }
+
         return false;
     }
 };

--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -67,8 +67,15 @@ public:
                 for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
                 {
                     Player* member = itr->GetSource();
-                    if (!member || sIndividualProgression->isBotAccount(member))
+                    if (!member)
                         continue;
+
+                    if (sIndividualProgression->isBotAccount(member))
+                    {
+                        member->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                        member->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
+                        continue;
+                    }
 
                     if (member->GetGUID() == player->GetGUID()) // not checking the player who is using the teleporter again
                         continue;
@@ -106,9 +113,10 @@ public:
                     if (allowed)
                     {
                         handler.PSendSysMessage("|cff00ffff{}|r is allowed to enter.", member->GetName());
-
                         member->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
-                        member->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
+
+                        if (player->GetDistance(member) <= 40.0f) 
+                            member->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
                     }
                 }
             }

--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -54,7 +54,7 @@ public:
             if (!sIndividualProgression->isAttuned(player))
             {
                 handler.PSendSysMessage("You are not attuned to Naxxramas.");
-                return allowed = false;
+                allowed = false;
             }
 
             if (!allowed)

--- a/src/vanillaScripts/instance_onyxias_lair.cpp
+++ b/src/vanillaScripts/instance_onyxias_lair.cpp
@@ -134,17 +134,46 @@ public:
             return false;
 
         ChatHandler handler(player->GetSession());
-
         Group* group = player->GetGroup();
 
         if (player->GetLevel() <= 70)
         {
+            bool allowed = true;
+
+            if (player->GetLevel() < 50)
+            {
+                handler.PSendSysMessage("You need to be at least level 50.");
+                allowed = false;
+            }
+
+            if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5)) // death knights
+            {
+                handler.PSendSysMessage("Your progression level is too high.");
+                allowed = false;
+            }
+
+            if (!player->HasItemCount(ITEM_DRAKEFIRE_AMULET))
+            {
+                handler.PSendSysMessage("You need to have the Drakefire Amulet in your inventory.");
+                allowed = false;
+            }
+
+            if (!allowed)
+                return false;
+
+            player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+
             if (group)
             {
+                group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+
                 for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
                 {
                     Player* member = itr->GetSource();
                     if (!member || sIndividualProgression->isBotAccount(member))
+                        continue;
+
+                    if (member->GetGUID() == player->GetGUID()) // not checking the first player again
                         continue;
 
                     bool allowed = true;
@@ -179,21 +208,6 @@ public:
 
                     member->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
                 }
-
-                group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
-            }
-            else
-            {
-                if (player->GetLevel() < 50)
-                    handler.PSendSysMessage("You need to be at least level 50.");
-
-                if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5)) // death knights
-                    handler.PSendSysMessage("Your progression level is too high.");
-
-                if (!player->HasItemCount(ITEM_DRAKEFIRE_AMULET))
-                    handler.PSendSysMessage("You need to have the Drakefire Amulet in your inventory.");
-
-                player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
             }
         }
         else


### PR DESCRIPTION
much like the recent change to the vanilla version of Onyxia's Lair.

First the player using the teleporter is checked.
If the player is allowed inside, then the party/raid gets checked.
now checking each member and giving the reason why that member can't enter.

when the first player uses the teleporter (and is allowed inside):
- RNDbots get teleported inside now
- ALTbots, excluded accounts and other real players within 40 yards (that are allowed inside ) also get teleported inside.

edit:
small change to Onyxia's Lair entrance as well.
Now checking the player first, THEN the raid. (It's more efficient. no need to check 39 members if you can't enter yourself.)