### PR TITLE
Update world SQL for AzerothCore creature id1 schema

### DIFF
--- a/data/sql/world/base/00_cleanup.sql
+++ b/data/sql/world/base/00_cleanup.sql
@@ -21,9 +21,9 @@ DELETE FROM `game_event_creature` WHERE `guid` IN
 (17676, 88155, 88156, 88158, 88159, 88160, 91798, 152022, 152023, 152026, 152027, 152028, 152029, 152030, 152031, 202335, 202336, 
 208486, 208487, 208488, 208489, 208491, 208492, 208494, 208496, 208498, 208499, 208500, 208501, 208503, 208504, 208506, 208508);
 
-DELETE FROM `creature`   WHERE `id`   IN (32405, 32832, 32834);
+DELETE FROM `creature`   WHERE `id1`  IN (32405, 32832, 32834);
 DELETE FROM `npc_vendor` WHERE `entry` IN (32405, 32832, 32834);
-DELETE FROM `creature` WHERE `guid` = 88156 AND `id` IN (20278); -- Vixton Pinchwhistle
+DELETE FROM `creature` WHERE `guid` = 88156 AND `id1` IN (20278); -- Vixton Pinchwhistle
 
 
 /* the following edits are temporary */

--- a/data/sql/world/base/aq_war.sql
+++ b/data/sql/world/base/aq_war.sql
@@ -47,7 +47,7 @@ INSERT INTO `creature_text` (`CreatureID`,`GroupID`,`ID`,`Text`,`Type`,`Language
 
 -- add bosses to Silithus and Darkshore 
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+101 AND @CGUID+140;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 (@CGUID+101,15810,1,0,0,1,@IPPPHASE,0,4386.996582, 550.179260, 54.762119, 0.581150,1800,5,0,0,0,1,0,0,0,'',0),
 (@CGUID+102,15810,1,0,0,1,@IPPPHASE,0,4388.178711, 513.457581, 53.590897, 3.921458,1800,5,0,0,0,1,0,0,0,'',0),

--- a/data/sql/world/base/aq_war_effort.sql
+++ b/data/sql/world/base/aq_war_effort.sql
@@ -3,7 +3,7 @@ SET @OGUID    := 650000;
 
 -- Collector Npcs
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+1 AND @CGUID+30;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 -- Alliance Collector Npcs
 (@CGUID+1,15383,0,0,0,1,1,1,-4914.29,-1228.1,501.65,3.66003,300,0,0,13495,0,0,0,0,0,'',0),
 (@CGUID+2,15431,0,0,0,1,1,1,-4915.32,-1220.84,501.658,4.07551,300,0,0,14355,0,0,0,0,0,'',0),
@@ -39,7 +39,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 -- Commendation Npcs
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+31 AND @CGUID+50;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 -- Alliance Commendation Npcs
 (@CGUID+31,15731,0,0,0,1,1,0,-4938.75,-1206.29,501.658,4.03146,300,0,0,2614,0,0,0,0,0,'npc_ipp_we',0),
 (@CGUID+32,15733,0,0,0,1,1,0,-4936.65,-1209.73,501.658,3.95796,300,0,0,2614,0,0,0,0,0,'npc_ipp_we',0),
@@ -86,7 +86,7 @@ INSERT INTO `creature_questender` (`id`, `quest`) VALUES (15700, 8792), (15701, 
 
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+51 AND @CGUID+58;
 DELETE FROM `creature` WHERE `guid` = 86424; -- placed by AC - copy of 15707
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 (@CGUID+51,15702,1,0,0,1,1,0,-1209.58, 100.22, 134.661, 3.15905,300,0,0,15260,0,0,0,0,0,'',0),
 (@CGUID+52,15703,0,0,0,1,1,0,1572.58, 272.707, -43.0193, 5.02655,300,0,0,15260,0,0,0,0,0,'',0),
 (@CGUID+53,15704,1,0,0,1,1,0,1653.07, -4403.81, 18.5819, 4.45059,300,0,0,15260,0,0,0,0,0,'',0),
@@ -98,7 +98,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 -- War Effort Commanders
 DELETE FROM `creature` WHERE `guid` IN (@CGUID+59, @CGUID+60);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 (@CGUID+59,15701,0,0,0,1,1,1,-4961.68,-1243.19,501.672,2.46488,300,0,1,30520,0,2,0,134254592,0,'',0),
 (@CGUID+60,15700,1,0,0,1,1,1,1581.39,-4202.27,41.8233,4.96133,300,0,1,30520,0,2,0,134217728,0,'',0);
 

--- a/data/sql/world/base/av_creatures.sql
+++ b/data/sql/world/base/av_creatures.sql
@@ -2,8 +2,8 @@ SET @CGUID    := 657000;
 
 /* VANILLA */
 
-DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 1 AND `id` IN (10986, 10991, 11675, 11678, 11837, 11838, 11839, 11840, 13959);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 1 AND `id1` IN (10986, 10991, 11675, 11678, 11837, 11838, 11839, 11840, 13959);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 -- Snowblind Harpy
 (@CGUID+1, 10986, 30, 0, 0, 1, 1, 0, 103.903, 83.4279, 3.3603, 5.97373, 120, 2, 0, 3189, 0, 1, 0, 0, 0, '', NULL, 0, NULL),
@@ -81,8 +81,8 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 /* TBC */
 
-DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 2 AND `id` IN (10986, 10991, 11675, 11678, 11837, 11838, 11839, 11840, 13959);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 2 AND `id1` IN (10986, 10991, 11675, 11678, 11837, 11838, 11839, 11840, 13959);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 -- Snowblind Harpy
 (@CGUID+64, 10986, 30, 0, 0, 2, 1, 0, 103.903, 83.4279, 3.3603, 5.97373, 300, 2, 0, 4331, 0, 1, 0, 0, 0, '', NULL, 0, NULL),
@@ -173,8 +173,8 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 /* WOTLK */
 
-DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 4 AND `id` IN (10986, 10991, 11675, 11678, 11837, 11838, 11839, 11840, 13959);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 4 AND `id1` IN (10986, 10991, 11675, 11678, 11837, 11838, 11839, 11840, 13959);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 -- Snowblind Harpy
 (@CGUID+140, 10986, 30, 0, 0, 4, 1, 0, 103.903, 83.4279, 3.3603, 5.97373, 300, 2, 0, 7435, 0, 1, 0, 0, 0, '', NULL, 0, NULL),
@@ -267,7 +267,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 -- Alliance
 DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 1 AND `guid` BETWEEN @CGUID+301 AND @CGUID+399;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+301, 13318, 30, 0, 0, 1, 1, 1, 652.073, -117.387, 49.7097, 0.974652, 432000, 0, 1, 31440, 0, 2, 0, 0, 0, '', NULL, 0, NULL),   -- Commander Mortimer
@@ -335,8 +335,8 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 -- Horde
 DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 1 AND `guid` BETWEEN @CGUID+401 AND @CGUID+499;
-DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` IN (2, 4) AND `id` = 13448;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` IN (2, 4) AND `id1` = 13448;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+401, 13152, 30, 0, 0, 1, 1, 1, -1090.32, -349.623, 54.6447, 0.0349066, 432000, 0, 0, 31440, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- Commander Malgor
@@ -390,7 +390,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 -- Winterax Hold
 DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 1 AND `guid` BETWEEN @CGUID+501 AND @CGUID+599;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+501, 12159, 30, 0, 0, 1, 1, 0, -256.68, -301.7, 6.7, 3.44473, 7200, 0, 0, 113295, 0, 0, 0, 0, 0, '', NULL, 0, NULL),           -- Korrak the Bloodrager (spawns after 2 hours)
@@ -407,7 +407,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 -- Guards, Archers, Patrols (alliance)
 DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 1 AND `guid` BETWEEN @CGUID+601 AND @CGUID+699;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+601, 113358, 30, 0, 0, 1, 1, 1, 569.395, -101.064, 52.8296, 2.34974, 120, 0, 0, 4442, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- Stormpike Bowman
@@ -498,7 +498,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 -- Guards, Archers, Patrols (horde)
 DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 1 AND `guid` BETWEEN @CGUID+701 AND @CGUID+799;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+701, 113359, 30, 0, 0, 1, 1, 1, -573.522, -271.854, 75.0078, 3.9619, 120, 0, 0, 4442, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- Frostwolf Bowman
@@ -599,7 +599,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 -- Archers, TBC
 DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 2 AND `guid` BETWEEN @CGUID+801 AND @CGUID+836;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+801, 113358, 30, 0, 0, 2, 1, 1, 569.395, -101.064, 52.8296, 2.34974, 120, 0, 0, 7230, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- TBC Stormpike Bowman
@@ -638,7 +638,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 -- Archers, WOTLK
 DELETE FROM `creature` WHERE `map` = 30 AND `spawnMask` = 4 AND `guid` BETWEEN @CGUID+841 AND @CGUID+876;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+841, 113358, 30, 0, 0, 4, 1, 1, 569.395, -101.064, 52.8296, 2.34974, 120, 0, 0, 7230, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- WOTLK Stormpike Bowman
@@ -680,7 +680,7 @@ SET @CGUID    := 674000;
 
 /* Irondeep Mine - Vanilla */
 DELETE FROM `creature` WHERE `spawnMask` = 1 AND `guid` BETWEEN @CGUID+1 AND @CGUID+300;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+1, 110987, 30, 0, 0, 1, 1, 1, 821.531, -334.511, 65.6551, 4.85141, 300, 0, 0, 1227, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- Irondeep Trogg
@@ -934,7 +934,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 /* Irondeep Mine - TBC */
 DELETE FROM `creature` WHERE `spawnMask` = 2 AND `guid` BETWEEN @CGUID+301 AND @CGUID+600;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+301, 110987, 30, 0, 0, 2, 1, 1, 821.531, -334.511, 65.6551, 4.85141, 300, 0, 0, 1227, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- Irondeep Trogg
@@ -1188,7 +1188,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 /* Irondeep Mine - WotLK */
 DELETE FROM `creature` WHERE `spawnMask` = 4 AND `guid` BETWEEN @CGUID+601 AND @CGUID+900;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+601, 110987, 30, 0, 0, 4, 1, 1, 821.531, -334.511, 65.6551, 4.85141, 300, 0, 0, 1227, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- Irondeep Trogg
@@ -1442,7 +1442,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 /* Coldtooth Mine - Vanilla */
 DELETE FROM `creature` WHERE `spawnMask` = 1 AND `guid` BETWEEN @CGUID+1001 AND @CGUID+1300;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+1001, 110982, 30, 0, 0, 1, 1, 1, -865.249, -131.622, 62.6325, 2.90284, 300, 0, 0, 1227, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- Whitewhisker Vermin
@@ -1713,7 +1713,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 /* Coldtooth Mine - TBC */
 DELETE FROM `creature` WHERE `spawnMask` = 2 AND `guid` BETWEEN @CGUID+1301 AND @CGUID+1600;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+1301, 110982, 30, 0, 0, 2, 1, 1, -865.249, -131.622, 62.6325, 2.90284, 300, 0, 0, 1227, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- Whitewhisker Vermin
@@ -1984,7 +1984,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 /* Coldtooth Mine - WotLK */
 DELETE FROM `creature` WHERE `spawnMask` = 4 AND `guid` BETWEEN @CGUID+1601 AND @CGUID+1900;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+1601, 110982, 30, 0, 0, 4, 1, 1, -865.249, -131.622, 62.6325, 2.90284, 300, 0, 0, 1227, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- Whitewhisker Vermin

--- a/data/sql/world/base/boss_lord_kazzak.sql
+++ b/data/sql/world/base/boss_lord_kazzak.sql
@@ -20,8 +20,8 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 (12397, 7, 0, 'The universe will be remade.', 14, 0, 0, 0, 0, 11339, 20083, 0, 'kazzak SAY_WIPE'),
 (12397, 8, 0, 'Kazzak is supreme!', 16, 0, 0, 0, 0, 0, 0, 0, 'kazzak SAY_SUPREME_VANILA');
 
-DELETE FROM `creature` WHERE `guid` = 156950 AND `id` = 12397;
-INSERT INTO `creature` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `spawntimesecs`, `MovementType`) VALUES
+DELETE FROM `creature` WHERE `guid` = 156950 AND `id1` = 12397;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `spawntimesecs`, `MovementType`) VALUES
 (156950, 12397, 0, -12226.8, -2433.57, 1.76505, 5.01826, 259200, 604800, 1);
    
 DELETE FROM `creature_template_model` WHERE `CreatureID` = 12397;

--- a/data/sql/world/base/dungeon_blackfathom_deeps.sql
+++ b/data/sql/world/base/dungeon_blackfathom_deeps.sql
@@ -88,8 +88,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 
 -- Lorgus Jett spawn locations
-DELETE FROM `creature` WHERE `id` IN (12902);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (12902);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (26173, 12902, 48, 0, 0, 1, 1, 1, -622.355, -10.3501, -22.777, 4.90438, 86400, 0, 0, 1713, 1236, 0, 0, 0, 0, '', 0, 0, NULL),
 (695095, 12902, 48, 0, 0, 1, 1, 1, -455.93, -39.96, -32.5239, 2.5, 86400, 0, 0, 1713, 1236, 0, 0, 0, 0, '', 0, 0, NULL),

--- a/data/sql/world/base/dungeon_blackrock_depths.sql
+++ b/data/sql/world/base/dungeon_blackrock_depths.sql
@@ -321,7 +321,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (-608891, 0, 7, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 911070, 0, 0, 0, 0, 0, 10, 91107, 0, 0, 0, 0, 0, 0, 0,  'BRD Bridge Trigger - On Near Player - Start Waypoints Anvilrage Guardsman 91107');
 
 DELETE FROM `creature` WHERE `guid` IN (90728, 91106, 91107, 608891);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (90728,  8911, 230, 0, 0, 1, 1, 0, 754.091, -73.9451, -46.2159, 0.84735, 7200, 0, 1, 7599, 0, 2, 0, 0, 0, '', 0, 0, NULL),
@@ -360,8 +360,8 @@ INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entr
 --
 (108982, 0, 0, 0, 0, 0, 'Ironhand Guardian', NULL, NULL, 0, 60, 60, 0, 15, 0, 1, 1.14286, 1, 1, 20, 1, 0, 0.1, 2000, 2000, 1, 1, 1, 70, 2048, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'SmartAI', 0, 1, 3, 2, 1, 1, 0, 0, 1, 0, 2, '', 0);
 
-DELETE FROM `creature` WHERE `id` IN (8982, 108982);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (8982, 108982);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (47323, 108982, 230, 0, 0, 1, 1, 0, 1407.29, -587.299, -91.9711, 3.15905, 7200, 0, 0, 126, 0, 0, 0, 0, 0, '', 0, 0, NULL),
@@ -437,7 +437,7 @@ DELETE FROM `creature` WHERE `guid` IN (
 47799, 47800, 47801, 47802, 47803,
 90658, 90659, 90660, 90661, 90662);
 
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (45857, 8895, 230, 0, 0, 1, 1, 1, 734.342, -115.562, -71.8692, 2.29181, 7200, 0, 1, 5502, 3728, 2, 0, 0, 0, '', 0, 0, NULL), -- Anvilrage Officer
@@ -582,7 +582,7 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 
 -- fix officer packs that are misplaced and have wrong movement
 DELETE FROM `creature` WHERE guid IN (90653, 90654, 90655, 90656, 90657, 90680, 90681, 90682, 90683, 90684, 90839, 90840, 90841, 90842, 90843);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (90653, 8895, 230, 0, 0, 1, 1, 1, 678.689, -121.644, -72.0716, 1.21643, 7200, 0, 0, 5502, 3728, 0, 0, 0, 0, '', 0, 0, NULL),
@@ -607,7 +607,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 DELETE FROM `creature` WHERE `guid` IN (
 45896, 45897, 45898, 45915, 45916, 45917, 45924, 45925, 45926, 47825, 47826, 47827, 47830, 47831, 47832, 
 90686, 90687, 90688, 90855, 90856, 90857, 90866, 90867, 90868, 90918, 90917, 90916, 91084, 91085, 91086);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (45896, 8921, 230, 0, 0, 1, 1, 0, 511.225, -178.22, -60.0722, 1.86715, 7200, 0, 0, 2672, 0, 0, 0, 0, 0, '', 0, 0, NULL),

--- a/data/sql/world/base/dungeon_blackrock_spire.sql
+++ b/data/sql/world/base/dungeon_blackrock_spire.sql
@@ -254,7 +254,7 @@ DELETE FROM `creature` WHERE `guid` IN
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+14 AND @CGUID+19;
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+31 AND @CGUID+36;
 
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (43560, 9241, 229, 0, 0, 1, 1, 1, -73.1897, -517.357, -7.14292, 0.00402808, 10800, 0, 0, 8097, 0, 0, 0, 0, 0, '', 0, 0, NULL),
 (43764, 9259, 229, 0, 0, 1, 1, 1, -61.9859, -406.51, -18.9337, 5.27176, 10800, 0, 0, 8097, 0, 0, 0, 0, 0, '', 0, 0, NULL),
@@ -381,8 +381,8 @@ DELETE FROM `waypoint_data` WHERE `id` = 926800;
 
 -- Bannok Grimaxe (9596), spawn locations
 DELETE FROM `creature` WHERE `guid` IN (44020, 44318); -- creatures placed in Bannok Grimaxe's spawn locations by AC
-DELETE FROM `creature` WHERE `id` IN (9596);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` IN (9596);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (@CGUID+11, 9596, 229, 0, 0, 1, 1, 1, -26.6918, -428.557, -18.935, 2.25881, 10800, 0, 0, 8883, 0, 0, 0, 0, 0, '', 0, 0, NULL),
 (@CGUID+12, 9596, 229, 0, 0, 1, 1, 1, -74.0576, -406.988, -18.935, 5.22526, 10800, 0, 0, 8883, 0, 0, 0, 0, 0, '', 0, 0, NULL),
@@ -446,7 +446,7 @@ INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES
 
 -- fix missing patrols
 DELETE FROM `creature` WHERE `guid` IN (@CGUID+1, @CGUID+2, @CGUID+3, @CGUID+4, @CGUID+5, @CGUID+6, @CGUID+7, @CGUID+8,  @CGUID+9, @CGUID+21, @CGUID+22);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (@CGUID+1, 9583, 229, 0, 0, 1, 1, 1, -138.983, -369.133, 58.079,  0, 10800, 0, 1, 8883, 0, 2, 0, 0, 0, '', 0, 0, NULL), -- Bloodaxe Veteran

--- a/data/sql/world/base/dungeon_deadmines.sql
+++ b/data/sql/world/base/dungeon_deadmines.sql
@@ -99,7 +99,7 @@ SET @IPPPHASE_III := 262144;
 
 DELETE FROM `creature` WHERE guid IN 
 (79139, 79144, 79151, 79152, 79170, 79171, 79177, 79188, 79189, 79207, 79229, 79230, 79233, 79244, 79245, 79273, 79277, 79280, 79281, 79283, 79284, 79285, 79373, 79374, 79376, 79377);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (79244, 634,  36, 0, 0, 1, @IPPPHASE, 1, -90.571, -400.149, 58.4755, 3.20291, 86400, 0, 1, 1158, 0,   2, 0, 0, 0, '', 0, 0, NULL),

--- a/data/sql/world/base/dungeon_dire_maul.sql
+++ b/data/sql/world/base/dungeon_dire_maul.sql
@@ -219,7 +219,7 @@ DELETE FROM `creature` WHERE `guid` IN
 (248093, 248094, 248095, 248096, 248097, 248098, 248099, 248100, 248101, 248106, 248107, 248108, 248131, 248132, 
 248135, 248136, 248137, 248138, 248145, 248146, 248147, 248155, 248163, 248164, 248171, 248176, 248179, 248180, 248186); -- 248155, 248186, 248101 (not used anymore)
 
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (248093, 13036, 429, 0, 0, 1, 1, 0, 346.936, -43.3005, -25.6162, 1.12652,  7200, 3, 0, 3758, 0, 1, 0, 0, 0, '', 0, 0, NULL),
@@ -462,12 +462,12 @@ UPDATE `creature_template` SET `lootid` = 0 WHERE `entry` = 14370;
 UPDATE `creature_template_model` SET `DisplayScale` = 0.25  WHERE `CreatureID` = 14370;
 
 -- fix waypoints
-DELETE FROM `creature` WHERE `id` IN (11459, 11484, 11488, 14308);
+DELETE FROM `creature` WHERE `id1` IN (11459, 11484, 11488, 14308);
 DELETE FROM `creature` WHERE `guid` IN (247932, 247933); -- unused Eldreth Phantasm guids
 DELETE FROM `creature` WHERE `guid` IN (247915, 247925);
 DELETE FROM `creature` WHERE `guid` IN (@CGUID+21, @CGUID+22, @CGUID+23, @CGUID+24, @CGUID+25, @CGUID+26);
 
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (247820, 11459, 429, 0, 0, 1, 1, 0, -92.0732, 344.012, -4.98579, 4.65212,     7200, 0, 1, 16704, 0, 2, 0, 0, 0, '', 0, 0, NULL), -- Ironbark Protector

--- a/data/sql/world/base/dungeon_maraudon.sql
+++ b/data/sql/world/base/dungeon_maraudon.sql
@@ -118,9 +118,9 @@ DELETE FROM `creature_addon` WHERE `guid` IN
 SET @CGUID  := 652000;
 SET @WPID   := 6520000;
 
-DELETE FROM `creature` WHERE `id` = 12242;
+DELETE FROM `creature` WHERE `id1` = 12242;
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+1 AND @CGUID+32;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (54684, 12242, 349, 0, 0, 1, 1, 1, 790.473, -500.472, -53.0402, 0.600063, 86400, 0, 1, 5346, 0, 2, 0, 0, 0, '', 0, 0, NULL), -- Spirit of Maraudos <The Fourth Khan>
@@ -437,8 +437,8 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 (@WPID+310, 30, 128.322, -274.962, -108.678, 5.98555, 0, 0, 0, 100, 0);
 
 -- The Nameless Prophet, should have multiple spawn locations and almost instant respawn - https://www.youtube.com/watch?v=NzIngiFj1lQ
-DELETE FROM `creature` WHERE `id` = 13718;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` = 13718;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (@CGUID+41, 13718, 1, 0, 0, 1, 1, 0, -1417.84, 2969.18, 124.195, 1.51197, 5, 0, 0, 3804, 1332, 0, 0, 0, 0, '', NULL, 0, NULL),
 (@CGUID+42, 13718, 1, 0, 0, 1, 1, 0, -1472.66, 2964.98, 122.436, 4.91161, 5, 0, 0, 3804, 1332, 0, 0, 0, 0, '', NULL, 0, NULL),

--- a/data/sql/world/base/dungeon_onyxia.sql
+++ b/data/sql/world/base/dungeon_onyxia.sql
@@ -582,7 +582,7 @@ REPLACE INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, 
 (302680, 3475, 0, 0.0, 0, 1, 1, 1);
 
 DELETE FROM `creature` WHERE `guid` BETWEEN 311000 AND 311006;
-INSERT INTO `creature` (`guid`, `id`, `map`, `spawnMask`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `MovementType`) VALUES
+INSERT INTO `creature` (`guid`, `id1`, `map`, `spawnMask`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `MovementType`) VALUES
 (311000, 301000, 249, 4, 0.69628, -211.972, -86.075, 3.19974, 604800, 0.0, 0),
 (311001, 301002, 249, 4, -166.623, -196.003, -66.2619, 5.06806, 6300, 0.0, 2),
 (311002, 301002, 249, 4, -52.9699, -96.8813, -38.6419, 5.66711, 6300, 0.0, 2),
@@ -649,7 +649,7 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 (301000, 4, 0, "%s takes in a deep breath...", 41, 0, 100.0, 0, 0, 0, 36542, 0, "Onyxia - Deep Breath Emote (Onyxia 40)"),
 (301000, 5, 0, "You seek to lure me from my clutch? You shall pay for your insolence!", 14, 0, 100.0, 0, 0, 0, 8570, 0, "Onyxia - Boundary Evade (Onyxia 40)");
 
-UPDATE `creature` SET `equipment_id` = 1 WHERE `id` = 301002;
+UPDATE `creature` SET `equipment_id` = 1 WHERE `id1` = 301002;
 DELETE FROM `creature_equip_template` WHERE `CreatureID` = 301002;
 INSERT INTO `creature_equip_template` (`CreatureID`, `ID`, `ItemID1`, `ItemID2`, `ItemID3`) VALUES
 (301002, 1, 13631, 0, 0);

--- a/data/sql/world/base/dungeon_scarlet_monastery.sql
+++ b/data/sql/world/base/dungeon_scarlet_monastery.sql
@@ -192,7 +192,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 DELETE FROM `creature` WHERE `guid` IN (40068, 40070);
 DELETE FROM `creature` WHERE `guid` BETWEEN 695001 AND 695007;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (40068, 4288, 189, 0, 0, 1, 1, 1, 201.223, -232.896, 18.5307, 3.14066, 86400, 0, 1, 3489, 0, 2, 0, 0, 0, '', 0, 0, NULL), -- Scarlet Beastmaster

--- a/data/sql/world/base/dungeon_stratholme.sql
+++ b/data/sql/world/base/dungeon_stratholme.sql
@@ -289,8 +289,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (-54069, 0, 8, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 2472270, 0, 0, 0, 0, 0, 10, 247227, 10808, 0, 0, 0, 0, 0, 0,     'Crimson Guardsman - On Death - Start Waypoints: Timmy the Cruel');
 
 -- fix spawn locations
-UPDATE `creature` SET `position_x` = 3719.82, `position_y` = -3426.25, `position_z` = 131.844, `orientation` = 3.3412 WHERE `id` = 10516;
-UPDATE `creature` SET `position_x` = 3614.7, `position_y` = -3187.64, `position_z` = 131.406, `MovementType` = 0 WHERE `id` = 10808;
+UPDATE `creature` SET `position_x` = 3719.82, `position_y` = -3426.25, `position_z` = 131.844, `orientation` = 3.3412 WHERE `id1` = 10516;
+UPDATE `creature` SET `position_x` = 3614.7, `position_y` = -3187.64, `position_z` = 131.406, `MovementType` = 0 WHERE `id1` = 10808;
 UPDATE `creature_template` SET `MovementType` = 0 WHERE `entry` = 10808; -- not 2, else waypoints will start on spawn
 
 -- fix waypoints Timmy the Cruel
@@ -334,8 +334,8 @@ SET @WPID     := 3290000; -- waypoint ID
 
 DELETE FROM `creature_addon` WHERE `guid` = 53854; -- remove old data, we creating new creatures
 
-DELETE FROM `creature` WHERE `id` IN (10408, 10409, 10809);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (10408, 10409, 10809);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (52147,    10809, 329, 0, 0, 1, 1, 0, 4058.86, -3530.33, 122.247, 0, 86400, 0, 1, 15260, 0, 2, 0, 0, 0, '', 0, 0, NULL), -- Stonespine

--- a/data/sql/world/base/dungeon_wailing_caverns.sql
+++ b/data/sql/world/base/dungeon_wailing_caverns.sql
@@ -85,11 +85,11 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 
 -- fix Respawn and Movement
-UPDATE `creature` SET `spawntimesecs` = 172800, `MovementType` = 1, `wander_distance` = 2 WHERE `id` = 3652; -- Trigore the Lasher
-UPDATE `creature` SET `spawntimesecs` = 54000,  `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 3672; -- Boahn
+UPDATE `creature` SET `spawntimesecs` = 172800, `MovementType` = 1, `wander_distance` = 2 WHERE `id1` = 3652; -- Trigore the Lasher
+UPDATE `creature` SET `spawntimesecs` = 54000,  `MovementType` = 1, `wander_distance` = 5 WHERE `id1` = 3672; -- Boahn
 
-DELETE FROM `creature` WHERE `id` IN (3655, 3671);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` IN (3655, 3671);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (14055,  3655, 1, 0, 0, 1, 1, 1, -658.948, -2006.91, 61.816, 3.46793,     275, 0, 0, 386, 0, 0, 0, 0, 0, '', 0, 0, NULL),   -- Mad Magglish

--- a/data/sql/world/base/dungeon_zulfarrak.sql
+++ b/data/sql/world/base/dungeon_zulfarrak.sql
@@ -82,7 +82,7 @@ SET @WPID   := 6520000;
 
 -- fix patrols
 DELETE FROM `creature` WHERE `guid` IN (45710, 81482, 81505, 81530, 81531, 81532, 81581, 81582, 81583, 81587, 81588, 81601, @CGUID+101, @CGUID+102, @CGUID+103);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (45710, 5650, 209, 0, 0, 1, 1, 1, 1658.52, 805.539, 9.29566, 1.36264, 18000, 0, 1, 4278, 2966, 2, 0, 0, 0, '', 0, 0, NULL),

--- a/data/sql/world/base/ipp_aware_npcs.sql
+++ b/data/sql/world/base/ipp_aware_npcs.sql
@@ -13,11 +13,11 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN
 (19915, 19909, 19911, 26012, 26007, 26075, 26307, 26309, 26760, 19912, 19859, 19860, 19861, 20499, 20497, 30610, 30611, 32832);
 
 -- Stormwind
-UPDATE `creature` SET `phaseMask` = @IPPPHASE_II  WHERE `id` = 1749;  -- Lady Katrana Prestor
-UPDATE `creature` SET `phaseMask` = @IPPPHASE_III WHERE `id` = 29611; -- King Varian Wrynn
+UPDATE `creature` SET `phaseMask` = @IPPPHASE_II  WHERE `id1` = 1749;  -- Lady Katrana Prestor
+UPDATE `creature` SET `phaseMask` = @IPPPHASE_III WHERE `id1` = 29611; -- King Varian Wrynn
 
 -- Orgrimmar
-UPDATE `creature` SET `phaseMask` = @IPPPHASE_III WHERE `id` = 29346; -- Apothecary Karlov
+UPDATE `creature` SET `phaseMask` = @IPPPHASE_III WHERE `id1` = 29346; -- Apothecary Karlov
 
 -- Phasing NPCs related to AllowEarlyDungeonSet2
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_ds2' WHERE `entry` IN (15270, 15282, 16012, 16013);
@@ -29,15 +29,15 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_preaq' WHERE `entry` IN
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_aqwewar' WHERE `entry` IN (15693); -- Jonathan the Revelator
 
 -- Phasing Cenarion Hold guards
-UPDATE `creature` SET `ScriptName` = 'npc_ipp_preaq' WHERE `id` = 15184 AND `guid` IN (42782, 42783, 42768);
+UPDATE `creature` SET `ScriptName` = 'npc_ipp_preaq' WHERE `id1` = 15184 AND `guid` IN (42782, 42783, 42768);
 
 -- Phasing ZG quest NPCs on YoJamba Isle and in Tanaris
-UPDATE `creature` SET `ScriptName` = 'npc_ipp_zg' WHERE `id` IN (10460, 14902, 14903, 14904, 14905, 14910, 15070);
+UPDATE `creature` SET `ScriptName` = 'npc_ipp_zg' WHERE `id1` IN (10460, 14902, 14903, 14904, 14905, 14910, 15070);
 
 -- Phasing NPCs until after the outdoors AQ war has been completed
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_aq' WHERE `entry` IN  (15498, 15499, 15500, 15540, 16091);                -- Cenarion Hold
 
-UPDATE `creature` SET `phaseMask` = @IPPPHASE_II WHERE `id` IN (15612, 15613, 15615, 15616, 15617, 17070, 17079, 17766,         -- Orgrimmar Legion Post
+UPDATE `creature` SET `phaseMask` = @IPPPHASE_II WHERE `id1` IN (15612, 15613, 15615, 15616, 15617, 17070, 17079, 17766,         -- Orgrimmar Legion Post
                                                                  15440, 15441, 15442, 15443, 15444, 15903, 17068, 17080, 17765); -- Ironforge Brigade post
 -- Phasing Wanted Poster Deathclasp
 UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_preaq' WHERE `entry` IN (180448);
@@ -81,9 +81,9 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc_t3' WHERE `entry` IN 
 
 -- TBC, phasing Shattered Sun offensive NPCs in Shattrath
 UPDATE `creature_template` SET `ScriptName` = '' WHERE `entry` IN (15599, 18594, 19227, 25167, 27666); -- 00_cleanup, undo previous method of phasing
-UPDATE `creature` SET `phaseMask` = 1 WHERE `id` IN (24938, 25115, 27667); -- 00_cleanup
+UPDATE `creature` SET `phaseMask` = 1 WHERE `id1` IN (24938, 25115, 27667); -- 00_cleanup
 
-UPDATE `creature` SET `phaseMask` = @IPPPHASE     WHERE `id`  IN (17076, 19475, 24932, 25134, 25135, 25136, 25137, 25138, 25141, 25142, 25143, 25153, 25155, 25167, 25885, 27666);
+UPDATE `creature` SET `phaseMask` = @IPPPHASE     WHERE `id1`  IN (17076, 19475, 24932, 25134, 25135, 25136, 25137, 25138, 25141, 25142, 25143, 25153, 25155, 25167, 25885, 27666);
 UPDATE `creature` SET `phaseMask` = @IPPPHASE_III WHERE `guid` IN (165102, 165103, 165104, 165105, 165106, 165107, 165108, 165109);
 
 -- Silvermoon City, M'uru
@@ -126,12 +126,12 @@ UPDATE `gameobject` SET `ScriptName` = 'gobject_ioq_P4' WHERE `guid` IN (27827, 
 UPDATE `gameobject` SET `ScriptName` = 'gobject_ioq_before_P3' WHERE `guid` IN (5300500, 5300501, 5300502, 5300503, 5300504);
 
 -- Dragons of Nightmare
-UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `id` IN (14887, 14888, 14889, 14890);
+UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `id1` IN (14887, 14888, 14889, 14890);
 
 -- Vault of Archavon
-UPDATE `creature` SET `phaseMask` = @IPPPHASE     WHERE `id` = 33993; -- Emalon the Storm Watcher
-UPDATE `creature` SET `phaseMask` = @IPPPHASE_II  WHERE `id` = 35013; -- Koralon the Flame Watcher
-UPDATE `creature` SET `phaseMask` = @IPPPHASE_III WHERE `id` = 38433; -- Toravon the Ice Watcher
+UPDATE `creature` SET `phaseMask` = @IPPPHASE     WHERE `id1` = 33993; -- Emalon the Storm Watcher
+UPDATE `creature` SET `phaseMask` = @IPPPHASE_II  WHERE `id1` = 35013; -- Koralon the Flame Watcher
+UPDATE `creature` SET `phaseMask` = @IPPPHASE_III WHERE `id1` = 38433; -- Toravon the Ice Watcher
 
 -- Argent Tournament
 UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `guid` IN (25, 63129, 63236, 63370, 63371, 65274, 65275, 65283, 65284, 65285, 65325, 65327, 65350, 65351, 65371, 65451,

--- a/data/sql/world/base/naxx40.sql
+++ b/data/sql/world/base/naxx40.sql
@@ -24,8 +24,8 @@ INSERT INTO `areatrigger_scripts` (`entry`, `ScriptName`) VALUES
 (5194, 'naxx_northrend_entrance');
 
 UPDATE `creature` SET `spawnMask` = 3 WHERE `spawnMask` = 7 AND `map` = 533;   -- Update spawnMask of all creatures to 10man + 25man
-UPDATE `creature` SET `spawnMask` = `spawnMask`| 4 WHERE `id` = 16980;        -- Lich King uses same entry in Naxx WotLK and Naxx40 - Allow spawning in all versions
-UPDATE `creature` SET `spawnMask` = `spawnMask`| 4 WHERE `id` = 16082;        -- Naxxramas Trigger (frogger) should also spawn in Naxx40
+UPDATE `creature` SET `spawnMask` = `spawnMask`| 4 WHERE `id1` = 16980;        -- Lich King uses same entry in Naxx WotLK and Naxx40 - Allow spawning in all versions
+UPDATE `creature` SET `spawnMask` = `spawnMask`| 4 WHERE `id1` = 16082;        -- Naxxramas Trigger (frogger) should also spawn in Naxx40
 
 UPDATE `gameobject` SET `spawnMask` = 7 WHERE `spawnMask` = 3 AND `map` = 533; -- Update spawnMask of all gameobjects to all
 UPDATE `gameobject` SET `spawnMask` = 3 WHERE `id` IN (202278, 202277);        -- Orb of Naxxramas does not exist in classic

--- a/data/sql/world/base/naxx40_creatures.sql
+++ b/data/sql/world/base/naxx40_creatures.sql
@@ -2462,7 +2462,7 @@ INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `
 (304800, 23219, 0, 0.0, 0, 1, 1, 1);
 
 DELETE FROM `creature` WHERE `guid` BETWEEN @GUID AND @GUID+1065;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (@GUID+0,  @CENTRY+68, 533, 0, 0, 4, 1, 0, 2689.72, -3579.8, 261.325, 1.16002, 30, 5, 0, 1, 0, 1, 0, 0, 0, '', NULL, 0, NULL),
@@ -5362,7 +5362,7 @@ INSERT INTO `creature_equip_template` (`CreatureID`, `ID`, `ItemID1`, `ItemID2`,
 (@CENTRY+86, 1, 4991, 0, 0),
 (@CENTRY+87, 1, 12285, 0, 0);
 
-UPDATE `creature` SET `equipment_id` = 1 WHERE `id` IN (@CENTRY+5,@CENTRY+7,@CENTRY+36,@CENTRY+37,@CENTRY+38,@CENTRY+39,@CENTRY+40,@CENTRY+44,@CENTRY+45,@CENTRY+48,@CENTRY+49,@CENTRY+50,
+UPDATE `creature` SET `equipment_id` = 1 WHERE `id1` IN (@CENTRY+5,@CENTRY+7,@CENTRY+36,@CENTRY+37,@CENTRY+38,@CENTRY+39,@CENTRY+40,@CENTRY+44,@CENTRY+45,@CENTRY+48,@CENTRY+49,@CENTRY+50,
 @CENTRY+52,@CENTRY+53,@CENTRY+54,16157,16158,@CENTRY+55,@CENTRY+57,@CENTRY+60,@CENTRY+61,@CENTRY+62,@CENTRY+63,@CENTRY+70,16451,16452,@CENTRY+80,@CENTRY+84,16861,@CENTRY+85,@CENTRY+86,@CENTRY+87);
 
 DELETE FROM `creature_addon` WHERE `guid` BETWEEN @GUID AND @GUID+1063;
@@ -5802,7 +5802,7 @@ INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entr
 (@CENTRY+97, 0, 0, 0, 0, 0, 'Naxx40 Strath Entrance Trigger', '', NULL, 0, 70, 70, 1, 35, 0, 1, 1.14286, 1, 1, 20, 0, 0, 1, 2000, 2000, 1, 1, 1, 33554432, 2048, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 'npc_naxx40_area_trigger', 0);
 
 DELETE FROM `creature` WHERE `guid` = 352042;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 (352042, @CENTRY+97, 329, 0, 0, 1, 1, 0, 3929.06, -3372.12, 119.653, 4.71395, 300, 0, 0, 6986, 0, 0, 0, 0, 0, '', 0);
 
 -- Razuvious
@@ -5819,8 +5819,8 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 -- Gothik Visuals
 -- re-do spawn locations for triggers
 SET @CGUID := @GUID + 1100;
-DELETE FROM `creature` WHERE `id`= @CENTRY+47 AND `guid` BETWEEN @CGUID AND @CGUID+14;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1`= @CENTRY+47 AND `guid` BETWEEN @CGUID AND @CGUID+14;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (@CGUID+0,  @CENTRY+47, 533, 3456, 3456, 4, 1, 0, 2643.73095703125,  -3399.680908203125, 284.18292236328125,  6.091198921203613281, 7200, 0, 0, 17010, 0, 0, 0, 0, 0, '', 46248, 0, 'living side soul trigger (south) - Naxx40'),
 (@CGUID+1,  @CENTRY+47, 533, 3456, 3456, 4, 1, 0, 2739.994873046875, -3399.779296875,    284.294647216796875, 6.108652114868164062, 7200, 0, 0, 17010, 0, 0, 0, 0, 0, '', 46248, 0, 'living side soul trigger (north) - Naxx40'),
@@ -5868,7 +5868,7 @@ SET
     `HealthModifier` = `HealthModifier` * @HEALTH_MULTIPLIER,
     `ArmorModifier`  = `ArmorModifier`  * @ARMOR_MULTIPLIER
 WHERE `entry` IN (
-    SELECT `id`
+    SELECT `id1`
     FROM `creature`
     WHERE `map` = 533 AND `spawnMask` = 4
 );

--- a/data/sql/world/base/professions.sql
+++ b/data/sql/world/base/professions.sql
@@ -112,11 +112,11 @@ UPDATE `creature_template` SET `subname` = 'Journeyman Tailor'        WHERE `ent
 UPDATE `creature_template` SET `subname` = 'Expert Tailor'            WHERE `entry` IN (16640, 16729);
 
 -- Delete added riding trainers
-DELETE FROM creature WHERE `id` IN (35093, 35100);
+DELETE FROM creature WHERE `id1` IN (35093, 35100);
 DELETE FROM creature_addon WHERE `guid` IN (88165, 88166);
 
 -- Optional - delete TBC trainers added in WotLK 3.1
-DELETE FROM creature WHERE `id` IN 
+DELETE FROM creature WHERE `id1` IN 
 (33608, 33609, 33610, 33611, 33612, 33613, 33614, 33615, 33616, 33617, 33618, 33619, 
 33621, 33623, 33630, 33631, 33633, 33634, 33635, 33636, 33637, 33639, 33640, 33641, 
 33674, 33675, 33676, 33677, 33678, 33680, 33681, 33682, 33683, 33684, 35099, 35101);
@@ -218,8 +218,8 @@ INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`,
 (@Brumman, 0, 18177, 1, 1, 12340),
 (@Grikka, 0, 20059, 1, 1, 12340);
 
-DELETE FROM `creature` WHERE `id` IN (@Darmari, @Barim, @Brumman, @Grikka);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
+DELETE FROM `creature` WHERE `id1` IN (@Darmari, @Barim, @Brumman, @Grikka);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (619187, @Darmari, 530, 0, 0, 1, 1, 1, -2060.92, 5256.68, -38.3819, 0.767945, 300, 0, 0, 3498, 0, 0, 0, 0, 0, '', 0, 0, NULL),
 (618754, @Barim, 530, 0, 0, 1, 1, 1, 148.588, 2636.02, 86.018, 1.27409, 300, 0, 0, 3113, 0, 0, 0, 0, 0, '', 0, 0, NULL),
 (618771, @Brumman, 530, 0, 0, 1, 1, 1, -721.657, 2745.26, 94.0548, 3.45575, 300, 0, 0, 3113, 0, 0, 0, 0, 0, '', 0, 0, NULL),

--- a/data/sql/world/base/pvp_quests.sql
+++ b/data/sql/world/base/pvp_quests.sql
@@ -74,8 +74,8 @@ INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`,
 (@HW_TBC, 0, 15387, 1, 1, 12340),
 (@ABG_TBC, 0, 27154, 1, 1, 12340);
 
-DELETE FROM `creature` WHERE `id` IN (@HW, @ABG, @HW_TBC, @ABG_TBC);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (@HW, @ABG, @HW_TBC, @ABG_TBC);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+201, @HW, 1, 0, 0, 1, 1, 1, -1381.13, -87.0034, 159.532, 3.14159, 300, 0, 0, 1, 0, 0, 0, 0, 0, '', 0, 0, NULL),

--- a/data/sql/world/base/quest_the_masquerade.sql
+++ b/data/sql/world/base/quest_the_masquerade.sql
@@ -254,8 +254,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 -- Spawn Lady Katrana Prestor
 -- Positions are hand-made. There's a huge throne where she used to be spawned in classic...
-DELETE FROM `creature` WHERE `guid` = 500800 AND `id` = 1749;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+DELETE FROM `creature` WHERE `guid` = 500800 AND `id1` = 1749;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 (500800, 1749, 0, 0, 0, 1, 1, 1, -8435, 335.559, 122.163, 2.56468, 300, 0, 3497, 2568, 0, 0, 0, 0, '', 0);
 
 # DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 30 AND `SourceEntry` = 1749;
@@ -266,8 +266,8 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 UPDATE `item_template` SET `startquest` = 4264 WHERE `entry` = 11446; -- A crumpled up note
 
 -- Spawn Bolvar
-DELETE FROM `creature` WHERE `guid` = 500801 AND `id` = 1748;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+DELETE FROM `creature` WHERE `guid` = 500801 AND `id1` = 1748;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 (500801, 1748, 0, 0, 0, 1, 1, 1, -8445.01, 329.85, 122.163, 2.12562, 300, 0, 1055700, 67740, 0, 0, 0, 0, '', 0);
 
 # DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 30 AND `SourceEntry` = 1748;

--- a/data/sql/world/base/si_creatures.sql
+++ b/data/sql/world/base/si_creatures.sql
@@ -37,7 +37,7 @@ SET @SCORN                 := 614693;
 SET @LORD_BLACKWOOD        := 614695;
 
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID AND @CGUID+1720;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 
 -- Skeletal Soldier
@@ -1534,11 +1534,11 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 (@CGUID+1720, @SKELETAL_SHOCKTROOPER, 0, 0, 0, 1, 1, 0, 1797.03, -2837.68, 71.2373, 1.05181, 300, 0, 0, 8241, 0, 0, 0, 0, 0, '', NULL, 0, NULL);
 
 
-UPDATE `creature` SET `ScriptName` = 'npc_ipp_si' WHERE `id` IN 
+UPDATE `creature` SET `ScriptName` = 'npc_ipp_si' WHERE `id1` IN 
 (@ARGENT_RECRUITER, @ARGENT_SCOUT, @ARGENT_EMISSARY, @ARGENT_MESSENGER, @ARGENT_QUARTERMASTER, @ARGENT_OUTFITTER,
  @KEEPER_OF_THE_ROLLS, @COMMANDER_THOMAS, @LIEUTENANT_ORRIN, @LIEUTENANT_NEVELL, @LIEUTENANT_LISANDE, @LIEUTENANT_DAGEL, @LIEUTENANT_RUKAG, @LIEUTENANT_BEITHA); -- 29441, 29442
 
-UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `id` IN 
+UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `id1` IN 
 (@CULTIST_ENGINEER, @GHOUL_BERSERKER, @SPECTRAL_SOLDIER, @SKELETAL_SHOCKTROOPER, @SPIRIT_OF_THE_DAMNED, @BONE_WITCH, @LUMBERING_HORROR,
  @SEVER, @BALZAPHON, @LADY_FALTHERESS, @REVANCHION, @SCORN, @LORD_BLACKWOOD); 
 
@@ -1546,11 +1546,11 @@ UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `guid` BETWEEN @CGUID+240 AN
 UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `guid` BETWEEN @CGUID+192 AND @CGUID+197; -- Mouth of Kel'Thuzad
 UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `guid` BETWEEN @CGUID     AND @CGUID+191; -- Skeletal Soldier, Spectral Apparition, Spectral Spirit, Skeletal Trooper
 
-UPDATE `creature` SET `wander_distance` = 4,  `MovementType` = 1 WHERE `id` IN (@GHOUL_BERSERKER, @SPECTRAL_SOLDIER, @SKELETAL_SHOCKTROOPER);
-UPDATE `creature` SET `wander_distance` = 20, `MovementType` = 1 WHERE `id` IN (@LUMBERING_HORROR, @SPIRIT_OF_THE_DAMNED, @BONE_WITCH);
+UPDATE `creature` SET `wander_distance` = 4,  `MovementType` = 1 WHERE `id1` IN (@GHOUL_BERSERKER, @SPECTRAL_SOLDIER, @SKELETAL_SHOCKTROOPER);
+UPDATE `creature` SET `wander_distance` = 20, `MovementType` = 1 WHERE `id1` IN (@LUMBERING_HORROR, @SPIRIT_OF_THE_DAMNED, @BONE_WITCH);
 
-UPDATE `creature` SET `spawntimesecs` = 7200 WHERE `id` IN (@NECROTIC_SHARD, @CULTIST_ENGINEER);
-UPDATE `creature` SET `spawntimesecs` = 3600 WHERE `id` IN (@LUMBERING_HORROR, @SPIRIT_OF_THE_DAMNED, @BONE_WITCH);
+UPDATE `creature` SET `spawntimesecs` = 7200 WHERE `id1` IN (@NECROTIC_SHARD, @CULTIST_ENGINEER);
+UPDATE `creature` SET `spawntimesecs` = 3600 WHERE `id1` IN (@LUMBERING_HORROR, @SPIRIT_OF_THE_DAMNED, @BONE_WITCH);
 
 -- undo AC adding IP's creatures to event 17
 DELETE FROM `game_event_creature` WHERE `eventEntry` = 17 AND `guid` BETWEEN @CGUID AND @CGUID+191;

--- a/data/sql/world/base/zone_alterac_mountains.sql
+++ b/data/sql/world/base/zone_alterac_mountains.sql
@@ -116,8 +116,8 @@ INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `e
 (63913, 639130, 0, 0, 0, 0, 0, NULL);
 
 -- Jailor Borhuin(2431) and Baron Vardus(2306) - multiple spawn locations 
-DELETE FROM `creature` WHERE `id` IN (2306, 2431);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (2306, 2431);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (16905,  2306, 0, 0, 0, 1, 1, 1, 1180.59, -555.904, 71.1468, 1.8822,  300, 0, 0, 1239, 3191, 0, 0, 0, 0, '', 0, 0, NULL),
 (695010, 2306, 0, 0, 0, 1, 1, 1, 693.333, -905.125, 157.78, 2.69564,  300, 0, 0, 1239, 3191, 0, 0, 0, 0, '', NULL, 0, NULL), -- https://www.youtube.com/watch?v=MgH-PCmxnUo

--- a/data/sql/world/base/zone_arathi_highlands.sql
+++ b/data/sql/world/base/zone_arathi_highlands.sql
@@ -143,8 +143,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (4481, 0, 3, 0, 2, 0, 100, 1, 0, 30, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Marcel Dabyrie - Between 0-30% Health - Flee For Assist (No Repeat)');
 
 -- multiple spawn locations for Prince Nazjak
-DELETE FROM `creature` WHERE `id` IN (2779);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` IN (2779);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (84713, 2779, 0, 0, 0, 1, 1, 1, -2316.75, -1582.54, -36.352, 4.89399, 115200, 5, 0, 1902, 0, 1, 0, 0, 0, '', 0, 0, NULL),
@@ -180,7 +180,7 @@ DELETE FROM `creature` WHERE `guid` = 11228; -- (11228, 2564, 0, 0, 0, 0, 0, 1, 
 DELETE FROM `creature_addon` WHERE `guid` = 11228;
 
 -- remove non elite Syndicate thief from Stromgarde
-DELETE FROM `creature` WHERE `id` = 24477;
+DELETE FROM `creature` WHERE `id1` = 24477;
 
 -- delete all guids for id 24477 from creature_addon
 DELETE FROM `creature_addon` WHERE `guid` IN 

--- a/data/sql/world/base/zone_ashenvale.sql
+++ b/data/sql/world/base/zone_ashenvale.sql
@@ -328,9 +328,9 @@ DELETE FROM `creature_text` WHERE `CreatureID` = 3816;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES 
 (3816, 0, 0, '%s charges!', 16, 0, 100, 0, 0, 0, 37643, 0, 'Wild Buck');
 
-UPDATE `creature` SET `spawntimesecs` = 75600, `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 10642; -- Eck'alom
-UPDATE `creature` SET `spawntimesecs` = 30600, `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 10643; -- Mugglefin
-UPDATE `creature` SET `spawntimesecs` = 37800, `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 12037; -- Ursul'lok
+UPDATE `creature` SET `spawntimesecs` = 75600, `MovementType` = 1, `wander_distance` = 5 WHERE `id1` = 10642; -- Eck'alom
+UPDATE `creature` SET `spawntimesecs` = 30600, `MovementType` = 1, `wander_distance` = 5 WHERE `id1` = 10643; -- Mugglefin
+UPDATE `creature` SET `spawntimesecs` = 37800, `MovementType` = 1, `wander_distance` = 5 WHERE `id1` = 12037; -- Ursul'lok
 
 -- Glowing Soul Gem(5366), fix drop rate
 UPDATE `creature_loot_template` SET `Chance` = 4 WHERE `Item` = 5366;

--- a/data/sql/world/base/zone_azshara.sql
+++ b/data/sql/world/base/zone_azshara.sql
@@ -128,7 +128,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 UPDATE `creature_loot_template` SET `Chance` = 100 WHERE `Entry` = 6109 AND `Item` = 18704;
 
 -- Antilos, fix spawn time and movement
-UPDATE `creature` SET `spawntimesecs` = 115200, `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 6648;
+UPDATE `creature` SET `spawntimesecs` = 115200, `MovementType` = 1, `wander_distance` = 5 WHERE `id1` = 6648;
 
 -- Quest: Kim'jael's "Missing" Equipment, fix drop rate 'Some Rune', was 100%
 UPDATE `creature_loot_template` SET `Chance` = 15 WHERE `Item` = 13815;

--- a/data/sql/world/base/zone_barrens.sql
+++ b/data/sql/world/base/zone_barrens.sql
@@ -380,8 +380,8 @@ UPDATE `quest_template_addon` SET `PrevQuestID` = 871  WHERE `ID` = 5041; -- Sup
 
 UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1 WHERE `guid` = 15085; -- Isha Iwak, waypoints
 
-DELETE FROM `creature` WHERE `id` IN (3392, 3434, 3435, 3436, 3438, 3472, 3474, 5830, 5832, 5834, 5835);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` IN (3392, 3434, 3435, 3436, 3438, 3472, 3474, 5830, 5832, 5834, 5835);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (13984,  3392, 1, 0, 0, 1, 1, 1, -4181.31, -2184.33, 50.2665, 0.292325, 240, 5, 0, 600, 618, 1, 0, 0, 0, '', 0, 0, NULL),  -- Prospector Khazgorm
@@ -879,7 +879,7 @@ DELETE FROM `creature` WHERE `guid` BETWEEN 20301 AND 20309; -- Razormane Hunter
 DELETE FROM `creature` WHERE `guid` BETWEEN 20563 AND 20574; -- Kolkar Pack Runner
 DELETE FROM `creature` WHERE `guid` BETWEEN 20855 AND 20860; -- Kolkar Packhound
 DELETE FROM `creature` WHERE `guid` BETWEEN 20863 AND 20869; -- Kolkar Packhound
-INSERT INTO `creature` (`guid`, `id`,`map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`,`map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (20301, 3265, 1, 0, 0, 1, 1, 1, -38.8009, -3234.81, 91.8888, 5.10638, 275, 0, 1, 222, 0, 2, 0, 0, 0, '', 0, 0, NULL),

--- a/data/sql/world/base/zone_blades_edge_mountains.sql
+++ b/data/sql/world/base/zone_blades_edge_mountains.sql
@@ -64,7 +64,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 UPDATE `smart_scripts` SET `target_type` = 1 WHERE `entryorguid` = 19747 AND `event_type` = 4 AND `id` = 15;
 
 -- fix movement for Dreadwing
-UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1, `position_x` = 1582.5800, `position_y` = 5299.3701, `position_z` = 267.8560 WHERE `id` = 21032;
+UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1, `position_x` = 1582.5800, `position_y` = 5299.3701, `position_z` = 267.8560 WHERE `id1` = 21032;
 
 DELETE FROM `creature_addon` WHERE `guid` IN (73837);
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 

--- a/data/sql/world/base/zone_blasted_lands.sql
+++ b/data/sql/world/base/zone_blasted_lands.sql
@@ -117,7 +117,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 -- Portal Seeker missing waypoints
 DELETE FROM `creature` WHERE `guid` = 605981;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (605981, 5981, 0, 0, 0, 1, 1, 1, -11384.5, -2998.08, -0.819786, 2.103, 430, 0, 1, 2158, 4650, 2, 0, 0, 0, '', NULL, 0, NULL);
 
@@ -148,7 +148,7 @@ SET @WPID        := 6560000;
 SET @IPPPHASE_II := 131072;
 
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID AND @CGUID+212;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 
 (@CGUID,   19287, 0, 0, 0, 1, @IPPPHASE_II, 0, -11871, -3218.74, -14.8771, 0.159796, 120, 0, 0, 3297, 2434, 0, 0, 0, 0, '', NULL, 0, NULL),        -- Invading Voidwalker

--- a/data/sql/world/base/zone_bloodmyst_isle.sql
+++ b/data/sql/world/base/zone_bloodmyst_isle.sql
@@ -1,3 +1,3 @@
 -- fix Lord Xiz path ID 0 error (these changes are correct, but sadly this doesn't fix it still)
-UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1 WHERE `id` = 17701;
+UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1 WHERE `id1` = 17701;
 UPDATE `creature_template` SET `MovementType` = 0 WHERE `entry` = 17701

--- a/data/sql/world/base/zone_burning_steppes.sql
+++ b/data/sql/world/base/zone_burning_steppes.sql
@@ -98,8 +98,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 
 -- fix spawn locations
-DELETE FROM `creature` WHERE `id` IN (8977);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` IN (8977);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (4596,   8977, 0, 0, 0, 1, 1, 1, -7958.56, -2603.77, 173.694, 5.76038, 500, 0, 0, 2634, 2041, 0, 0, 0, 0, '', 0, 0, NULL), -- Krom'Grul

--- a/data/sql/world/base/zone_dalaran.sql
+++ b/data/sql/world/base/zone_dalaran.sql
@@ -1,5 +1,5 @@
-DELETE FROM `creature` WHERE `id` IN (31863, 31864, 31865, 33921, 33922, 33923, 33925, 33926, 33927, 33936, 33937, 33938, 34087, 34092, 34095);
-INSERT INTO `creature` (`guid`, `id`, `map`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
+DELETE FROM `creature` WHERE `id1` IN (31863, 31864, 31865, 33921, 33922, 33923, 33925, 33926, 33927, 33936, 33937, 33938, 34087, 34092, 34095);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 --
 (631863, 31863, 571, 1, 1, 5753.74, 585.413, 615.052, 0, 180),       -- Nargle Lashcord, WotLK Season 5
 (633921, 33921, 571, 1, 1, 5753.74, 585.413, 615.052, 0, 180),       -- Nargle Lashcord, WotLK Season 6

--- a/data/sql/world/base/zone_darnassus.sql
+++ b/data/sql/world/base/zone_darnassus.sql
@@ -18,8 +18,8 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (15, 4349, 0, 7, 197, 50,  'Show menu if tailoring is 50 or higher');       -- Me'lynn <Expert Tailor>
 
 -- Battlemasters
-DELETE FROM `creature` WHERE `id` IN (907, 2302, 5118);
-INSERT INTO `creature` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES
+DELETE FROM `creature` WHERE `id1` IN (907, 2302, 5118);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES
 (600907, 907,  1, 9975.14, 2324.34, 1330.87, 0.0698132, 600), -- Keras Wolfheart <Arathi Basin Battlemaster>
 (602302, 2302, 1, 9977.6, 2313.53, 1330.87, 0.698132, 600),   -- Aethalas <Warsong Gulch Battlemaster>
 (605118, 5118, 1, 9923.77, 2323.84, 1330.87, 1.6057, 600);    -- Brogun Stoneshield <Alterac Valley Battlemaster>

--- a/data/sql/world/base/zone_deadwind_pass.sql
+++ b/data/sql/world/base/zone_deadwind_pass.sql
@@ -1782,12 +1782,12 @@ INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `
 
 /* Add Ley Sprites and Mana Sprites removed in 2.0 */
 DELETE FROM `creature` WHERE `guid` IN (350995, 350996, 350997, 350998, 350999);
-INSERT INTO `creature` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `MovementType`, `spawntimesecs`) VALUES
-(350995, 12381, 0, -11177.200195, -2033.979980, 47.158798, 2.9482, 0, 2, 340),
-(350996, 12381, 0, -10922.000000, -1968.719971, 114.875999, 0.990982, 0, 2, 340),
-(350997, 12381, 0, -10807.400391, -2072.270020, 121.989998, 5.83641, 0, 2, 340),
-(350998, 12381, 0, -10993.299805, -1938.250000, 47.139301, 5.50472, 0, 2, 340),
-(350999, 12381, 0, -11153.000000, -2093.860107, 47.877800, 1.74458, 0, 2, 340);
+INSERT INTO `creature` (`guid`, `id1`, `id2`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `MovementType`, `spawntimesecs`) VALUES
+(350995, 12381, 12382, 0, -11177.200195, -2033.979980, 47.158798, 2.9482, 0, 2, 340),
+(350996, 12381, 12382, 0, -10922.000000, -1968.719971, 114.875999, 0.990982, 0, 2, 340),
+(350997, 12381, 12382, 0, -10807.400391, -2072.270020, 121.989998, 5.83641, 0, 2, 340),
+(350998, 12381, 12382, 0, -10993.299805, -1938.250000, 47.139301, 5.50472, 0, 2, 340),
+(350999, 12381, 12382, 0, -11153.000000, -2093.860107, 47.877800, 1.74458, 0, 2, 340);
 
 DELETE FROM `creature_addon` WHERE `guid` IN (350995, 350996, 350997, 350998, 350999);
 INSERT INTO `creature_addon` (`guid`, `path_id`) VALUES 
@@ -1796,14 +1796,6 @@ INSERT INTO `creature_addon` (`guid`, `path_id`) VALUES
 (350997, 3509970),
 (350998, 3509980),
 (350999, 3509990);
-
-DELETE FROM `creature_multispawn` WHERE `spawnId` IN (350995, 350996, 350997, 350998, 350999);
-INSERT INTO `creature_multispawn` (`spawnId`, `entry`) VALUES 
-(350995, 12382),
-(350996, 12382),
-(350997, 12382),
-(350998, 12382),
-(350999, 12382);
 
 DELETE FROM `waypoint_data`  WHERE `id` IN (3509950, 3509960, 3509970, 3509980, 3509990);
 INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`) VALUES

--- a/data/sql/world/base/zone_desolace.sql
+++ b/data/sql/world/base/zone_desolace.sql
@@ -125,7 +125,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 -- Khan Dez'Hepah, 3 spawn locations
 DELETE FROM `creature` WHERE `guid` IN (29141, 27042, 27052);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (29141, 5600, 1, 0, 0, 1, 1, 1, -795.566, 934.17, 90.5846, 2.77507,  300, 0, 0, 1342, 0, 0, 0, 0, 0, '', 0, 0, NULL),
 (27042, 5600, 1, 0, 0, 1, 1, 1, -947.212, 954.353, 96.303, 4.27606,  300, 0, 0, 1342, 0, 0, 0, 0, 0, '', 0, 0, NULL), -- https://www.youtube.com/watch?v=tkMfTwnqFNY
@@ -215,7 +215,7 @@ UPDATE `broadcast_text_locale` SET `MaleText` = 'Salutations, $c. Je suis Rexxar
 UPDATE `creature_template_model` SET `CreatureDisplayID` = 11660 WHERE `CreatureID` = 10182;
 
 DELETE FROM `creature` WHERE `guid` IN (29113, 610204);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, 
 `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (29113, 10182, 1, 0, 0, 1, 1, 1, 248.28, 1834.76, 86.2291, 3.32486, 550, 0, 1, 647400, 0, 2, 0, 0, 0, '', 0, 0, NULL),
 (610204, 10204, 1, 0, 0, 1, 1, 0, 247.329, 1830.72, 86.2303, 3.36506, 550, 0, 0, 161850, 0, 0, 0, 0, 0, '', 0, 0, NULL);
@@ -587,7 +587,7 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 
 -- fix kodo patrols
 DELETE FROM `creature` WHERE `guid` IN (28272, 28273, 28274, 28295, 28278, 28279, 28280, 28298, 28282, 28283, 28284, 28299);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (28272, 4700, 1, 0, 0, 1, 1, 0, -1313.12, 957.979, 91.9389, 1.58056,  180, 0, 1, 1570, 0, 2, 0, 0, 0, '', 0, 0, NULL),
@@ -786,7 +786,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 I'm removing this script from the kodo patrols so I can use smartAI to despawn the patrol when it reaches it's last waypoint and to keep them active so the formation stays intact
 this does mean that the kodos in the patrol can't be used for the Kodo Roundup quest, but the alternative is teleporting kodos catching up to the leader */
 UPDATE `creature_template` SET `ScriptName` = '' WHERE `entry` IN (4700, 4701);
-UPDATE `creature` SET `ScriptName` = 'npc_aged_dying_ancient_kodo' WHERE `id` IN (4700, 4701);
+UPDATE `creature` SET `ScriptName` = 'npc_aged_dying_ancient_kodo' WHERE `id1` IN (4700, 4701);
 UPDATE `creature` SET `ScriptName` = '' WHERE `guid` IN (28272, 28273, 28274, 28278, 28279, 28280, 28282, 28283, 28284, 28295, 28298, 28299);
 
 
@@ -795,7 +795,7 @@ DELETE FROM `creature` WHERE `guid` IN (
 27939, 27940, 27941, 27942, 27943, 27949, 27950, 27951, 27952, 27953, 27954, 27955, 27956, 27957, 27958,
 27959, 27960, 27961, 27962, 27963, 27964, 27965, 27966, 27967, 27968, 27969, 27970, 27971, 27972, 27973);
 
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (27939, 4688, 1, 0, 0, 1, 1, 0, -1726.32, 2567.95, 107.69, 0.39374,  300, 0, 1, 444, 0, 2, 0, 0, 0, '', 0, 0, NULL), -- Bonepaw Hyena

--- a/data/sql/world/base/zone_dragonblight.sql
+++ b/data/sql/world/base/zone_dragonblight.sql
@@ -1,6 +1,6 @@
 -- fix Dregmar Runebrand waypoints
 UPDATE `creature_template` SET `MovementType` = 0 WHERE `entry` = 27003;
-UPDATE `creature` SET `position_x` =  3671.979, `position_y` = -497.5903, `position_z` = 157.9536, `MovementType` = 2, `currentwaypoint` = 1 WHERE `id` = 27003;
+UPDATE `creature` SET `position_x` =  3671.979, `position_y` = -497.5903, `position_z` = 157.9536, `MovementType` = 2, `currentwaypoint` = 1 WHERE `id1` = 27003;
 
 DELETE FROM `creature_addon` WHERE `guid` = 107239;
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 

--- a/data/sql/world/base/zone_dun_morogh.sql
+++ b/data/sql/world/base/zone_dun_morogh.sql
@@ -100,11 +100,11 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (8503, 0, 2, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Gibblewilt - Between 0-15% Health - Flee For Assist (No Repeat)');
 
 -- fix respawn times
-UPDATE `creature` SET `spawntimesecs` = 270  WHERE `id` = 808;  -- Grik'nir the Cold
-UPDATE `creature` SET `spawntimesecs` = 5400 WHERE `id` = 1119; -- Hammerspine
-UPDATE `creature` SET `spawntimesecs` = 5400 WHERE `id` = 1137; -- Edan the Howler
-UPDATE `creature` SET `spawntimesecs` = 270  WHERE `id` = 1961; -- Mangeclaw
-UPDATE `creature` SET `spawntimesecs` = 270  WHERE `id` = 6124; -- Captain Beld
+UPDATE `creature` SET `spawntimesecs` = 270  WHERE `id1` = 808;  -- Grik'nir the Cold
+UPDATE `creature` SET `spawntimesecs` = 5400 WHERE `id1` = 1119; -- Hammerspine
+UPDATE `creature` SET `spawntimesecs` = 5400 WHERE `id1` = 1137; -- Edan the Howler
+UPDATE `creature` SET `spawntimesecs` = 270  WHERE `id1` = 1961; -- Mangeclaw
+UPDATE `creature` SET `spawntimesecs` = 270  WHERE `id1` = 6124; -- Captain Beld
 
 -- Beginnings (Warlock)
 DELETE FROM `creature_questender` WHERE `id` = 460 AND `quest` = 1599;

--- a/data/sql/world/base/zone_durotar.sql
+++ b/data/sql/world/base/zone_durotar.sql
@@ -119,8 +119,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 
 -- fix multiple spawn locations and respawn times
-DELETE FROM `creature` WHERE `id` IN (3204, 5809, 5822, 5824, 5826);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` IN (3204, 5809, 5822, 5824, 5826);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (695041, 3204, 1, 0, 0, 1, 1, 1, 1454.2, -4701.82, -2.62193, 4.57276, 300, 0, 0, 178, 382, 0, 0, 0, 0, '', 0, 0, NULL),   -- Gazz'uz
@@ -192,8 +192,8 @@ INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES
 UPDATE `creature` SET `spawntimesecs` = 3600, `MovementType` = 1, `Wander_distance` = 5 WHERE `guid` = 12260;
 
 -- Death Flayer, fix waypoints and respawn time
-DELETE FROM `creature` WHERE `id` = 5823;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` = 5823;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (12322, 5823, 1, 0, 0, 1, 1, 0, 57.4579, -3894.15, 42.8933, 0.345736, 5400, 0, 1, 222, 0, 2, 0, 0, 0, '', 0, 0, NULL);
 

--- a/data/sql/world/base/zone_duskwood.sql
+++ b/data/sql/world/base/zone_duskwood.sql
@@ -111,7 +111,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 
 -- fix respawn time of Lord Malathrom and Naraxis
-UPDATE `creature` SET `spawntimesecs` = 23400 WHERE `id` IN (503, 574);
+UPDATE `creature` SET `spawntimesecs` = 23400 WHERE `id1` IN (503, 574);
 
 -- Nothing but the Truth, should require deepstrider tumor(6082)
 DELETE FROM `item_dbc` WHERE `ID` = 6082;

--- a/data/sql/world/base/zone_dustwallow_marsh.sql
+++ b/data/sql/world/base/zone_dustwallow_marsh.sql
@@ -128,15 +128,15 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 -- quest: Stinky's Escape, fix worldserver error
 UPDATE `smart_scripts` SET `link` = 0 WHERE `entryorguid` = 4880 AND `source_type` = 0 AND `id` IN (0, 1);
 
-UPDATE `creature` SET `spawntimesecs` = 18000, `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 14230; -- Burgle Eye
+UPDATE `creature` SET `spawntimesecs` = 18000, `MovementType` = 1, `wander_distance` = 5 WHERE `id1` = 14230; -- Burgle Eye
 
-DELETE FROM `creature`       WHERE `id` = 23589;  -- Defias Rummager
-DELETE FROM `creature`       WHERE `id` = 23841;  -- Razorspine
+DELETE FROM `creature`       WHERE `id1` = 23589;  -- Defias Rummager
+DELETE FROM `creature`       WHERE `id1` = 23841;  -- Razorspine
 DELETE FROM `creature_addon` WHERE `guid` = 39309; -- Razorspine
 
 /* Fiora Longears - restore her location to Theramore and restore quests that involve her */
-DELETE FROM `creature` WHERE `id` = 4456;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`,
+DELETE FROM `creature` WHERE `id1` = 4456;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`,
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES
 (37087, 4456, 1, 0, 0, 1, 1, 1, -3613.47, -4464.02, 13.7054, 2.61799, 275, 0, 0, 787, 0, 0, 0, 0, 0, '', 0, NULL);
 
@@ -162,14 +162,14 @@ INSERT INTO `quest_poi_points` (`QuestID`,`Idx1`,`Idx2`,`X`,`Y`,`VerifiedBuild`)
 (1135, 0, 0, -3613, -4464, 0);
 
 /* Old Vanilla Varian Wrynn Npc in Alcaz during Vanilla phases */
-DELETE FROM `creature` WHERE `id` = 11699 AND `map` = 1;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`,
+DELETE FROM `creature` WHERE `id1` = 11699 AND `map` = 1;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`,
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES
 (611699, 11699, 1, 0, 0, 1, 1, 1, -2744.03, -4994.2, 8.26564, 0.0392587, 300, 0, 0, 4121, 0, 0, 0, 0, 0, 'npc_ipp_pre_naxx40', 0, 'Varian Wrynn in Alcaz (Vanilla)');
 
 -- fix Deadmire waypoints
 UPDATE `creature_template` SET `MovementType` = 0 WHERE `entry` = 4841;
-UPDATE `creature` SET `position_x` = -4019.49, `position_y` = -3537.49, `position_z` = 29.8848, `orientation` = 0.719014, `MovementType` = 2, `currentwaypoint` = 1 WHERE `id` = 4841;
+UPDATE `creature` SET `position_x` = -4019.49, `position_y` = -3537.49, `position_z` = 29.8848, `orientation` = 0.719014, `MovementType` = 2, `currentwaypoint` = 1 WHERE `id1` = 4841;
 
 DELETE FROM `creature_addon` WHERE `guid` = 33909;
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
@@ -275,7 +275,7 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 
 -- fix Firemane Scout patrols
 DELETE FROM `creature` WHERE `guid` IN (31125, 31126, 31338, 31339, 31487, 31488, 31492, 31493, 34008, 34019);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`,
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`,
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (31125, 4329, 1, 0, 0, 1, 1, 1, -4929.12, -3419.79, 34.505, 0.149126, 720, 0, 1, 1751, 0, 2, 0, 0, 0, '', 0, 0, NULL),

--- a/data/sql/world/base/zone_eastern_plaguelands.sql
+++ b/data/sql/world/base/zone_eastern_plaguelands.sql
@@ -194,8 +194,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 
 -- fix spawn locations, respawn and movement
-DELETE FROM `creature` WHERE `id` IN (10822, 10823, 10827);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (10822, 10823, 10827);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (86607,  10822, 0, 0, 0, 1, 1, 1, 3314, -4855.85, 167.322, 2.50322, 18000, 5, 0, 3876, 0, 1, 0, 0, 0, '', 0, 0,        'Warlord Thresh\'jin'),
 (695028, 10822, 0, 0, 0, 1, 1, 1, 3221.36, -4710.45, 158.034, 5.60277, 18000, 0, 0, 3876, 0, 0, 0, 0, 0, '', 0, 0,     'Warlord Thresh\'jin'), -- https://www.youtube.com/watch?v=1fU3H5dqXZI

--- a/data/sql/world/base/zone_elwynn_forest.sql
+++ b/data/sql/world/base/zone_elwynn_forest.sql
@@ -64,8 +64,8 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 (79, 0, 2, 'No kill me! No kill me!', 12, 0, 100, 0, 0, 0, 1863, 0, 'Narg the Taskmaster');
 
 -- Hogger, fix missing waypoints and spawn points, entry 448, guid 80531
-DELETE FROM `creature` WHERE `id` = 448;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` = 448;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (80531, 448, 0, 0, 0, 1, 1, 1, -9946, 604.266, 38.2862, 0.297245, 180, 0, 1, 666, 0, 2, 0, 0, 0, '', 0, 0, NULL),
 (695022, 448, 0, 0, 0, 1, 1, 1, -9947.88, 594.773, 39.608, 5.19393, 180, 15, 0, 666, 0, 1, 0, 0, 0, '', 0, 0, NULL),
@@ -223,8 +223,8 @@ INSERT INTO `creature_questitem` (`CreatureEntry`, `Idx`, `ItemId`, `VerifiedBui
 (299, 0, 750, 0);
 
 -- Restore Mirror Lake Orchard creatures removed in WotLK
-DELETE FROM `creature` WHERE `guid` IN (80391, 80392, 80393, 80394, 80396, 80397, 80399, 80400, 80401, 80402, 80403, 80404, 80405) AND `id` IN (116, 94);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `guid` IN (80391, 80392, 80393, 80394, 80396, 80397, 80399, 80400, 80401, 80402, 80403, 80404, 80405) AND `id1` IN (116, 94);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 (80391, 116, 0, 0, 0, 1, 1, 1, -9441.48, 469.81, 53.2758, 4.26422, 180, 5, 0, 156, 0, 1, 0, 0, 0, '', 0),
 (80392, 116, 0, 0, 0, 1, 1, 1, -9444.94, 473.775, 52.3257, 4.03171, 180, 5, 0, 156, 0, 1, 0, 0, 0, '', 0),

--- a/data/sql/world/base/zone_felwood.sql
+++ b/data/sql/world/base/zone_felwood.sql
@@ -139,13 +139,13 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 (14344, 0, 0, '$s becomes enraged!', 16, 0, 100, 0, 0, 0, 10677, 0, 'Mongress enrage at 30%');
 
 -- Ragepaw, fix movement
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 14342;
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5 WHERE `id1` = 14342;
 
 -- fix Irontree Wood Ancients
 SET @IPPPHASE := 65536;
 
-DELETE FROM `creature` WHERE `id` IN (14524, 14525, 14526);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (14524, 14525, 14526);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (614524, 14524, 1, 0, 0, 1, @IPPPHASE, 0, 6194.55, -1176.35, 369.056, 1.1098,  600, 0, 0, 3331, 0, 0, 0, 0, 0, '', 0, 0, NULL),
 (614525, 14525, 1, 0, 0, 1, @IPPPHASE, 0, 6197.12, -1135.42, 366.31,  5.28025, 600, 0, 0, 3331, 0, 0, 0, 0, 0, '', 0, 0, NULL),
@@ -153,8 +153,8 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 
 -- fix Withered Protector waypoints
-DELETE FROM `creature` WHERE `id` IN (7149);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (7149);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (39489, 7149, 1, 0, 0, 1, 1, 0, 6177, -1322.46, 376.746, 5.71257, 300, 0, 1, 4318, 0, 2, 0, 0, 0, '', 0, 0, NULL);
 

--- a/data/sql/world/base/zone_feralas.sql
+++ b/data/sql/world/base/zone_feralas.sql
@@ -181,12 +181,12 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (14661, 0, 1, 0, 0, 0, 100, 0, 6000, 8000, 7000, 10000, 0, 0, 11, 6607, 0, 0, 0, 0, 0, 5, 5, 0, 0, 0, 0, 0, 0, 0,        'Stinglasher - Within 0-5 Range - cast Lash');
 
 
-UPDATE `creature` SET `spawntimesecs` = 23400 WHERE `id` = 5343; -- Lady Szallah
-UPDATE `creature` SET `spawntimesecs` = 54000 WHERE `id` = 5347; -- Antilus the Soarer
-UPDATE `creature` SET `spawntimesecs` = 23400 WHERE `id` = 5349; -- Arash-ethis
+UPDATE `creature` SET `spawntimesecs` = 23400 WHERE `id1` = 5343; -- Lady Szallah
+UPDATE `creature` SET `spawntimesecs` = 54000 WHERE `id1` = 5347; -- Antilus the Soarer
+UPDATE `creature` SET `spawntimesecs` = 23400 WHERE `id1` = 5349; -- Arash-ethis
 
-DELETE FROM `creature` WHERE `id` IN (5356, 11447, 11497, 11498);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` IN (5356, 11447, 11497, 11498);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (51683, 5356,  1, 0, 0, 1, 1, 0, -4142.19, -423.252, 24.9747, 4.12439, 21000,  0, 1, 1981,  0,     2, 0, 0, 0, '', 0, 0, NULL), -- Snarler
 (45758, 11447, 1, 0, 0, 1, 1, 0, -3758.47, 1096.15, 131.97, 3.34614,   25200, 10, 0, 60000, 0,     1, 0, 0, 0, '', 0, 0, NULL), -- Mushgog

--- a/data/sql/world/base/zone_hellfire_peninsula.sql
+++ b/data/sql/world/base/zone_hellfire_peninsula.sql
@@ -21,7 +21,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 
 -- fix Arzeth the Merciless worldserver error
-UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1 WHERE `id` = 19354;
+UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1 WHERE `id1` = 19354;
 
 -- fix Pit Commander worldserver error
 UPDATE `smart_scripts` SET `event_type` = 61 WHERE `entryorguid` = 18945 AND `id` = 4;

--- a/data/sql/world/base/zone_hillsbrad_foothills.sql
+++ b/data/sql/world/base/zone_hillsbrad_foothills.sql
@@ -177,8 +177,8 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 UPDATE `quest_template_addon` SET `PrevQuestID` = 527 WHERE `ID` = 546;
 
 -- fix creature movement and spawn locations
-DELETE FROM `creature` WHERE `id` IN (232, 2403, 2427, 2428, 2450, 14275, 14276, 14277, 14280);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` IN (232, 2403, 2427, 2428, 2450, 14275, 14276, 14277, 14280);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (16520,  232, 0, 0, 0, 1, 1, 1, -341.604, 3.60308, 60.3681, 2.21657,        300, 0, 0, 617, 0, 0, 0, 0, 0, '', 0, 0, NULL),    -- Farmer Ray
@@ -412,7 +412,7 @@ INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `e
 (@CGUID+40, 148400, 0, 0, 1, 0, 0, NULL);
 
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+10 AND @CGUID+42;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (@CGUID+10, 607068, 0, 0, 0, 1, 1, 1, -1262.56, 479.974, 10.5137, 5.06174,  600, 0, 0, 1, 1, 0, 0, 0, 0, '', 0, 0, NULL), -- Condemned Acolyte
@@ -460,5 +460,5 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 SET @IPPPHASE    := 65536; 
 SET @IPPPHASE_II := 131072;
 
-UPDATE `creature` SET `phaseMask` = @IPPPHASE_II WHERE `id` IN (7068, 7069, 7070, 7071, 7072, 7075);
-UPDATE `creature` SET `phaseMask` = @IPPPHASE    WHERE `id` IN (607068, 607069, 607070, 607071, 607072, 7073, 7074, 607075);
+UPDATE `creature` SET `phaseMask` = @IPPPHASE_II WHERE `id1` IN (7068, 7069, 7070, 7071, 7072, 7075);
+UPDATE `creature` SET `phaseMask` = @IPPPHASE    WHERE `id1` IN (607068, 607069, 607070, 607071, 607072, 7073, 7074, 607075);

--- a/data/sql/world/base/zone_hinterlands.sql
+++ b/data/sql/world/base/zone_hinterlands.sql
@@ -119,7 +119,7 @@ UPDATE `creature` SET `spawntimesecs` = 37800, `MovementType` = 1, `wander_dista
 
 -- Grimungous, fix spawn and waypoints
 DELETE FROM `creature` WHERE `guid` = 77480;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (77480, 8215, 0, 0, 0, 1, 1, 0, 45.1769, -4277.32, 122.17, 4.22167, 115200, 0, 1, 6645, 0, 2, 0, 0, 0, '', 0, 0, NULL);
 

--- a/data/sql/world/base/zone_ironforge.sql
+++ b/data/sql/world/base/zone_ironforge.sql
@@ -22,8 +22,8 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (15, 4345, 0, 7, 197, 50,  'Show menu if tailoring is 50 or higher');      -- Jormund Stonebrow <Expert Tailor>
 
 -- battlemasters
-DELETE FROM `creature` WHERE `id` IN (857, 5113, 5115, 6114, 12197, 14982, 19915, 34991, 35007, 35025, 35600) OR `guid` = 86263;
-INSERT INTO `creature` (`guid`, `id`, `map`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `curhealth`, `curmana`) VALUES 
+DELETE FROM `creature` WHERE `id1` IN (857, 5113, 5115, 6114, 12197, 14982, 19915, 34991, 35007, 35025, 35600) OR `guid` = 86263;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `curhealth`, `curmana`) VALUES 
 (600857, 857,   0, 1, -5039.19, -1266.88, 510.326, 3.92579,  120, 1, 0), -- Donal Osgood <Arathi Basin Battlemaster>
 (2019,   5113,  0, 1, -5047.54, -1269.69, 510.408, 6.24828,  540, 1, 0), -- Kelv Sternhammer <Warrior Trainer>
 (2020,   5115,  0, 1, -5043.84, -1274.68, 510.324, 1.33007,  490, 1, 0), -- Daera Brightspear <Hunter Trainer>

--- a/data/sql/world/base/zone_isle_of_queldanas.sql
+++ b/data/sql/world/base/zone_isle_of_queldanas.sql
@@ -233,9 +233,9 @@ SET @WPID   := 6730000;
 SET @IPPPHASE_III := 262144;
 SET @IPPPHASE_V   := 1048576;
 
-DELETE FROM `creature` WHERE `id` IN (25001, 25002, 25003);
+DELETE FROM `creature` WHERE `id1` IN (25001, 25002, 25003);
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+2 AND @CGUID+5;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+1,  25003, 530, 0, 0, 1, 1, 1, 12583.2998, -6916.2798, 4.6855, 6.2606, 300, 0, 1, 7084, 0, 2, 0, 0, 0, '', NULL, 0, NULL), -- Emissary of Hate
 --
@@ -431,8 +431,8 @@ DELETE FROM `creature_addon` WHERE `guid` BETWEEN 97023 AND 97035;
 DELETE FROM `creature_addon` WHERE `guid` BETWEEN 97073 AND 97081;
 
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+171 AND @CGUID+175;
-DELETE FROM `creature` WHERE `id` IN (22323, 24918, 24919);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (22323, 24918, 24919);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+101, 22323, 530, 0, 0, 1, 1, 0, 779.805, 2025.520, 272.724, 2.082, 300, 5, 0, 6986, 0, 1, 0, 0, 0, '', 0, 0, NULL),

--- a/data/sql/world/base/zone_mulgore.sql
+++ b/data/sql/world/base/zone_mulgore.sql
@@ -71,7 +71,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (5807, 0, 0, 0, 9, 0, 100, 0, 0, 0, 8000, 12000, 0, 5, 11, 12166, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'The Rake - Within 0-5 Range - Cast Muscle Tear');
 
 -- Mazzranache, waypoints
-UPDATE `creature` SET `spawntimesecs` = 9000, `MovementType` = 2, `currentwaypoint` = 1 WHERE `id` = 3068;
+UPDATE `creature` SET `spawntimesecs` = 9000, `MovementType` = 2, `currentwaypoint` = 1 WHERE `id1` = 3068;
 
 DELETE FROM `creature_addon` WHERE `guid` = 26908;
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 
@@ -145,8 +145,8 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 (269080, 64, -1731.65, -542.165, -13.1692, NULL, 0, 0, 0, 100, 0);
 
 -- Galak Centaur, waypoints
-DELETE FROM `creature` WHERE `id` IN (2967, 2968);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` IN (2967, 2968);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (25998, 2967, 1, 0, 0, 1, 1, 1, -2261.41, -1456.51, 46.2608, 5.28361, 375, 0, 1, 176, 0, 2, 0, 0, 0, '', 0, 0, NULL),
 (25999, 2967, 1, 0, 0, 1, 1, 1, -2227.05, -1386.47, 43.9742, 5.23882, 375, 0, 1, 176, 0, 2, 0, 0, 0, '', 0, 0, NULL),

--- a/data/sql/world/base/zone_nagrand.sql
+++ b/data/sql/world/base/zone_nagrand.sql
@@ -40,8 +40,8 @@ SET @WPID    := 6700000;
 -- add kodo corpses near the Greater Windrocs
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+1 AND @CGUID+6;
 DELETE FROM `creature` WHERE `guid` IN (59582, 60208);
-DELETE FROM `creature` WHERE `id`  IN (23022); -- needed to remove creature placed by AC
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1`  IN (23022); -- needed to remove creature placed by AC
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (@CGUID+1, 17133, 530, 0, 0, 1, 1, 0, -1179.0300, 8585.5195, 35.3682, 2.7576, 300, 0, 0, 1, 0, 0, 0, 258, 0, '', NULL, 0, NULL),
@@ -64,8 +64,8 @@ INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `e
 (@CGUID+4, 0, 0, 7, 0, 65, 0, NULL);
 
 -- fix movement for Gutripper and Bach'lor
-UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1, `position_x` = -1099.5699, `position_y` = 8582.3896, `position_z` = 46.3612 WHERE `id` = 18257; -- Gutripper
-UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1, `position_x` = -1915, `position_y` = 8854, `position_z` = 30.8850           WHERE `id` = 18258; -- Bach'lor
+UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1, `position_x` = -1099.5699, `position_y` = 8582.3896, `position_z` = 46.3612 WHERE `id1` = 18257; -- Gutripper
+UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1, `position_x` = -1915, `position_y` = 8854, `position_z` = 30.8850           WHERE `id1` = 18258; -- Bach'lor
 
 DELETE FROM `creature_template_movement` WHERE `CreatureId` IN (18257, 18258);
 INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES 

--- a/data/sql/world/base/zone_netherstorm.sql
+++ b/data/sql/world/base/zone_netherstorm.sql
@@ -152,7 +152,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (2028104, 9, 2, 0, 0, 0, 100, 0, 6000, 6000, 0, 0, 0, 0, 1, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                            'Script9 - Talk'); -- let's get out of here
 
 UPDATE `creature_template` SET `detection_range` = 10, `MovementType` = 0 WHERE `entry` = 20281;
-UPDATE `creature` SET `MovementType` = 0 WHERE `id` = 20281;
+UPDATE `creature` SET `MovementType` = 0 WHERE `id1` = 20281;
 DELETE FROM `waypoints` WHERE `entry` = 20281;
 
 DELETE FROM `creature_addon` WHERE `guid` IN (72042);
@@ -203,8 +203,8 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 (20281, 8, 0, 'Very well.  Before we head down there, take a moment to prepare yourself.', 12, 0, 100, 0, 0, 0, 17940, 0, 'Drijya');
 
 -- add waypoints for Summoner Kanthin
-DELETE FROM `creature` WHERE `id` IN (19657, 19653);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (19657, 19653);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (70089, 19653, 530, 0, 0, 1, 1, 0, 2948.9099, 2280.3501, 161.7080, 5.9072, 300, 0, 0, 2530, 0, 0, 0, 0, 0, '', 0, 0, NULL),    -- Glacius
@@ -251,9 +251,9 @@ SET @Krixel     := 123396;
 SET @Leeni      := 124392;
 
 DELETE FROM `creature` WHERE `guid` IN (@CGUID+71, @CGUID+72);
-DELETE FROM `creature` WHERE `id` IN (23396, 24392, 26352, @Leeni, @Krixel);
-DELETE FROM `creature` WHERE `id` IN (32354, 33919, 33930, 33941, 32355, 33916, 33932, 33933, 32356, 33918, 33931, 33940, 34089, 34091, 34094);
-INSERT INTO `creature` (`guid`, `id`, `map`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
+DELETE FROM `creature` WHERE `id1` IN (23396, 24392, 26352, @Leeni, @Krixel);
+DELETE FROM `creature` WHERE `id1` IN (32354, 33919, 33930, 33941, 32355, 33916, 33932, 33933, 32356, 33918, 33931, 33940, 34089, 34091, 34094);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 --
 (@CGUID+71, 20278,   530, 1, 1, 3070.16, 3635.11, 143.864, 0.750492, 180), -- Vixton Pinchwhistle, WotLK Season 1
 (@CGUID+72, @Vixton, 530, 1, 1, 3070.16, 3635.11, 143.864, 0.750492, 180), -- Vixton Pinchwhistle, WotLK Season 2
@@ -320,8 +320,8 @@ INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `e
 SET @CGUID   := 670000;
 SET @WPID    := 6700000;
 
-DELETE FROM `creature` WHERE `id` IN (18875, 19642);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (18875, 19642);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+101, 18875, 530, 0, 0, 1, 1, 1, 2493.2236, 4047.8603, 133.6053, 0.0523, 300, 0, 0, 6326, 0, 0, 0, 0, 0, '', 0, 0, NULL),
@@ -493,8 +493,8 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 SET @CGUID   := 670000;
 SET @WPID    := 6700000;
 
-DELETE FROM `creature` WHERE `id` IN (18852, 18853, 18855, 18857, 19453, 19643);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (18852, 18853, 18855, 18857, 19453, 19643);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+201, 18853, 530, 0, 0, 1, 1, 1, 2810.81, 3923.14, 147.125, 0.122173, 360, 0, 0, 6326, 0, 0, 0, 0, 0, '', 0, 0, NULL),
@@ -632,7 +632,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+341 AND @CGUID+343;
 DELETE FROM `creature` WHERE `guid` BETWEEN 69406 AND 69417;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+341, 19421, 530, 0, 0, 1, 1, 0, 3008.33, 4225.37, 160.777, 2.25655, 300, 0, 0, 42, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- Netherstorm Crystal Target

--- a/data/sql/world/base/zone_orgrimmar.sql
+++ b/data/sql/world/base/zone_orgrimmar.sql
@@ -29,10 +29,10 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (15, 4209, 0, 7, 165, 50,  'Show menu if leatherworking is 50 or higher'), -- Karolek <Expert Leatherworker>
 (15, 4347, 0, 7, 197, 50,  'Show menu if tailoring is 50 or higher');      -- Magar <Expert Tailor>
 
-DELETE FROM `creature` WHERE `id` = 3230 AND `map`= 1;
+DELETE FROM `creature` WHERE `id1` = 3230 AND `map`= 1;
 DELETE FROM `creature` WHERE `guid` IN (10299, 203492, 203493, 203494, 203495);
-DELETE FROM `creature` WHERE `id` IN (3890, 14720, 14942, 15006);
-INSERT INTO `creature` (`guid`, `id`, `map`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
+DELETE FROM `creature` WHERE `id1` IN (3890, 14720, 14942, 15006);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 (603230, 3230,  1, 1, 1938.55, -4133.22, 41.1424, 4.07636, 300), -- Nazgrel <Advisor to Thrall>
 (10299,  3296,  1, 1, 1620.45, -4252.84, 47.5273, 3.7001,  300), -- Orgrimmar Grunt
 (603890, 3890,  1, 1, 1991.89, -4793.95, 56.0462, 3.27581, 300), -- Brakgul Deathbringer <Warsong Gulch Battlemaster>
@@ -41,7 +41,7 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `equipment_id`, `position_x`, `posi
 (615006, 15006, 1, 1, 2002.26, -4796.74, 56.8471, 3.00197, 600); -- Deze Snowbane <Arathis Basin Battlemaster>
 
 -- Master Pyreanor <Paladin Trainer>
-UPDATE `creature` SET `position_x`= 1940.23, `position_y`= -4135.53, `position_z`= 41.1522, `orientation`= 3.12425  WHERE `id` = 23128;
+UPDATE `creature` SET `position_x`= 1940.23, `position_y`= -4135.53, `position_z`= 41.1522, `orientation`= 3.12425  WHERE `id1` = 23128;
 
 -- Knowledge of the Orb of Orahil (Warlock)
 DELETE FROM `creature_queststarter` WHERE `id` = 3326 AND `quest` = 4967;
@@ -97,11 +97,11 @@ UPDATE `creature_template` SET `subname` = 'Arena Vendor'                      W
 UPDATE `creature_template_addon` SET `mount` = 0 WHERE `entry` = 12796;
 
 DELETE FROM `creature` WHERE `guid` IN (125688, 125690, 125694, 125695, 612792, 612793, 612794, 612795, 612796, 612799, 614581, 623396, 623447, 626397, 620278, 626396); -- 00_cleanup
-DELETE FROM `creature` WHERE `id`  IN (12788, 19850, 32383, 32385, 34036, 34037, 34038, 34058, 34059, 34060);
+DELETE FROM `creature` WHERE `id1`  IN (12788, 19850, 32383, 32385, 34036, 34037, 34038, 34058, 34059, 34060);
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+1 AND @CGUID+18;
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+101 AND @CGUID+118;
 
-INSERT INTO `creature` (`guid`, `id`, `map`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 --
 (@CGUID+101, 12799, 1, 1, 1632.21, -4262.19, 49.027, 3.63029, 430),     -- Sergeant Ba'sha <Accessories Quartermaster>, Vanilla
 (@CGUID+102, @Stonehide, 1, 1, 1657.6, -4191.97, 56.383, 4.52365, 180), -- Brave Stonehide <Officer Accessories Quartermaster>, Vanilla
@@ -337,7 +337,7 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 
 
 -- WotLK pvp vendors
-DELETE FROM `creature` WHERE `id` IN 
+DELETE FROM `creature` WHERE `id1` IN 
 (34043,  -- Lady Palanseer <Armor Quartermaster>
  34063); -- Blood Guard Zar'shi <Northrend Armor Quartermaster>
 

--- a/data/sql/world/base/zone_redridge_mountains.sql
+++ b/data/sql/world/base/zone_redridge_mountains.sql
@@ -167,11 +167,11 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 
 -- update respawn time for Stonewatch elites
-UPDATE `creature` SET `spawntimesecs` = 900 WHERE `id` IN (334, 335, 436, 486, 4064, 4065, 4462, 4464);
+UPDATE `creature` SET `spawntimesecs` = 900 WHERE `id1` IN (334, 335, 436, 486, 4064, 4065, 4462, 4464);
 
 -- missing patrols
 DELETE FROM `creature` WHERE `guid` IN (17972, 18379, 18389, 18394, 18396, 18397, 18434, 18451, 18455, 26167, 28362, 31829);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (18389, 4065, 0, 0, 0, 1, 1, 1, -9440.13, -3073.22, 136.855, 5.02655, 900, 0, 0, 521, 0,    0, 0, 0, 0, '', 0, 0, NULL), -- Blackrock Sentry

--- a/data/sql/world/base/zone_searing_gorge.sql
+++ b/data/sql/world/base/zone_searing_gorge.sql
@@ -102,19 +102,19 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (839101, 9, 3, 0, 0, 0, 100, 1, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                                  'Script9 - On Reset - Set Walk');
 
 /* Anvilrage Overseers and Anvilrage Wardens were replaced with new non-elite mobs in 2.3 - restore the originals */
-UPDATE `creature` SET `id` = 8889 WHERE `id` = 24818;
-UPDATE `creature` SET `id` = 8890 WHERE `id` = 24819;
+UPDATE `creature` SET `id1` = 8889 WHERE `id1` = 24818;
+UPDATE `creature` SET `id1` = 8890 WHERE `id1` = 24819;
 
 /* 3 Dark Iron Sentries in the towers were replaced with non-elite dark iron lookouts in 2.3 - restore the originals */
-UPDATE `creature` SET `id` = 8504 WHERE `guid` = 6830;
-UPDATE `creature` SET `id` = 8504 WHERE `guid` = 6831;
-UPDATE `creature` SET `id` = 8504 WHERE `guid` = 6832;
+UPDATE `creature` SET `id1` = 8504 WHERE `guid` = 6830;
+UPDATE `creature` SET `id1` = 8504 WHERE `guid` = 6831;
+UPDATE `creature` SET `id1` = 8504 WHERE `guid` = 6832;
 
 /* Maltorius had 2 elite Dark Iron Sentries next to him that were replaced by a single non-elite dark iron lookout in 2.3 - restore the originals */
-UPDATE `creature` SET `id` = 8504 WHERE `guid` = 5846;
+UPDATE `creature` SET `id1` = 8504 WHERE `guid` = 5846;
 
 DELETE FROM `creature` WHERE `guid` IN (608504, 608505);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (608504, 8504, 0, 0, 0, 1, 1, 1, -6630.98, -1233.1, 209.809, 1.29509, 300, 0, 0, 4950, 0, 0, 0, 0, 0, '', NULL, 0, NULL),
 (608505, 8504, 0, 0, 0, 1, 1, 1, -7023.45, -1283.97, 258.302, 4.8895, 300, 0, 0, 4950, 0, 0, 0, 0, 0, '', NULL, 0, NULL); -- 4th tower Dark Iron Sentry

--- a/data/sql/world/base/zone_shadowmoon_valley.sql
+++ b/data/sql/world/base/zone_shadowmoon_valley.sql
@@ -7,7 +7,7 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (30, 0, 21766, 0, 0, 5, 0, 934, 240, 0, 0, 0, 0, '', 'Only able to activate flight path if friendly with Scryers');
 
 -- fix movement for Parsha
-UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1, `position_x` = -3493.5701, `position_y` = 2277.0901, `position_z` = 65.3081 WHERE `id` = 22024;
+UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1, `position_x` = -3493.5701, `position_y` = 2277.0901, `position_z` = 65.3081 WHERE `id1` = 22024;
 
 DELETE FROM `creature_addon` WHERE `guid` IN (83112);
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 

--- a/data/sql/world/base/zone_shattrath.sql
+++ b/data/sql/world/base/zone_shattrath.sql
@@ -31,8 +31,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 UPDATE `smart_scripts` SET `event_type` = 61 WHERE `entryorguid` = 22374 AND `source_type` = 0 AND `id` = 1;
 
 -- TBC battlemasters
-DELETE FROM `creature` WHERE `id` IN (20269, 20271, 20272, 20273, 20274, 20276, 20339, 20362, 20384, 20395);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (20269, 20271, 20272, 20273, 20274, 20276, 20339, 20362, 20384, 20395);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (207610, 20269, 530, 0, 0, 1, 1, 1, -1971.8900, 5269.0400, -38.7644, 3.0718, 300, 0, 0, 1, 0, 0, 0, 0, 0, '', 0, 0, NULL),
@@ -53,7 +53,7 @@ DELETE FROM `game_event_creature` WHERE `guid` IN (72252, 72364, 207610, 207611,
 DELETE FROM `creature` WHERE `guid` IN (63451, 88251, 88252, 88254, 207710, 207711);
 
 -- change Shattered Sun Marksmen into Warriors. Marksmen refuse to use waypoints to run towards the Quel'Danas portal
-UPDATE `creature` SET `id` = 25115 WHERE `guid` IN (165106, 165107, 165108, 165109);
+UPDATE `creature` SET `id1` = 25115 WHERE `guid` IN (165106, 165107, 165108, 165109);
 
 
 /* Scryer's Tier */
@@ -85,7 +85,7 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 (667360, 13, -2110.05, 5512.4, 49.4188, NULL, 0, 0, 0, 100, 0);
 
 DELETE FROM `creature` WHERE `guid` IN (@CGUID+17, @CGUID+18, @CGUID+19, @CGUID+20, @CGUID+23, @CGUID+24, @CGUID+25, @CGUID+26);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@CGUID+17, 18547, 530, 0, 0, 1, 1, 1, -2107.36, 5641.19, 50.31, 3.25, 300, 0, 0, 3611, 5875, 0, 0, 0, 0, '', 0, 0, NULL), -- Scryer Arcanist
@@ -104,9 +104,9 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 -- remove creatures placed by AC
 DELETE FROM `creature` WHERE `guid` IN (68495, 68496, 68497, 68498, 68492, 68493, 68494, 68923, 68924, 68925, 68926, 68927, 68928, 68929, 69136, 69137, 69138, 69139);
 
-DELETE FROM `creature` WHERE `id` IN (19346, 19377, 19378);
+DELETE FROM `creature` WHERE `id1` IN (19346, 19377, 19378);
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+1 AND @CGUID+12;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (68962,     19346, 530, 0, 0, 1, 1, 0, -1764.84, 5726.25, 126.538, 4.27606, 300, 0, 0, 6986, 0, 2, 0, 0, 0, '', 0, 0, NULL),      -- Harbring Erothem

--- a/data/sql/world/base/zone_silithus.sql
+++ b/data/sql/world/base/zone_silithus.sql
@@ -130,8 +130,8 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 15 WHERE `guid` IN (42970, 42997, 43036);
 
 -- Deathclasp waypoints
-DELETE FROM `creature` WHERE `id` = 15196;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` = 15196;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (42921, 15196, 1, 0, 0, 1, 1, 0, -8102.7, 967.628, 59.7207, 2.96696, 600, 0, 1, 8883, 0, 2, 0, 0, 0, '', 0, 0, NULL); 
 
@@ -163,9 +163,9 @@ SET @CGUID    := 651000;
 DELETE FROM `creature` WHERE `guid` IN (42969, 42983, 42984); 
 DELETE FROM `creature_addon` WHERE `guid` IN (42969, 42983, 42984); 
 
-DELETE FROM `creature` WHERE `id` = 15308;
+DELETE FROM `creature` WHERE `id1` = 15308;
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+1 AND @CGUID+8;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (43322, 15308, 1, 0, 0, 1, 1, 1, -7612.16, 1619.85, 2.5204, -1.45604, 3600, 0, 1, 7369, 11502, 2, 0, 0, 0, '', 0, 0, NULL),
 (43323, 15308, 1, 0, 0, 1, 1, 1, -6888.79, 1636.61, 2.8743, 0.795651, 3600, 0, 1, 7369, 11502, 2, 0, 0, 0, '', 0, 0, NULL),
@@ -413,9 +413,9 @@ DELETE FROM `creature` WHERE `guid` IN (43202, 43203);
 DELETE FROM `creature_addon` WHERE `guid` IN (43202, 43203); 
 DELETE FROM `waypoint_data` WHERE `id` IN (432020, 432030); 
 
-DELETE FROM `creature` WHERE `id` = 15541;
+DELETE FROM `creature` WHERE `id1` = 15541;
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+11 AND @CGUID+15;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (43201, 15541, 1, 0, 0, 1, 1, 1, -6374.21, 532.318, 6.19409, 4.31401, 600, 0, 1, 10529, 0, 2, 0, 0, 0, '', 0, 0, NULL),
 (@CGUID+11, 15542, 1, 0, 0, 1, 1, 1, -6365.12, 537.924, 7.15975, 6.17294, 600, 0, 0, 3998, 0, 0, 0, 0, 0, '', NULL, 0, NULL), -- escort of 15541

--- a/data/sql/world/base/zone_silvermoon.sql
+++ b/data/sql/world/base/zone_silvermoon.sql
@@ -1,7 +1,7 @@
 -- Restore M'uru
 SET @MURU_GUID := 352043;
 DELETE FROM `creature` WHERE `guid` = @MURU_GUID;
-INSERT INTO `creature` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`) VALUES
+INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`) VALUES
 (@MURU_GUID, 17544, 530, 9850.99, -7522.666, -9.157837, 1.537163);
 
 UPDATE `creature_template` SET `rank` = 3, `type_flags` = 4 WHERE `entry` = 17544; -- M'uru
@@ -159,7 +159,7 @@ UPDATE `conditions` SET `ConditionValue2` = 17544 WHERE `SourceTypeOrReferenceId
 
 -- Restore Lady Liadrin and move Magister Astalor Bloodsworn a bit.
 DELETE FROM `creature` WHERE `guid` IN (96976, 617076);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (96976,  17718, 530, 0, 0, 1, 1, 0, 9859.45, -7519.19, -8.06573, 1.69273, 180, 0, 0, 3484, 5751, 0, 0, 0, 0, '', 0, 0, NULL),        -- Magister Astalor Bloodsworn
 (617076, 17076, 530, 0, 0, 1, 1, 0, 9862.12, -7518.44, -8.06524, 1.86945, 300, 0, 0, 1214000, 33870, 0, 0, 0, 0, '', NULL, 0, NULL); -- Lady Liadrin

--- a/data/sql/world/base/zone_silverpine.sql
+++ b/data/sql/world/base/zone_silverpine.sql
@@ -167,7 +167,7 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 
 
 -- Quest: The Dead Fields - Nightlash now gets summoned by killing Rot Hide Mystics
-DELETE FROM `creature` WHERE `id` = 1983;
+DELETE FROM `creature` WHERE `id1` = 1983;
 DELETE FROM `creature_addon` WHERE `guid` = 28379;
 
 -- Quest: Call of Water (Shaman)

--- a/data/sql/world/base/zone_stonetalon_mountains.sql
+++ b/data/sql/world/base/zone_stonetalon_mountains.sql
@@ -160,8 +160,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 UPDATE `creature` SET `MovementType` = 1, `Wander_distance` = 5 WHERE `guid` = 51889;
 
 -- fix waypoints, spawn locations and respawn times
-DELETE FROM `creature` WHERE `id` IN (4202, 5916, 11921);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` IN (4202, 5916, 11921);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (29254,  4202, 1, 0, 0, 1, 1, 1, 1605.99, 96.7067, 98.6662, 0.191986, 300, 0, 0, 840, 0, 0, 0, 0, 0, '', 0, 0, NULL),     -- Gerenzo Wrenchwhistle

--- a/data/sql/world/base/zone_stormwind.sql
+++ b/data/sql/world/base/zone_stormwind.sql
@@ -50,11 +50,11 @@ UPDATE `creature_template` SET `npcflag` = 4224 WHERE `entry` IN (24671, 24672);
 UPDATE `creature_template_addon` SET `mount` = 0 WHERE `entry` = 12783;
 
 DELETE FROM `creature` WHERE `guid` IN (133928, 133926, 133929, 612781, 133927, 612783, 612785, 623446, 624671, 624672, 612777, 612778, 626394, 720278, 723396); -- 00_cleanup
-DELETE FROM `creature` WHERE `id`  IN (7410, 7798, 12779, 12780, 12805, 14981, 15008, 32380, 32381, 34073, 34074, 34075, 34076, 34077, 34078, 40607);
+DELETE FROM `creature` WHERE `id1`  IN (7410, 7798, 12779, 12780, 12805, 14981, 15008, 32380, 32381, 34073, 34074, 34075, 34076, 34077, 34078, 40607);
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+21 AND @CGUID+38;
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+121 AND @CGUID+142;
 
-INSERT INTO `creature` (`guid`, `id`, `map`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 --
 (@CGUID+121, @Biggins, 0, 1, -8777.4, 417.124, 103.921, 6.23553, 180),  -- Master Sergeant Biggins <Officer Accessories Quartermaster>, Vanilla
 (@CGUID+122, 12781, 0, 1, -8777.4, 417.124, 103.921, 6.23553, 180),     -- Master Sergeant Biggins <Officer Accessories Quartermaster>, TBC
@@ -308,7 +308,7 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_pre_tbc' WHERE `guid` IN (61936, 61940, 61942, 61944, 61945, 61946, 61947, 61949, 61951);
 
 -- WotLK pvp vendors
-DELETE FROM `creature` WHERE `id` IN 
+DELETE FROM `creature` WHERE `id1` IN 
 (12782,  -- Captain O'Neal <Weapons Quartermaster>
  34081); -- Captain O'Neal <Jewelcrafting Quartermaster>
 

--- a/data/sql/world/base/zone_stranglethorn.sql
+++ b/data/sql/world/base/zone_stranglethorn.sql
@@ -315,8 +315,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 
 -- Bhag'thera(728) and Tethis(730) have multiple spawn locations 
-DELETE FROM `creature` WHERE `id` IN (728, 730);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (728, 730);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (1348,   728, 0, 0, 0, 1, 1, 0, -12191, -944.651, 32.9082, 0.187693, 480, 0, 0, 1753, 0, 0, 0, 0, 0, '', 0, 0, NULL),
 (695017, 728, 0, 0, 0, 1, 1, 0, -12016.5, -896.876, 35.3047, 3.59511, 480, 5, 0, 1753, 0, 1, 0, 0, 0, '', 0, 0, NULL),
@@ -341,7 +341,7 @@ INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES
 
 -- Skullsplitter patrols missing formations
 DELETE FROM `creature` WHERE `guid` IN (1408, 1409, 2516, 2517, 2518, 2539);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (1408, 780, 0, 0, 0, 1, 1, 1, -12762, -890.346, 52.7586, 2.23398, 390, 0, 0, 1357, 1236, 2, 0, 0, 0, '', 0, 0, NULL),
@@ -369,8 +369,8 @@ UPDATE `creature_loot_template` SET `Chance` = 4 WHERE `Item` = 3862;
 -- Drop chance for Jungle Stalker Feather was incorrectly set to 80 - updated to 25
 UPDATE `creature_loot_template` SET `Chance` = 25 WHERE `Item` = 3863;
 
-DELETE FROM `creature` WHERE `id` IN (723);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (723);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (600723, 723, 0, 0, 0, 1, 1, 1, -12357.4, -1075.36, 1.94221, 1.94815, 54000, 5, 0, 5346, 0, 1, 0, 0, 0, '', NULL, 0, NULL); 
     

--- a/data/sql/world/base/zone_tanaris.sql
+++ b/data/sql/world/base/zone_tanaris.sql
@@ -102,7 +102,7 @@ INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, 
 
 UPDATE `gameobject_template` SET `ScriptName` = "go_cavernsoftimedoor" WHERE `entry` = 176996;
 
-UPDATE `creature` SET `position_x` = -8175.67, `position_y` = -4718.28, `position_z` = 26.3489, `orientation` = 1.88496 WHERE `id` = 15192;
+UPDATE `creature` SET `position_x` = -8175.67, `position_y` = -4718.28, `position_z` = 26.3489, `orientation` = 1.88496 WHERE `id1` = 15192;
 
 -- fix Omgorn the Lost waypoints, was placed on wrong continent
 UPDATE `creature` SET `map` = 1 WHERE `guid` IN (152280, 152281);
@@ -144,10 +144,10 @@ SET @Evee      := 125177;
 SET @Ecton     := 125178;
 
 DELETE FROM `creature` WHERE `guid` IN (@CGUID+41, @CGUID+42);
-DELETE FROM `creature` WHERE `id` IN (25177, 25178, 26378, @Evee, @Ecton);
-DELETE FROM `creature` WHERE `id` IN (32359, 32360, 32362, 32407, 33915, 33917, 33920, 33924, 33928, 33929, 33934, 33935, 33939, 34088, 34090, 34093);
+DELETE FROM `creature` WHERE `id1` IN (25177, 25178, 26378, @Evee, @Ecton);
+DELETE FROM `creature` WHERE `id1` IN (32359, 32360, 32362, 32407, 33915, 33917, 33920, 33924, 33928, 33929, 33934, 33935, 33939, 34088, 34090, 34093);
 
-INSERT INTO `creature` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 --
 (@CGUID+41, 20278,   1, -7119.02, -3779.06, 8.78404, 0, 180),     -- Vixton Pinchwhistle, WotLK Season 1
 (@CGUID+42, @Vixton, 1, -7119.02, -3779.06, 8.78404, 0, 180),     -- Vixton Pinchwhistle, WotLK Season 2

--- a/data/sql/world/base/zone_terokkar_forest.sql
+++ b/data/sql/world/base/zone_terokkar_forest.sql
@@ -78,7 +78,7 @@ UPDATE `smart_scripts` SET `target_type` = 21, `target_param1` = 40 WHERE `entry
 UPDATE `smart_scripts` SET `target_type` = 21, `target_param1` = 40 WHERE `entryorguid` = 16769 AND `source_type` = 0 AND `id` = 17;
 
 DELETE FROM `creature` WHERE `guid` IN (247237, 622441);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (247237, 22441, 530, 0, 0, 1, 1, 0, -3400.86, 4665.3, 99.6544, 4.62677, 300, 0, 0, 29570, 0, 0, 0, 0, 0, '', 0, 0, 'SAI Target'),
 (622441, 122441, 530, 0, 0, 1, 1, 0, -3536.9500, 4552.8501, 83.9206, 1.4071, 300, 0, 1, 29570, 0, 2, 0, 0, 0, '', 0, 0, 'Patrol');
@@ -165,7 +165,7 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 
 -- fix movement Rotting Forest-Rager (entry 22307)
 UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1, `wander_distance` = 0 WHERE `guid` IN (78435, 78436, 78437, 78438, 78439);
-DELETE FROM `creature` WHERE `guid` = 133907 AND `id` = 22307; -- misplaced
+DELETE FROM `creature` WHERE `guid` = 133907 AND `id1` = 22307; -- misplaced
 
 DELETE FROM `creature_addon` WHERE `guid` BETWEEN 78435 AND 78439;
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 
@@ -287,8 +287,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 -- fix speed Monstrous Kaliri - https://www.youtube.com/watch?v=vLIzGAOyQjY
 UPDATE `creature_template` SET `speed_walk` = 4 WHERE `Entry` = 23051; -- was set to 14
 
-DELETE FROM `creature` WHERE `id` IN (21644, 21649, 21650, 21651, 21723, 21728, 21730, 21763, 21787, 21804, 21911, 23029, 23051, 23219);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` IN (21644, 21649, 21650, 21651, 21723, 21728, 21730, 21763, 21787, 21804, 21911, 23029, 23051, 23219);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 
 -- Skettis Wing Guard

--- a/data/sql/world/base/zone_thousand_needles.sql
+++ b/data/sql/world/base/zone_thousand_needles.sql
@@ -105,9 +105,9 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (14427, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                     'Gibblesnik - Between 0-15% Health - Flee For Assist (No Repeat)');
 
 
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5, `spawntimesecs` = 37800  WHERE `id` = 14427; -- Gibblesnik
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 10 WHERE `id` = 5937; -- give Vile Sting some movement
-UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1  WHERE `id` = 4499; -- Rok'Alim the Pounder, waypoints
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5, `spawntimesecs` = 37800  WHERE `id1` = 14427; -- Gibblesnik
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 10 WHERE `id1` = 5937; -- give Vile Sting some movement
+UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1  WHERE `id1` = 4499; -- Rok'Alim the Pounder, waypoints
 
 DELETE FROM `creature_addon` WHERE `guid` = 21591;
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 

--- a/data/sql/world/base/zone_thunder_bluff.sql
+++ b/data/sql/world/base/zone_thunder_bluff.sql
@@ -26,8 +26,8 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (15, 4351, 0, 7, 197, 50,  'Show menu if tailoring is 50 or higher');       -- Tepa <Expert Tailor>
 
 -- battlemasters
-DELETE FROM `creature` WHERE `id` IN (7427, 10360, 12198, 34976, 34978);
-INSERT INTO `creature` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
+DELETE FROM `creature` WHERE `id1` IN (7427, 10360, 12198, 34976, 34978);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 (607427, 7427,  1, -1384.29, -98.6163, 159.018, 2.87979, 300), -- Taim Ragetotem <Alterac Valley Battlemaster>
 (610360, 10360, 1, -1381.29, -75.9809, 160.602, 3.19395, 300), -- Kergul Bloodaxe <Warsong Gulch Battlemaster>
 (612198, 12198, 1, -995.143, 217.173, 104.729, 4.46804,  300); -- Martin Lindsey <Arathi Basin Battlemaster>

--- a/data/sql/world/base/zone_tirisfal_glades.sql
+++ b/data/sql/world/base/zone_tirisfal_glades.sql
@@ -114,8 +114,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 UPDATE `creature_loot_template` SET `Chance` = 80 WHERE `Entry` = 1890 AND `Item` = 6281;
 
 -- Undertaker Mordo (not sure why we creating a new version of this guy, we only seem to be moving him)
-DELETE FROM `creature` WHERE `id` = 1568;
-INSERT INTO `creature` (`guid`, `id`, `map`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
+DELETE FROM `creature` WHERE `id1` = 1568;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES 
 (601568, 1568, 0, 1, 1678.99, 1667.86, 135.855, 3.76991, 300);
 
 DELETE FROM `creature_addon` WHERE `guid` IN (29803, 601568);
@@ -192,15 +192,15 @@ DELETE FROM `creature_queststarter` WHERE `id` = 5667 AND `quest` = 1470;
 INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (5667, 1470);
 
 -- fix respawn times and movement
-UPDATE `creature` SET `spawntimesecs` = 5400 WHERE `id` = 1910; -- Muad
-UPDATE `creature` SET `spawntimesecs` = 7200 WHERE `id` = 1911; -- Deeb
-UPDATE `creature` SET `spawntimesecs` = 5400 WHERE `id` = 1936; -- Farmer Solliden
+UPDATE `creature` SET `spawntimesecs` = 5400 WHERE `id1` = 1910; -- Muad
+UPDATE `creature` SET `spawntimesecs` = 7200 WHERE `id1` = 1911; -- Deeb
+UPDATE `creature` SET `spawntimesecs` = 5400 WHERE `id1` = 1936; -- Farmer Solliden
 
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 1911;
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5 WHERE `id1` = 1911;
 
 -- fix patrols
 DELETE FROM `creature` WHERE `guid` IN (37920, 38292, 42142, 44762, 44763, 44990, 49222);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 --
 (37920, 1540, 0, 0, 0, 1, 1, 1, 2943.75, -554.264, 109.317, 3.22052, 300,  0, 1, 198, 0,   2, 0, 0, 0, '', 0, 0, NULL), -- Scarlet Vanguard

--- a/data/sql/world/base/zone_undercity.sql
+++ b/data/sql/world/base/zone_undercity.sql
@@ -54,8 +54,8 @@ INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionTex
 (2849, 11, 0, 'A profession trainer', 6635, 1, 1, 2847, 0, 0, 0, NULL, 0, 0);
 
 -- Batllemasters
-DELETE FROM `creature` WHERE `id` IN (347, 2804, 15007, 20386);
-INSERT INTO `creature` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES
+DELETE FROM `creature` WHERE `id1` IN (347, 2804, 15007, 20386);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES
 (600347, 347, 0, 1331.94, 334.713, -63.6249, 3.40339, 900),
 (602804, 2804, 0, 1262.97, 353.389, -63.6165, 5.46288, 900),
 (615007, 15007, 0, 1282.43, 284.592, -63.6281, 1.27409, 900),
@@ -124,7 +124,7 @@ INSERT INTO `creature_questender` (`id`, `quest`) VALUES
 
 DELETE FROM `creature` WHERE `guid` IN (@Faranell_guid, @Varimathras, 31901, 43466, 79263);
 DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+1 AND @CGUID+44;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 --
 (@Faranell_guid,@Faranell_entry, 0, 0, 0, 1, 1, 1, 1434.48, 404.854, -85.1753, 2.26893, 300, 0, 0, 2215, 1807, 0, 0, 0, 0, '', 0, 0, NULL), -- Master Apothecary Faranell
@@ -181,8 +181,8 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `p
 UPDATE `creature` SET `phaseMask` = @IPPPHASE_II  WHERE `guid` IN (@Faranell_guid, @Varimathras); -- pre Wrathgate
 UPDATE `creature` SET `phaseMask` = @IPPPHASE_III WHERE `guid` IN (31900, 31901, 43466, 79263, 203394, 203395, 203420);   -- post Wrathgate
 
-UPDATE `creature` SET `phaseMask` = @IPPPHASE_II  WHERE `id` = 5624;  -- pre Wrathgate
-UPDATE `creature` SET `phaseMask` = @IPPPHASE_III WHERE `id` = 36213; -- post Wrathgate
+UPDATE `creature` SET `phaseMask` = @IPPPHASE_II  WHERE `id1` = 5624;  -- pre Wrathgate
+UPDATE `creature` SET `phaseMask` = @IPPPHASE_III WHERE `id1` = 36213; -- post Wrathgate
 
 -- guard waypoints, can use existing ones
 DELETE FROM `creature_addon` WHERE `guid` IN (@CGUID+12, @CGUID+13, @CGUID+17);

--- a/data/sql/world/base/zone_ungoro.sql
+++ b/data/sql/world/base/zone_ungoro.sql
@@ -108,20 +108,20 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (911700, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'J.D. Collie - On Script - Say Line 0'),
 (911700, 9, 3, 0, 0, 0, 100, 0, 10000, 10000, 0, 0, 0, 0, 15, 4321, 0, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0, 0, 'J.D. Collie - On Script - Quest Credit \'Making Sense of It\'');
 
-UPDATE `creature` SET `spawntimesecs` = 54000  WHERE `id` = 6581; -- Ravasaur Matriarch
-UPDATE `creature` SET `spawntimesecs` = 47000  WHERE `id` = 6582; -- Clutchmother Zavas
-UPDATE `creature` SET `spawntimesecs` = 108000 WHERE `id` = 6583; -- Gruff
-UPDATE `creature` SET `spawntimesecs` = 108000 WHERE `id` = 6584; -- King Mosh
-UPDATE `creature` SET `spawntimesecs` = 23400  WHERE `id` = 6585; -- Uhk'loc
+UPDATE `creature` SET `spawntimesecs` = 54000  WHERE `id1` = 6581; -- Ravasaur Matriarch
+UPDATE `creature` SET `spawntimesecs` = 47000  WHERE `id1` = 6582; -- Clutchmother Zavas
+UPDATE `creature` SET `spawntimesecs` = 108000 WHERE `id1` = 6583; -- Gruff
+UPDATE `creature` SET `spawntimesecs` = 108000 WHERE `id1` = 6584; -- King Mosh
+UPDATE `creature` SET `spawntimesecs` = 23400  WHERE `id1` = 6585; -- Uhk'loc
 
-UPDATE `creature` SET`MovementType` = 1, `wander_distance` = 5 WHERE `id` IN (6581, 6582, 6583, 6585);
+UPDATE `creature` SET`MovementType` = 1, `wander_distance` = 5 WHERE `id1` IN (6581, 6582, 6583, 6585);
 
 -- U'cha, waypoints
 -- https://www.youtube.com/watch?v=UYj7pj7Jqf4&t=10s
 -- https://www.youtube.com/watch?v=Ee2KVKJuINw&t=200s
 -- https://www.youtube.com/watch?v=_YKpLAzQaX8&t=150s
 
-UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1 WHERE `id` = 9622; -- U'cha
+UPDATE `creature` SET `MovementType` = 2, `currentwaypoint` = 1 WHERE `id1` = 9622; -- U'cha
 
 DELETE FROM `creature_addon` WHERE `guid` IN (24254);
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 

--- a/data/sql/world/base/zone_western_plaguelands.sql
+++ b/data/sql/world/base/zone_western_plaguelands.sql
@@ -205,12 +205,12 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 
 
 -- Bloodshot gets summoned by Huntsman Radley
-DELETE FROM `creature` WHERE `id` = 11614;
+DELETE FROM `creature` WHERE `id1` = 11614;
 DELETE FROM `creature_addon` WHERE `guid` = 52640;
 
 -- Lord Maldazzar, fix spawn locations, respawn and movement
-DELETE FROM `creature` WHERE `id` = 1848;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+DELETE FROM `creature` WHERE `id1` = 1848;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
 `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES 
 (52725,  1848, 0, 0, 0, 1, 1, 1, 1061.03, -1912.26, 31.1128, 4.71571, 18000, 5, 0, 2915, 2163, 1, 0, 0, 0, '', 0, 0, NULL),
 (695026, 1848, 0, 0, 0, 1, 1, 1, 1123.73, -1714.49, 62.33, 0, 18000, 5, 0, 2915, 2163, 1, 0, 0, 0, '', 0, 0, NULL),          -- https://www.youtube.com/watch?v=pCwj-bglyV8
@@ -223,5 +223,5 @@ INSERT INTO `pool_creature` (`guid`, `pool_entry`, `chance`, `description`) VALU
 (695027, 368, 0, 'Lord Maldazzar Sorrow hill');
 
 -- fix npc movement
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 1850; -- Putridius, 
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 1844; -- Foreman Marcrid
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5 WHERE `id1` = 1850; -- Putridius, 
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5 WHERE `id1` = 1844; -- Foreman Marcrid

--- a/data/sql/world/base/zone_wetlands.sql
+++ b/data/sql/world/base/zone_wetlands.sql
@@ -206,7 +206,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (14425, 0, 1, 0, 2, 0, 100, 1, 0, 15, 0, 0, 0, 0, 25, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                      'Gnawbone - Between 0-15% Health - Flee For Assist (No Repeat)');
 
 -- Garneg Charskull, fix respawn time
-UPDATE `creature` SET `spawntimesecs` = 23400 WHERE `id` = 2108; 
+UPDATE `creature` SET `spawntimesecs` = 23400 WHERE `id1` = 2108; 
 
 -- Quest: Digging Through the Ooze - Sida's Bag drop chance 
 UPDATE `creature_loot_template` SET `Chance` = 10 WHERE `Item` = 3349 AND `Entry` = 1031; -- Crimson Ooze
@@ -215,8 +215,8 @@ UPDATE `creature_loot_template` SET `Chance` = 5  WHERE `Item` = 3349 AND `Entry
 
 -- missing patrols
 DELETE FROM `pool_creature` WHERE `pool_entry` = 1072; -- remove 22 spawn locations used by AC, we are now using waypoints
-DELETE FROM `creature` WHERE `id` IN (14424);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
+DELETE FROM `creature` WHERE `id1` IN (14424);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, 
 `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (91113, 14424, 0, 0, 0, 1, 1, 0, -2752.94, -1311.99, 6.14436, 1.69779, 39600, 0, 1, 734, 0, 2, 0, 0, 0, '', 0, 0, NULL); -- Mirelow
 

--- a/data/sql/world/base/zone_winterspring.sql
+++ b/data/sql/world/base/zone_winterspring.sql
@@ -152,9 +152,9 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 
 -- update Respawn Times and Movement
-UPDATE `creature` SET `spawntimesecs` = 115200, `MovementType` = 1, `Wander_distance` = 5 WHERE `id` = 10201; -- Lady Hederine
-UPDATE `creature` SET `spawntimesecs` = 37800,  `MovementType` = 1, `Wander_distance` = 5 WHERE `id` = 10196; -- General Colbatann
-UPDATE `creature` SET `spawntimesecs` = 75600                                             WHERE `id` = 10198; -- Kashoch the Reaver
+UPDATE `creature` SET `spawntimesecs` = 115200, `MovementType` = 1, `Wander_distance` = 5 WHERE `id1` = 10201; -- Lady Hederine
+UPDATE `creature` SET `spawntimesecs` = 37800,  `MovementType` = 1, `Wander_distance` = 5 WHERE `id1` = 10196; -- General Colbatann
+UPDATE `creature` SET `spawntimesecs` = 75600                                             WHERE `id1` = 10198; -- Kashoch the Reaver
 
 
 DELETE FROM `creature_text` WHERE `CreatureID` IN (7451, 7454, 10200);

--- a/data/sql/world/base/zone_zangarmarsh.sql
+++ b/data/sql/world/base/zone_zangarmarsh.sql
@@ -12,5 +12,5 @@ INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionTex
 (10437, 1, 3, 'I seek training in Fishing.', 34245, 5, 16, 0, 0, 0, 0, '', 0, 0);
 
 -- fix orientation Innkeeper Coryth Stoktron
-UPDATE `creature` SET `orientation` = 3.61916 WHERE `id` = 18907;
+UPDATE `creature` SET `orientation` = 3.61916 WHERE `id1` = 18907;
 UPDATE `waypoint_data` SET `orientation` = 3.61916 WHERE `id` = 678800;


### PR DESCRIPTION
docker compose up --build -d failed during ac-db-import.
The current creature table has id1/id2/id3, not id.
After this patch ac-db-import exits 0 and auth/worldserver start.

Fixes SQL imports against current AzerothCore creature spawn schema.

AzerothCore now uses creature.id1/id2/id3 instead of creature.id plus creature_multispawn.

Changes:
- Replace creature.id references with creature.id1 in world base SQL.
- Move the Deadwind Pass alternate spawn from creature_multispawn into creature.id2.
- Remove writes to the removed creature_multispawn table.

Verified with:

docker compose up --build -d

Result:
- ac-db-import exits 0
- ac-authserver starts
- ac-worldserver starts