### PR TITLE
Update RNDbot spells

### DIFF
--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -150,6 +150,35 @@ uint8 IndividualProgression::GetAccountProgression(uint32 accountId)
     return progressionLevel;
 }
 
+void IndividualProgression::UpdateRNDbotSpells(Player* player)
+{
+    if (!player || !player->IsInWorld())
+        return;
+
+    if (!sIndividualProgression->isBotAccount(player))
+        return;
+
+    switch (player->getClass())
+    {
+    case CLASS_WARLOCK:
+        if (player->GetLevel() >= 40)
+            player->learnSpell(1710, false); // Summon Felsteed
+        break;
+    case CLASS_PALADIN:
+        if (player->GetLevel() >= 40)
+            player->learnSpell(13820, false); // Summon Warhorse
+        break;
+    case CLASS_DRUID:
+        if (player->GetLevel() >= 10)
+            player->learnSpell(18960, false); // Teleport: Moonglade
+        if (player->GetLevel() >= 16)
+            player->learnSpell(1066, false); // Aquatic Form
+        break;
+    default:
+        return;
+    }
+}
+
 void IndividualProgression::UpdateAccountReputation(uint32 factionId, uint32 accountId, Player* player)
 {
     if (!factionId || !accountId || !player || !player->IsInWorld())

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -161,12 +161,12 @@ void IndividualProgression::UpdateRNDbotSpells(Player* player)
     switch (player->getClass())
     {
     case CLASS_WARLOCK:
-        if (player->GetLevel() >= 40 && !player->HasSpell(1710)) // Summon Felsteed
-            player->learnSpell(1710, false);
+        if (player->GetLevel() >= 40 && !player->HasSpell(7584)) // Summon Felsteed
+            player->learnSpell(7584, false);
         break;
     case CLASS_PALADIN:
-        if (player->GetLevel() >= 40 && !player->HasSpell(13820)) // Summon Warhorse
-            player->learnSpell(13820, false);
+        if (player->GetLevel() >= 40 && !player->HasSpell(13819)) // Summon Warhorse
+            player->learnSpell(13819, false);
         break;
     case CLASS_DRUID:
         if (player->GetLevel() >= 10 && !player->HasSpell(18960)) // Teleport: Moonglade

--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -161,18 +161,18 @@ void IndividualProgression::UpdateRNDbotSpells(Player* player)
     switch (player->getClass())
     {
     case CLASS_WARLOCK:
-        if (player->GetLevel() >= 40)
-            player->learnSpell(1710, false); // Summon Felsteed
+        if (player->GetLevel() >= 40 && !player->HasSpell(1710)) // Summon Felsteed
+            player->learnSpell(1710, false);
         break;
     case CLASS_PALADIN:
-        if (player->GetLevel() >= 40)
-            player->learnSpell(13820, false); // Summon Warhorse
+        if (player->GetLevel() >= 40 && !player->HasSpell(13820)) // Summon Warhorse
+            player->learnSpell(13820, false);
         break;
     case CLASS_DRUID:
-        if (player->GetLevel() >= 10)
-            player->learnSpell(18960, false); // Teleport: Moonglade
-        if (player->GetLevel() >= 16)
-            player->learnSpell(1066, false); // Aquatic Form
+        if (player->GetLevel() >= 10 && !player->HasSpell(18960)) // Teleport: Moonglade
+            player->learnSpell(18960, false);
+        if (player->GetLevel() >= 16 && !player->HasSpell(1066)) // Aquatic Form
+            player->learnSpell(1066, false);
         break;
     default:
         return;

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -430,6 +430,7 @@ public:
     void checkIPProgression(Player* player);
     void UpdateProgressionAchievements(Player* player, uint16 achievementID);
     void UpdateGroupAttunement(Player* player, std::string location);
+    void UpdateRNDbotSpells(Player* player);
     void checkKillProgression(Player* player, Creature* killed);
 	void UpdateAccountReputation(uint32 factionId, uint32 accountId, Player* player);
     void CleanUpVanillaPvpTitles(Player* player);

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -27,6 +27,9 @@ public:
 
         if (!sIndividualProgression->isNormalAccount(player)) // bot or exluded account
         {
+            if (sIndividualProgression->isBotAccount(player))
+                sIndividualProgression->UpdateRNDbotSpells(player); // give class spells to RNDbots that have been removed from trainers by IP.
+            
             if (player->GetLevel() <= 60)
                 sIndividualProgression->ForceUpdateProgressionState(player, static_cast<ProgressionState>(0));
             else if ((player->GetLevel() > 60) && (player->GetLevel() <= 70))
@@ -72,6 +75,15 @@ public:
 
         // exluded accounts should be effected by server nerfs as well
         sIndividualProgression->CheckAdjustments(player);
+    }
+
+    void OnPlayerLevelChanged(Player* player, uint8 /*oldLevel*/) override
+    {
+        if (!player || !player->IsInWorld())
+            return;
+
+        if (sIndividualProgression->isBotAccount(player))
+            sIndividualProgression->UpdateRNDbotSpells(player);
     }
 
     void OnPlayerResurrect(Player* player, float /*restore_percent*/, bool& /*applySickness*/) override

--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -115,7 +115,7 @@ public:
                         handler.PSendSysMessage("|cff00ffff{}|r is allowed to enter.", member->GetName());
                         member->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
 
-                        if (player->GetDistance(member) <= 40.0f) 
+                        if (player->GetDistance(member) <= 30.0f && member->GetMapId() != 533) // teleport only if the player is close enough and not already in naxxramas 
                             member->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
                     }
                 }

--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -115,7 +115,7 @@ public:
                         handler.PSendSysMessage("|cff00ffff{}|r is allowed to enter.", member->GetName());
                         member->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
 
-                        if (player->GetDistance(member) <= 30.0f && member->GetMapId() != 533) // teleport only if the player is close enough and not already in naxxramas 
+                        if (player->GetDistance(member) <= 30.0f && member->GetMapId() != 533) // teleport only if the player is close enough and not already in naxxramas
                             member->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
                     }
                 }


### PR DESCRIPTION
Give class spells to RNDbots that have been removed from class trainers by Individual Progression.
Else RNDbot may not ever learn these spells.

Summon Charger and Summon Dreadsteed are excluded.
I want the player to feel special after going through the required quest lines.
Not to see every bot running around with the same mount you had to work and pay for.

credit to `Crow` for uncovering this.