### PR TITLE
Fix DK creation for Blood Elves and Draenei

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -1265,17 +1265,19 @@ public:
             return true;
 
         uint8 highestProgression = sIndividualProgression->GetAccountProgression(accountId);
-        if (charRace == RACE_DRAENEI || charRace == RACE_BLOODELF)
+        bool allowed = true;
+        
+        if ((charRace == RACE_DRAENEI || charRace == RACE_BLOODELF) && sIndividualProgression->tbcRacesProgressionLevel != 0)
         {
             if (highestProgression < sIndividualProgression->tbcRacesProgressionLevel)
-                return false;
+                allowed = false;
         }
-        else if (charClass == CLASS_DEATH_KNIGHT && sIndividualProgression->deathKnightProgressionLevel)
+        if (charClass == CLASS_DEATH_KNIGHT && sIndividualProgression->deathKnightProgressionLevel != 0)
         {
             if (highestProgression < sIndividualProgression->deathKnightProgressionLevel)
-                return false;
+                allowed = false;
         }
-        return true;
+        return allowed;
     }
 };
 

--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -115,7 +115,7 @@ public:
                         handler.PSendSysMessage("|cff00ffff{}|r is allowed to enter.", member->GetName());
                         member->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
 
-                        if (player->GetDistance(member) <= 40.0f) 
+                        if (player->GetDistance(member) <= 30.0f && member->GetMapId() != 533) // teleport only if the player is close enough and not already in naxxramas 
                             member->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
                     }
                 }

--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -115,7 +115,7 @@ public:
                         handler.PSendSysMessage("|cff00ffff{}|r is allowed to enter.", member->GetName());
                         member->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
 
-                        if (player->GetDistance(member) <= 30.0f && member->GetMapId() != 533) // teleport only if the player is close enough and not already in naxxramas 
+                        if (player->GetDistance(member) <= 30.0f && member->GetMapId() != 533) // teleport only if the player is close enough and not already in naxxramas
                             member->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
                     }
                 }


### PR DESCRIPTION
it was possible to create Blood Elf and Draenei deathknights before you're supposed to be able to.
only the level 55 check by AzerothCore was done.