### PR TITLE
Reward TBC Call to Arms quests

### DIFF
--- a/data/sql/world/base/pvp_quests.sql
+++ b/data/sql/world/base/pvp_quests.sql
@@ -382,6 +382,8 @@ UPDATE `quest_template` SET `RewardItem1` = 20560, `RewardAmount1` = 3 WHERE `ID
 UPDATE `quest_template` SET `RewardItem1` = 29024, `RewardAmount1` = 3 WHERE `ID` IN (11337, 11341); -- Call to Arms: Eye of the Storm (repeatable)
 UPDATE `quest_template` SET `RewardItem1` = 20558, `RewardAmount1` = 3 WHERE `ID` IN (11338, 11342); -- Call to Arms: Warsong Gulch (repeatable)
 
+UPDATE `quest_template` SET `Flags` = 4162 WHERE `ID` IN (11335, 11339, 11336, 11340, 11337, 11341, 11338, 11342); -- set completable in a raid
+
 UPDATE `quest_template_addon` SET `PrevQuestID` = 13476, `SpecialFlags` = 1 WHERE `ID` = 13475;
 UPDATE `quest_template_addon` SET `PrevQuestID` = 13478, `SpecialFlags` = 1 WHERE `ID` = 13477;
 

--- a/src/IndividualProgressionBG.cpp
+++ b/src/IndividualProgressionBG.cpp
@@ -103,28 +103,16 @@ public:
             switch (battlegroundType)
             {
             case BATTLEGROUND_AB:
-                if (playerTeamId == TEAM_ALLIANCE && player->hasQuest(11335))
-                    player->CompleteQuest(11335);
-                else if (playerTeamId == TEAM_HORDE && player->hasQuest(11339))
-                    player->CompleteQuest(11339);
+                player->CastSpell(player, SPELL_AB_QUEST_REWARD, true);
                 break;
             case BATTLEGROUND_AV:
-                if (playerTeamId == TEAM_ALLIANCE && player->hasQuest(11336))
-                    player->CompleteQuest(11336);
-                else if (playerTeamId == TEAM_HORDE && player->hasQuest(11340))
-                    player->CompleteQuest(11340);
+                player->CastSpell(player, SPELL_AV_QUEST_REWARD, true);
                 break;
             case BATTLEGROUND_EY:
-                if (playerTeamId == TEAM_ALLIANCE && player->hasQuest(11337))
-                    player->CompleteQuest(11337);
-                else if (playerTeamId == TEAM_HORDE && player->hasQuest(11341))
-                    player->CompleteQuest(11341);
+                player->CastSpell(player, SPELL_EY_QUEST_REWARD, true);
                 break;
             case BATTLEGROUND_WS:
-                if (playerTeamId == TEAM_ALLIANCE && player->hasQuest(11338))
-                    player->CompleteQuest(11338);
-                else if (playerTeamId == TEAM_HORDE && player->hasQuest(11342))
-                    player->CompleteQuest(11342);
+                player->CastSpell(player, SPELL_WS_QUEST_REWARD, true);
                 break;
             }
         }

--- a/src/IndividualProgressionBG.cpp
+++ b/src/IndividualProgressionBG.cpp
@@ -63,6 +63,7 @@ public:
             return;
 
         const TeamId playerTeamId = player->GetBgTeamId();
+        const uint8 playerLevel = player->GetLevel();
 
         uint8_t rewardQuantity = 1;
 
@@ -95,6 +96,37 @@ public:
             draft.AddItem(item);
             draft.SendMailTo(transaction, MailReceiver(player, player->GetGUID().GetRawValue()), MailSender(MAIL_CREATURE, battlemasterId));
             CharacterDatabase.CommitTransaction(transaction);
+        }
+
+        if (playerLevel >= 60 && playerLevel <= 70 && playerTeamId == winner)
+        {
+            switch (battlegroundType)
+            {
+            case BATTLEGROUND_AB:
+                if (playerTeamId == TEAM_ALLIANCE && player->hasQuest(11335))
+                    player->CompleteQuest(11335);
+                else if (playerTeamId == TEAM_HORDE && player->hasQuest(11339))
+                    player->CompleteQuest(11339);
+                break;
+            case BATTLEGROUND_AV:
+                if (playerTeamId == TEAM_ALLIANCE && player->hasQuest(11336))
+                    player->CompleteQuest(11336);
+                else if (playerTeamId == TEAM_HORDE && player->hasQuest(11340))
+                    player->CompleteQuest(11340);
+                break;
+            case BATTLEGROUND_EY:
+                if (playerTeamId == TEAM_ALLIANCE && player->hasQuest(11337))
+                    player->CompleteQuest(11337);
+                else if (playerTeamId == TEAM_HORDE && player->hasQuest(11341))
+                    player->CompleteQuest(11341);
+                break;
+            case BATTLEGROUND_WS:
+                if (playerTeamId == TEAM_ALLIANCE && player->hasQuest(11338))
+                    player->CompleteQuest(11338);
+                else if (playerTeamId == TEAM_HORDE && player->hasQuest(11342))
+                    player->CompleteQuest(11342);
+                break;
+            }
         }
     }
 

--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -115,7 +115,7 @@ public:
                         handler.PSendSysMessage("|cff00ffff{}|r is allowed to enter.", member->GetName());
                         member->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
 
-                        if (player->GetDistance(member) <= 40.0f) 
+                        if (player->GetDistance(member) <= 30.0f && member->GetMapId() != 533) // teleport only if the player is close enough and not already in naxxramas 
                             member->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
                     }
                 }

--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -115,7 +115,7 @@ public:
                         handler.PSendSysMessage("|cff00ffff{}|r is allowed to enter.", member->GetName());
                         member->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
 
-                        if (player->GetDistance(member) <= 30.0f && member->GetMapId() != 533) // teleport only if the player is close enough and not already in naxxramas 
+                        if (player->GetDistance(member) <= 30.0f && member->GetMapId() != 533) // teleport only if the player is close enough and not already in naxxramas
                             member->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
                     }
                 }


### PR DESCRIPTION
I wasn't getting credit for TBC call to arms quests
This PR should fix it.

~~still need to test this.~~

edit:
~~doesn't work. not sure why.~~
~~I've also tested setting quest flag for it to be completable while in a raid. still didn't work.~~
~~investigating.~~
found the solution. special spells are cast to complete these quests.

tested AV, I'm now getting credit.